### PR TITLE
Correct the lengths of the ADIF header fields on export

### DIFF
--- a/application/views/adif/data/exportall.php
+++ b/application/views/adif/data/exportall.php
@@ -2,11 +2,10 @@
 
 	header("content-type: plain/text"); 
 	header('Content-Disposition: attachment; filename="export_log.adi"')
-
 ?>
 <ADIF_VERS:3>2.2
-<PROGRAMID:14><?php echo $this->config->item('app_name')."\n"; ?>
-<PROGRAMVERSION:22>Version <?php echo $this->config->item('app_version')."\n"; ?>
+<PROGRAMID:<?php echo strlen($this->config->item('app_name')); ?>><?php echo $this->config->item('app_name')."\n"; ?>
+<PROGRAMVERSION:<?php echo strlen($this->config->item('app_version')); ?>>Version <?php echo $this->config->item('app_version')."\n"; ?>
 <EOH>
 
 <?php foreach ($qsos->result() as $qso) { //print_r($qso);?>

--- a/application/views/backup/exportall.php
+++ b/application/views/backup/exportall.php
@@ -1,6 +1,6 @@
 <ADIF_VERS:3>2.2
-<PROGRAMID:14><?php echo $this->config->item('app_name')."\n"; ?>
-<PROGRAMVERSION:22>Version <?php echo $this->config->item('app_version')."\n"; ?>
+<PROGRAMID:<?php echo strlen($this->config->item('app_name')); ?>><?php echo $this->config->item('app_name')."\n"; ?>
+<PROGRAMVERSION:<?php echo strlen($this->config->item('app_version')); ?>>Version <?php echo $this->config->item('app_version')."\n"; ?>
 <EOH>
 
 <?php foreach ($qsos->result() as $qso) { //print_r($qso);?>


### PR DESCRIPTION
Previously it was hard coded to values that were out of date, which caused Club Log to parse the app name as "CLOUDLOG<PROGR"
