### PR TITLE
make google map calls use https

### DIFF
--- a/application/views/layout/header.php
+++ b/application/views/layout/header.php
@@ -10,7 +10,7 @@
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/bootstrap-dropdown.js"></script>
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/bootstrap-tabs.js"></script>
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/global.js"></script>
-	<script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=true"></script>
+	<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=true"></script>
 
 	<!-- CSS Files -->
 	<link type="text/css" href="<?php echo base_url(); ?>css/flick/jquery-ui-1.8.12.custom.css" rel="stylesheet" />	

--- a/application/views/layout/mini_header.php
+++ b/application/views/layout/mini_header.php
@@ -10,7 +10,7 @@
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/jquery-1.5.1.min.js"></script>
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/jquery-ui-1.8.12.custom.min.js"></script>
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/global.js"></script>
-	<script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=true"></script>
+	<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=true"></script>
 	
 </head>
 

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -19,7 +19,7 @@ line-height: 1.7;
 margin: 10px 0;
 }
 	</style>
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false"></script> 
+<script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false"></script> 
 </head>
 
 <body onload="initialize()">


### PR DESCRIPTION
This commit alters the google map api calls to use https instead of http. I believe google prefers this over http.
