### PR TITLE
Re-add adif + tq8 mime types, upload path

### DIFF
--- a/application/config/mimes.php
+++ b/application/config/mimes.php
@@ -179,5 +179,11 @@ return array(
 	'odt'	=>	'application/vnd.oasis.opendocument.text',
 	'odm'	=>	'application/vnd.oasis.opendocument.text-master',
 	'ott'	=>	'application/vnd.oasis.opendocument.text-template',
-	'oth'	=>	'application/vnd.oasis.opendocument.text-web'
+	'oth'	=>	'application/vnd.oasis.opendocument.text-web',
+	'adi'   =>  array('application/octet-stream','text/plain'),
+	'adif'  =>  array('application/octet-stream','text/plain'),
+	'ADI'   =>  array('application/octet-stream','text/plain'),
+	'ADIF'  =>  array('application/octet-stream','text/plain'),
+	'tq8'   =>  'application/octet-stream',
+	'TQ8'   =>  'application/octet-stream'
 );

--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -70,7 +70,7 @@ class adif extends CI_Controller {
 
 		$data['page_title'] = "ADIF Import";
 
-		$config['upload_path'] = 'uploads/';
+		$config['upload_path'] = './uploads/';
 		$config['allowed_types'] = 'adi|ADI|adif|ADIF';
 
 		$this->load->library('upload', $config);


### PR DESCRIPTION
- Set ADIF upload path to "./upload/" to be clear about where the files go.
- For ADIF files, my browser uses text/plain so add this to the adi/adif mime type.