### PR TITLE
Fix statistics 404 and HTTPS in installer

### DIFF
--- a/application/views/statistics/custom.php
+++ b/application/views/statistics/custom.php
@@ -10,9 +10,9 @@
 	<h2><?php echo $page_title; ?></h2>
 
 	<ul class="tabs">
-	  <li><a href="statistics">General</a></li>
-	  <li><a href="statistics">Satellite Contacts</a></li>
-	  <li class="active"><a href="statistics/custom">Custom</a></li>
+	  <li><a href="<?php echo site_url('statistics');?>#home">General</a></li>
+	  <li><a href="<?php echo site_url('statistics');?>#space">Satellite Contacts</a></li>
+	  <li class="active"><a href="<?php echo site_url('statistics');?>/custom">Custom</a></li>
 	</ul>
 	
 		<p>This is a work in-progress</p>

--- a/application/views/statistics/custom_result.php
+++ b/application/views/statistics/custom_result.php
@@ -10,9 +10,9 @@
 	<h2><?php echo $page_title; ?></h2>
 
 	<ul class="tabs">
-	  <li><a href="statistics">General</a></li>
-	  <li><a href="statistics">Satellite Contacts</a></li>
-	  <li class="active"><a href="statistics/custom">Custom</a></li>
+	  <li><a href="<?php echo site_url('statistics');?>#home">General</a></li>
+	  <li><a href="<?php echo site_url('statistics');?>#space">Satellite Contacts</a></li>
+	  <li class="active"><a href="<?php echo site_url('statistics');?>/custom">Custom</a></li>
 	</ul>
 	
 		<p>This is a work in-progress</p>

--- a/install/index.php
+++ b/install/index.php
@@ -101,7 +101,7 @@ if($_POST) {
 		  <fieldset>
 		  	<legend>Configuration Settings</legend>
 		  	<label for="directory">Directory</label><input type="text" id="directory" value="<?php echo str_replace("/install/", "", $_SERVER['REQUEST_URI']); ?>" class="input_text" name="directory" />
-		  	<label for="websiteurl">Website URL</label><input type="text" id="websiteurl" value="http://<?php echo $_SERVER['HTTP_HOST'].str_replace("/install/", "", $_SERVER['REQUEST_URI']); ?>" class="input_text" name="websiteurl" />
+		  	<label for="websiteurl">Website URL</label><input type="text" id="websiteurl" value="<?php echo $_SERVER['REQUEST_SCHEME']; ?>://<?php echo $_SERVER['HTTP_HOST'].str_replace("/install/", "", $_SERVER['REQUEST_URI']); ?>" class="input_text" name="websiteurl" />
 		  	<label for="locator">Default Gridsquare</label><input type="text" id="locator" value="IO91JS" class="input_text" name="locator" />
 		  </fieldset>
 


### PR DESCRIPTION
Hi,

these are 2 minor changes, the first isn't too nice actually because the tab-switching is handled in JavaScript and still isn't working right, but at least it doesn't cause a 404 anymore. 

The second one automatically detects http/https for the URL in the install wizard. 

So long
Tobias