### PR TITLE
Add configuration parameter for GMaps API key

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -35,6 +35,16 @@ $config['display_freq'] = true;
 
 /*
 |--------------------------------------------------------------------------
+| Google Maps JavaScript API Key
+|--------------------------------------------------------------------------
+| visit https://developers.google.com/maps/documentation/javascript/get-api-key
+|
+| 'gmaps_api_key'	API key from Google Cloud Plattform
+*/
+$config['gmaps_api_key'] = "";
+
+/*
+|--------------------------------------------------------------------------
 | Authentication
 |--------------------------------------------------------------------------
 |

--- a/application/views/layout/header.php
+++ b/application/views/layout/header.php
@@ -10,7 +10,7 @@
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/bootstrap-dropdown.js"></script>
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/bootstrap-tabs.js"></script>
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/global.js"></script>
-	<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js"></script>
+	<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=<?php echo $this->config->item('gmaps_api_key');?>"></script>
 
 	<!-- CSS Files -->
 	<link type="text/css" href="<?php echo base_url(); ?>css/flick/jquery-ui-1.8.12.custom.css" rel="stylesheet" />

--- a/application/views/layout/mini_header.php
+++ b/application/views/layout/mini_header.php
@@ -10,7 +10,7 @@
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/jquery-1.5.1.min.js"></script>
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/jquery-ui-1.8.12.custom.min.js"></script>
 	<script type="text/javascript" src="<?php echo base_url(); ?>js/global.js"></script>
-	<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js"></script>
+	<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=<?php echo $this->config->item('gmaps_api_key');?>"></script>
 	
 </head>
 

--- a/application/views/statistics/custom.php
+++ b/application/views/statistics/custom.php
@@ -10,9 +10,9 @@
 	<h2><?php echo $page_title; ?></h2>
 
 	<ul class="tabs">
-	  <li><a href="statistics">General</a></li>
-	  <li><a href="statistics">Satellite Contacts</a></li>
-	  <li class="active"><a href="statistics/custom">Custom</a></li>
+	  <li><a href="<?php echo site_url('statistics');?>#home">General</a></li>
+	  <li><a href="<?php echo site_url('statistics');?>#space">Satellite Contacts</a></li>
+	  <li class="active"><a href="<?php echo site_url('statistics');?>/custom">Custom</a></li>
 	</ul>
 	
 		<p>This is a work in-progress</p>

--- a/application/views/statistics/custom_result.php
+++ b/application/views/statistics/custom_result.php
@@ -10,9 +10,9 @@
 	<h2><?php echo $page_title; ?></h2>
 
 	<ul class="tabs">
-	  <li><a href="statistics">General</a></li>
-	  <li><a href="statistics">Satellite Contacts</a></li>
-	  <li class="active"><a href="statistics/custom">Custom</a></li>
+	  <li><a href="<?php echo site_url('statistics');?>#home">General</a></li>
+	  <li><a href="<?php echo site_url('statistics');?>#space">Satellite Contacts</a></li>
+	  <li class="active"><a href="<?php echo site_url('statistics');?>/custom">Custom</a></li>
 	</ul>
 	
 		<p>This is a work in-progress</p>

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -19,7 +19,7 @@ line-height: 1.7;
 margin: 10px 0;
 }
 	</style>
-<script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false"></script> 
+<script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false&key=<?php echo $this->config->item('gmaps_api_key');?>"></script> 
 </head>
 
 <body onload="initialize()">

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -34,6 +34,16 @@ $config['display_freq'] = false;
 
 /*
 |--------------------------------------------------------------------------
+| Google Maps JavaScript API Key
+|--------------------------------------------------------------------------
+| visit https://developers.google.com/maps/documentation/javascript/get-api-key
+|
+| 'gmaps_api_key'	API key from Google Cloud Plattform
+*/
+$config['gmaps_api_key'] = "";
+
+/*
+|--------------------------------------------------------------------------
 | Authentication
 |--------------------------------------------------------------------------
 |

--- a/install/index.php
+++ b/install/index.php
@@ -101,7 +101,7 @@ if($_POST) {
 		  <fieldset>
 		  	<legend>Configuration Settings</legend>
 		  	<label for="directory">Directory</label><input type="text" id="directory" value="<?php echo str_replace("/install/", "", $_SERVER['REQUEST_URI']); ?>" class="input_text" name="directory" />
-		  	<label for="websiteurl">Website URL</label><input type="text" id="websiteurl" value="http://<?php echo $_SERVER['HTTP_HOST'].str_replace("/install/", "", $_SERVER['REQUEST_URI']); ?>" class="input_text" name="websiteurl" />
+		  	<label for="websiteurl">Website URL</label><input type="text" id="websiteurl" value="<?php echo $_SERVER['REQUEST_SCHEME']; ?>://<?php echo $_SERVER['HTTP_HOST'].str_replace("/install/", "", $_SERVER['REQUEST_URI']); ?>" class="input_text" name="websiteurl" />
 		  	<label for="locator">Default Gridsquare</label><input type="text" id="locator" value="IO91JS" class="input_text" name="locator" />
 		  </fieldset>
 


### PR DESCRIPTION
Hi,

this PR adds a configuration parameter for the GMaps API key, this fixes #199. 

$config['gmaps_api_key'] = "";
can now be set. 

(I'm sorry about the double commits in this PR; I messed up my local branches. This fixes itself if the other PR is merged, otherwise I can rebase this).

So long
Tobias