### PR TITLE
Create updates folder

### DIFF
--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -169,6 +169,11 @@ class Update extends CI_Controller {
 		}
 		gzclose($gz);
 		
+		if (!file_exists("./updates/"))
+		{
+			mkdir("./updates");
+		}
+		
 		file_put_contents('./updates/cty.xml', $data);
 	
 	    // Clear the tables, ready for new data

--- a/updates/index.html
+++ b/updates/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>


### PR DESCRIPTION
Hi,

this PR adds the "updates" folder to the git repository.
Without this folder being present, clicking on the DXCC update button causes a cascade failure, resulting in a crash and an empty DXCC table. If you then import an ADIF file, you completely ruin your database :-) 
Luckily, I had a recent backup at hand... 

EDIT: thinking about it, I added an additional check to the Update controller, to create the folder if it doesn't already exist. Doesn't hurt, but could help. 

Best regards,
Tobias