### PR TITLE
Fix #213: Eqsl errors in download may not be handled correctly

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -106,9 +106,10 @@ class eqsl extends CI_Controller {
 			
 			// Get credentials for eQSL
 			$query = $this->user_model->get_by_id($this->session->userdata('user_id'));
-    		$q = $query->row();
-    		$data['user_eqsl_name'] = $q->user_eqsl_name;
+			$q = $query->row();
+			$data['user_eqsl_name'] = $q->user_eqsl_name;
 			$data['user_eqsl_password'] = $q->user_eqsl_password;
+			$data['user_eqsl_qth_nickname'] = $q->user_eqsl_qth_nickname;
 			
 			// Get URL for downloading the eqsl.cc inbox
 			$query = $query = $this->db->query('SELECT eqsl_download_url FROM config');
@@ -128,6 +129,11 @@ class eqsl extends CI_Controller {
 			$eqsl_url .= "?";
 			$eqsl_url .= "UserName=" . $data['user_eqsl_name'];
 			$eqsl_url .= "&Password=" . $data['user_eqsl_password'];
+
+			if ($data['user_eqsl_qth_nickname'] != '')
+			{
+				$eqsl_url .= "&QTHNickname=" . $data['user_eqsl_qth_nickname'];
+			}
 			
 			$eqsl_url .= "&RcvdSince=" . $eqsl_last_qsl_date;
 			

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -214,6 +214,12 @@ class User extends CI_Controller {
 				$data['user_eqsl_password'] = $q->user_eqsl_password;
 			}
 			
+			if($this->input->post('user_eqsl_qth_nickname')) {
+				$data['user_eqsl_qth_nickname'] = $this->input->post('user_eqsl_qth_nickname');
+			} else {
+				$data['user_eqsl_qth_nickname'] = $q->user_eqsl_qth_nickname;
+			}
+			
 			$this->load->view('user/edit', $data);
 			$this->load->view('layout/footer');
 		}

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -124,7 +124,8 @@ class User_Model extends CI_Model {
 					'user_lastname' => $fields['user_lastname'],
 					'user_timezone' => $fields['user_timezone'],
 					'user_lotw_name' => $fields['user_lotw_name'],
-					'user_eqsl_name' => $fields['user_eqsl_name']
+					'user_eqsl_name' => $fields['user_eqsl_name'],
+					'user_eqsl_qth_nickname' => $fields['user_eqsl_qth_nickname']
 				);
 	
 				// Check to see if the user is allowed to change user levels
@@ -213,14 +214,15 @@ class User_Model extends CI_Model {
 		$u = $this->get_by_id($id);
 
 		$userdata = array(
-			'user_id'		=> $u->row()->user_id,
-			'user_name'		=> $u->row()->user_name,
-			'user_type'		=> $u->row()->user_type,
-			'user_callsign'		=> $u->row()->user_callsign,
-			'user_locator'		=> $u->row()->user_locator,
-			'user_lotw_name'	=> $u->row()->user_lotw_name,
-			'user_eqsl_name'	=> $u->row()->user_eqsl_name,
-			'user_hash'		=> $this->_hash($u->row()->user_id."-".$u->row()->user_type)
+			'user_id'		 => $u->row()->user_id,
+			'user_name'		 => $u->row()->user_name,
+			'user_type'		 => $u->row()->user_type,
+			'user_callsign'		 => $u->row()->user_callsign,
+			'user_locator'		 => $u->row()->user_locator,
+			'user_lotw_name'	 => $u->row()->user_lotw_name,
+			'user_eqsl_name'	 => $u->row()->user_eqsl_name,
+			'user_eqsl_qth_nickname' => $u->row()->user_eqsl_qth_nickname,
+			'user_hash'		 => $this->_hash($u->row()->user_id."-".$u->row()->user_type)
 		);
 
 		$this->session->set_userdata($userdata);

--- a/application/views/eqsl/import.php
+++ b/application/views/eqsl/import.php
@@ -15,7 +15,7 @@
 	<tr>
 		<td><input type="radio" name="eqslimport" id="fetch" value="fetch" /> Pull eQSL data for me</td>
 		<td>
-			<p>Cloudlog will use the eQSL username an password stored in your user profile to download confirmations from eQSL for you. We will only download confirmations received since your last eQSL confirmed QSO.</p>
+			<p>Cloudlog will use the eQSL username and password stored in your user profile to download confirmations from eQSL for you. We will only download confirmations received since your last eQSL confirmed QSO.</p>
 		</td>
 	</tr>
 </table>

--- a/application/views/lotw/import.php
+++ b/application/views/lotw/import.php
@@ -15,7 +15,7 @@
 	<tr>
 		<td><input type="radio" name="lotwimport" id="fetch" value="fetch" /> Pull LoTW data for me</td>
 		<td>
-			<p>Cloudlog will use the LoTW username an password stored in your user profile to download a report from LoTW for you. The report Cloudlog downloads will have all confirmations since your last LoTW confirmation, up until now.</p>
+			<p>Cloudlog will use the LoTW username and password stored in your user profile to download a report from LoTW for you. The report Cloudlog downloads will have all confirmations since your last LoTW confirmation, up until now.</p>
 		</td>
 	</tr>
 </table>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -115,6 +115,12 @@ $this->load->helper('form');
 		<?php } ?>
 	</tr>
 	
+	<tr>
+		<td>eQSL.cc QTH Nickname</td>
+		<td><input type="text" name="user_eqsl_qth_nickname" value="<?php if(isset($user_eqsl_qth_nickname)) { echo $user_eqsl_qth_nickname; } ?>" />
+		</td>
+	</tr>
+	
 </table>	
 <input type="hidden" name="id" value="<?php echo $this->uri->segment(3); ?>" />
 <div class="actions"><input class="btn primary" type="submit" value="Update profile" /></div>


### PR DESCRIPTION
Prior to running, an extra column needs adding to the users table.

`alter table users add user_eqsl_qth_nickname varchar(32);`

I'm fairly sure this can be streamlined to have some method of picking which log to upload to when required, but for now, this fixes the immediate failure at hand ...

http://www.eqsl.cc/qslcard/DownloadInBox.txt gives further info on how their interface can be manipulated (which I'd found the doc before I trial and errored this fix!)