### PR TITLE
LoTW: Prevent error auto pull after initial pull

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -132,8 +132,12 @@ class Lotw extends CI_Controller {
 			//TODO: Option to specifiy whether we download location data from LoTW or not
 			//$lotw_url .= "&qso_qsldetail=\"yes\";
 
-			$lotw_url .= "&qso_qslsince=";
-			$lotw_url .= "$lotw_last_qsl_date";
+      /*
+       * TODO: (G0WFV) commented this out as it's causing a crash (needs investigation)
+       *
+       * $lotw_url .= "&qso_qslsince=";
+       * $lotw_url .= "$lotw_last_qsl_date";
+       */
 
 			// Only pull back entries that belong to this callsign
 			$lotw_call = $this->session->userdata('user_callsign');

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -104,8 +104,8 @@ class Lotw extends CI_Controller {
 
 			// Get credentials for LoTW
 			$query = $this->user_model->get_by_id($this->session->userdata('user_id'));
-    		$q = $query->row();
-    		$data['user_lotw_name'] = $q->user_lotw_name;
+    	$q = $query->row();
+    	$data['user_lotw_name'] = $q->user_lotw_name;
 			$data['user_lotw_password'] = $q->user_lotw_password;
 
 			// Get URL for downloading LoTW
@@ -121,7 +121,7 @@ class Lotw extends CI_Controller {
 			}
 
 			// Query the logbook to determine when the last LoTW confirmation was
-			$lotw_last_qsl_date = $this->logbook_model->lotw_last_qsl_date();
+			$lotw_last_qsl_date = date('Y-m-d', strtotime($this->logbook_model->lotw_last_qsl_date()));
 
 			// Build URL for LoTW report file
 			$lotw_url .= "?";
@@ -132,12 +132,8 @@ class Lotw extends CI_Controller {
 			//TODO: Option to specifiy whether we download location data from LoTW or not
 			//$lotw_url .= "&qso_qsldetail=\"yes\";
 
-      /*
-       * TODO: (G0WFV) commented this out as it's causing a crash (needs investigation)
-       *
-       * $lotw_url .= "&qso_qslsince=";
-       * $lotw_url .= "$lotw_last_qsl_date";
-       */
+      $lotw_url .= "&qso_qslsince=";
+      $lotw_url .= "$lotw_last_qsl_date";
 
 			// Only pull back entries that belong to this callsign
 			$lotw_call = $this->session->userdata('user_callsign');


### PR DESCRIPTION
This temporarily prevents an error (failed to open stream: HTTP request failed! HTTP/1.1 400 Bad Request) from occurting during auto pull of LoTW QSLs.

I will investigate further, but for now the offending part of the URL generation has been commented out; it's probably an easy fix along the lines of date format? 