### PR TITLE
Added authentication for api/radio

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -351,6 +351,8 @@ class API extends CI_Controller {
 	function radio() {
 		header('Content-type: application/json');
 
+		$this->load->model('api_model');
+
 		//$json = '{"radio":"FT-950","frequency":14075,"mode":"SSB","timestamp":"2012/04/07 16:47"}';
 
 		$this->load->model('cat');
@@ -359,6 +361,11 @@ class API extends CI_Controller {
 
 		// Decode JSON and store
 		$obj = json_decode(file_get_contents("php://input"), true);
+
+		if(!isset($obj['key']) || $this->api_model->authorize($obj['key']) == 0) {
+		   echo json_encode(['status' => 'failed', 'reason' => "missing api key"]);
+		   die();
+		}
 
 		// Store Result to Database
 		$this->cat->update($obj);


### PR DESCRIPTION
Hi,

like mentioned here: https://github.com/magicbug/Cloudlog/issues/238
I've implemented authentication into the api/radio call. 

There are 2 open questions for me: 
1. There's a api/cat_status command. I'm not sure who/what uses that. Should this get the same authentication code? 
2. This breaks your existing SatPC32 implementation because it requires key-auth, non-optionally. Is that OK? 

73,
Tobias (DL4TMA)