### PR TITLE
Fix encoding on this file (convert to UTF8)

### DIFF
--- a/application/views/notes/main.php
+++ b/application/views/notes/main.php
@@ -18,7 +18,7 @@
 				}
 				echo "</ul>";
 			} else {
-				echo "<p>You don’t currently have any notes, these are a fantastic way of storing data like ATU settings, beacons and general station notes and its better than paper as you can’t lose them!</p>";
+				echo "<p>You don't currently have any notes, these are a fantastic way of storing data like ATU settings, beacons and general station notes and its better than paper as you can't lose them!</p>";
 			}
 
 		?>


### PR DESCRIPTION
Very small change:
![screenshot](https://screenshot.tbspace.de/hqepvzkjibg.png)

This looked a bit nasty. For some reason the main.php was saved as windows-1251 encoding.