### PR TITLE
Request CAT information as JSON

### DIFF
--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -61,6 +61,18 @@
 			
 	}
 	
+	function json($id)
+	{
+		echo json_encode(array(
+			"uplink_freq" => $this->frequency($id, false),
+			"downlink_freq" => $this->frequency($id, true),
+			"mode" => $this->mode($id),
+			"satmode" => $this->satmode($id),
+			"satname" => $this->satname($id),
+		), JSON_PRETTY_PRINT);
+	}
+
+
 	function frequency_downlink($id) {
 		return $this->frequency($id, true);
 	}
@@ -90,19 +102,20 @@
 							foreach ($query->result() as $row)
 							{
 								if ($downlink)
-									echo strtoupper($row->downlink_freq);
+									return strtoupper($row->downlink_freq);
 								else	
-									echo strtoupper($row->uplink_freq);
+									return strtoupper($row->uplink_freq);
 							}
 						}
 					} else {
 						if ($downlink)
-							echo "";
+							return "";
 						else	
-							echo strtoupper($row->frequency);	
+							return strtoupper($row->frequency);	
 					}
 				}
 			}
+		return ""; 
 	}
 	
 	function mode($id) {
@@ -122,19 +135,20 @@
 				{
 					if($row->radio != "SatPC32") {
 						if(strtoupper($row->mode) == "FMN"){
-							echo "FM";
+							return "FM";
 						} else {
-							echo strtoupper($row->mode);
+							return strtoupper($row->mode);
 						}
 					} else {
 						if(strtoupper($row->uplink_mode) == "FMN"){
-							echo "FM";
+							return "FM";
 						} else {
-							echo strtoupper($row->uplink_mode);
+							return strtoupper($row->uplink_mode);
 						}
 					}
 				}
 			}
+		return "";
 	}
 
 	function satname($id) {
@@ -153,14 +167,15 @@
 			   foreach ($query->result() as $row)
 				{
 					if($row->sat_name == "AO-07") {
-						echo "AO-7";
+						return "AO-7";
 					} elseif ($row->sat_name == "LILACSAT") {
-						echo "CAS-3H";
+						return "CAS-3H";
 					} else {
-						echo strtoupper($row->sat_name);
+						return strtoupper($row->sat_name);
 					}
 				}
 			}
+		return "";
 	}
 
 	function satmode($id) {
@@ -198,9 +213,11 @@
 					}
 					
 					if ($uplink_mode != "" && $downlink_mode != "")
-						echo $uplink_mode."/".$downlink_mode;
+						return $uplink_mode."/".$downlink_mode;
 				}
 			}
+
+			return ""; 
 	}
 	
 	function delete($id) {

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -332,41 +332,33 @@
 <?php if ( $_GET['manual'] == 0 ) { ?>
   var updateFromCAT = function() {
     if($('select.radios option:selected').val() != '0') {
-      // Get frequency
-      $.get('radio/frequency/' + $('select.radios option:selected').val(), function(result) {
+      radioID = $('select.radios option:selected').val(); 
+      $.getJSON( "radio/json/" + radioID, function( data ) {
+          /* {
+              "uplink_freq": "2400210000",
+              "downlink_freq": "10489710000",
+              "mode": "SSB",
+              "satmode": "",
+              "satname": "ES'HAIL-2"
+          }  */
+          if (data.downlink_freq != "")
+          {
+            $('#frequency').val(data.downlink_freq);
+            $(".band").val(frequencyToBand(data.downlink_freq));
+          }
+          if (data.uplink_freq != "")
+          {
+            $('#frequency_rx').val(data.uplink_freq);
+          }
+          if (data.mode == "LSB" || data.mode == "USB" || data.mode == "SSB") {
+            $(".mode").val('SSB');
+          } else {
+            $(".mode").val(data.mode);  
+          }
 
-        if(result == "0") {
-        } else {
-          $('#frequency').val(result);
-          $(".band").val(frequencyToBand(result));
-        }
+          $(".sat_name").val(data.satname);  
+          $(".sat_mode").val(data.satmode);  
       });
-      $.get('radio/frequency_downlink/' + $('select.radios option:selected').val(), function(result) {
-      if(result == "0") {
-      } else {
-        $('#frequency_rx').val(result);
-      }
-      });
-            
-      // Get Mode
-      $.get('radio/mode/' + $('select.radios option:selected').val(), function(result) {
-        if (result == "LSB" || result == "USB" || result == "SSB") {
-          $(".mode").val('SSB');
-        } else {
-          $(".mode").val(result);  
-        }
-      });
-
-        // Get SAT_Name
-      $.get('radio/satname/' + $('select.radios option:selected').val(), function(result) {
-        $(".sat_name").val(result);  
-      });
-
-        // Get SAT_Name
-      $.get('radio/satmode/' + $('select.radios option:selected').val(), function(result) {
-        $(".sat_mode").val(result);  
-      });
-
     }
   };
 


### PR DESCRIPTION
Here's already the next PR. 
I have changed the way the CAT information is requested from the server. Instead of 4 (well, with the DL frequency 5) seperate HTTP requests every second, now only 1 has to be executed and replies with a JSON array containing the neccesarry information.

Should be faster and neater this way :+1: 