### PR TITLE
Updated the $db_config_path not-writable error

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -127,7 +127,7 @@ if($_POST) {
 		  	<p>When you login create a new admin account and delete the m0abc user account.</p>
 
 	 <?php else: ?>
-     <p class="error">Please make the /application/config/database.php file writable. <strong>Example</strong>:<br /><br /><code>chmod 777 /application/config/database.php</code></p>
+     <p class="error">Please make the /application/config/ folder writable. <strong>Example</strong>:<br /><br /><code>chmod -R 777 /application/config/</code><br /><br /><i>Don't forget to restore the permissions afterwards.</i></p>
 	 <?php endif; ?>
 
 	</body>


### PR DESCRIPTION
A slightly more informative error message for when $db_config_path isn't writable.