### PR TITLE
Fixing bug with & in name of DXCC

### DIFF
--- a/application/views/awards/dxcc/index.php
+++ b/application/views/awards/dxcc/index.php
@@ -36,7 +36,7 @@
                 if ($count == 0){
                     print("<td>&nbsp;</td>");
                 }else{
-                    printf("<td><a href='dxcc_details?Country=\"%s\"&Band=\"%s\"'>%d</a></td>", $country, $band, $count);
+                    printf("<td><a href='dxcc_details?Country=\"%s\"&Band=\"%s\"'>%d</a></td>", str_replace("&", "%26", $country), $band, $count);
                 }
             }
             print("</tr>");


### PR DESCRIPTION
An & in the name of a DXCC causes the webserver to ERROR 500.