### PR TITLE
Storing Station profile and selected CAT-Radio-controller in cookie

### DIFF
--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -63,6 +63,9 @@ class QSO extends CI_Controller {
 				'station_profile_id' => $this->input->post('station_profile')
 			);
 			// ];
+			
+			setcookie("radio", $qso_data['radio'], time()+3600*24*99);
+			setcookie("station_profile_id", $qso_data['station_profile_id'], time()+3600*24*99);
 
 			$this->session->set_userdata($qso_data);
 				

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -229,7 +229,9 @@ class User_Model extends CI_Model {
 			'user_lotw_name'	 => $u->row()->user_lotw_name,
 			'user_eqsl_name'	 => $u->row()->user_eqsl_name,
 			'user_eqsl_qth_nickname' => $u->row()->user_eqsl_qth_nickname,
-			'user_hash'		 => $this->_hash($u->row()->user_id."-".$u->row()->user_type)
+			'user_hash'		 => $this->_hash($u->row()->user_id."-".$u->row()->user_type),
+			'radio' => isset($_COOKIE["radio"])?$_COOKIE["radio"]:"",
+			'station_profile_id' => isset($_COOKIE["station_profile_id"])?$_COOKIE["station_profile_id"]:""
 		);
 
 		$this->session->set_userdata($userdata);


### PR DESCRIPTION
The info is stored for 3600 * 24 * 99 seconds = 99 days within a local browser cookie.