### PR TITLE
Remove static table name from migrations

### DIFF
--- a/application/migrations/017_qslviavarchar.php
+++ b/application/migrations/017_qslviavarchar.php
@@ -7,7 +7,7 @@ class Migration_qslviavarchar extends CI_Migration {
         public function up()
         {
                 $this->db->db_debug = false;
-                $this->db->query("ALTER TABLE TABLE_HRD_CONTACTS_V01 CHANGE COLUMN COL_QSL_VIA COL_QSL_VIA varchar(255) DEFAULT NULL;");
+                $this->db->query("ALTER TABLE ".$this->config->item('table_name')." CHANGE COLUMN COL_QSL_VIA COL_QSL_VIA varchar(255) DEFAULT NULL;");
                 $this->db->db_debug = true;
         }
 

--- a/application/migrations/019_forceint_wrongtype.php
+++ b/application/migrations/019_forceint_wrongtype.php
@@ -19,7 +19,7 @@ class Migration_forceint_wrongtype extends CI_Migration {
                                 'constraint' => '2',
                         ),
                 );
-                $this->dbforge->modify_column('TABLE_HRD_CONTACTS_V01', $fields);
+                $this->dbforge->modify_column($this->config->item('table_name'), $fields);
         }
 
         public function down()


### PR DESCRIPTION
This allows the migrations to run smoothly :) 