### PR TITLE
Qslprint is considering only the QSOs of the active station profile now.

### DIFF
--- a/application/config/cloudlog.php
+++ b/application/config/cloudlog.php
@@ -32,7 +32,7 @@ $config['show_time'] = FALSE;
 | Default is: M
 |
 */
-$config['measurement_base'] = 'M';
+$config['measurement_base'] = 'K';
 
 /*
 |--------------------------------------------------------------------------
@@ -73,6 +73,6 @@ $config['cat_timeout_interval'] = 300;
 |
 */
 
-$config['public_search'] = FALSE;
+$config['public_search'] = TRUE;
 
 $config['callsign_tags'] = TRUE;

--- a/application/config/cloudlog.php
+++ b/application/config/cloudlog.php
@@ -32,7 +32,7 @@ $config['show_time'] = FALSE;
 | Default is: M
 |
 */
-$config['measurement_base'] = 'K';
+$config['measurement_base'] = 'M';
 
 /*
 |--------------------------------------------------------------------------
@@ -73,6 +73,6 @@ $config['cat_timeout_interval'] = 300;
 |
 */
 
-$config['public_search'] = TRUE;
+$config['public_search'] = FALSE;
 
 $config['callsign_tags'] = TRUE;

--- a/application/controllers/Qslprint.php
+++ b/application/controllers/Qslprint.php
@@ -54,7 +54,7 @@ class QSLPrint extends CI_Controller {
 		// file creation
 		$file = fopen('php://output', 'w');
  
-		$header = array("COL_STATION_CALLSIGN",
+		$header = array("STATION_CALLSIGN",
 						"COL_CALL", 
 						"COL_QSL_VIA", 
 						"COL_TIME_ON", 
@@ -73,7 +73,7 @@ class QSLPrint extends CI_Controller {
  
 		foreach ($myData->result() as $qso) {
 			fputcsv($file, 
-				array($qso->COL_STATION_CALLSIGN,
+				array($qso->STATION_CALLSIGN,
 				str_replace("0", "Ø", $qso->COL_CALL), 
 				$qso->COL_QSL_VIA!=""?"Via ".str_replace("0", "Ø", $qso->COL_QSL_VIA):"", 
 				$qso->COL_TIME_ON, 

--- a/application/controllers/Qslprint.php
+++ b/application/controllers/Qslprint.php
@@ -54,7 +54,8 @@ class QSLPrint extends CI_Controller {
 		// file creation
 		$file = fopen('php://output', 'w');
  
-		$header = array("COL_CALL", 
+		$header = array("COL_STATION_CALLSIGN",
+						"COL_CALL", 
 						"COL_QSL_VIA", 
 						"COL_TIME_ON", 
 						"COL_MODE", 
@@ -72,7 +73,8 @@ class QSLPrint extends CI_Controller {
  
 		foreach ($myData->result() as $qso) {
 			fputcsv($file, 
-				array(str_replace("0", "Ø", $qso->COL_CALL), 
+				array($qso->COL_STATION_CALLSIGN,
+				str_replace("0", "Ø", $qso->COL_CALL), 
 				$qso->COL_QSL_VIA!=""?"Via ".str_replace("0", "Ø", $qso->COL_QSL_VIA):"", 
 				$qso->COL_TIME_ON, 
 				$qso->COL_MODE, 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -404,7 +404,8 @@ class Logbook_model extends CI_Model {
 
 
   // Set Paper to recived
-  function paperqsl_update($qso_id, $method) {
+  function paperqsl_update($qso_id, $method) {  
+	
     $data = array(
          'COL_QSLRDATE' => date('Y-m-d'),
          'COL_QSL_RCVD' => 'Y',
@@ -417,7 +418,11 @@ class Logbook_model extends CI_Model {
   }
 
   function get_qsos_for_printing() {
-    $query = $this->db->query('SELECT COL_PRIMARY_KEY, COL_CALL, COL_QSL_VIA, COL_TIME_ON, COL_MODE, COL_FREQ, UPPER(COL_BAND) as COL_BAND, COL_RST_SENT, COL_SAT_NAME, COL_SAT_MODE, COL_QSL_RCVD, (CASE WHEN COL_QSL_VIA != \'\' THEN COL_QSL_VIA ELSE COL_CALL END) AS COL_ROUTING, ADIF, ENTITY FROM '.$this->config->item('table_name').', dxcc_prefixes WHERE COL_QSL_SENT LIKE \'R\' and (CASE WHEN COL_QSL_VIA != \'\' THEN COL_QSL_VIA ELSE COL_CALL END) like CONCAT(dxcc_prefixes.call,\'%\') and (end is null or end > now()) ORDER BY adif, col_routing');
+	$CI =& get_instance();
+    $CI->load->model('Stations');
+    $station_id = $CI->Stations->find_active();
+	
+    $query = $this->db->query('SELECT COL_PRIMARY_KEY, COL_CALL, COL_STATION_CALLSIGN, COL_QSL_VIA, COL_TIME_ON, COL_MODE, COL_FREQ, UPPER(COL_BAND) as COL_BAND, COL_RST_SENT, COL_SAT_NAME, COL_SAT_MODE, COL_QSL_RCVD, (CASE WHEN COL_QSL_VIA != \'\' THEN COL_QSL_VIA ELSE COL_CALL END) AS COL_ROUTING, ADIF, ENTITY FROM '.$this->config->item('table_name').', dxcc_prefixes WHERE COL_QSL_SENT LIKE \'R\' and (CASE WHEN COL_QSL_VIA != \'\' THEN COL_QSL_VIA ELSE COL_CALL END) like CONCAT(dxcc_prefixes.call,\'%\') and (end is null or end > now()) and station_id = '.$station_id.' ORDER BY adif, col_routing');
     return $query;
   }
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -422,7 +422,30 @@ class Logbook_model extends CI_Model {
     $CI->load->model('Stations');
     $station_id = $CI->Stations->find_active();
 	
-    $query = $this->db->query('SELECT COL_PRIMARY_KEY, COL_CALL, COL_STATION_CALLSIGN, COL_QSL_VIA, COL_TIME_ON, COL_MODE, COL_FREQ, UPPER(COL_BAND) as COL_BAND, COL_RST_SENT, COL_SAT_NAME, COL_SAT_MODE, COL_QSL_RCVD, (CASE WHEN COL_QSL_VIA != \'\' THEN COL_QSL_VIA ELSE COL_CALL END) AS COL_ROUTING, ADIF, ENTITY FROM '.$this->config->item('table_name').', dxcc_prefixes WHERE COL_QSL_SENT LIKE \'R\' and (CASE WHEN COL_QSL_VIA != \'\' THEN COL_QSL_VIA ELSE COL_CALL END) like CONCAT(dxcc_prefixes.call,\'%\') and (end is null or end > now()) and station_id = '.$station_id.' ORDER BY adif, col_routing');
+    $query = $this->db->query('SELECT 
+								STATION_CALLSIGN,
+								COL_PRIMARY_KEY, 
+								COL_CALL,  
+								COL_QSL_VIA, 
+								COL_TIME_ON, 
+								COL_MODE, 
+								COL_FREQ, 
+								UPPER(COL_BAND) as COL_BAND, 
+								COL_RST_SENT, 
+								COL_SAT_NAME, 
+								COL_SAT_MODE, 
+								COL_QSL_RCVD, 
+								(CASE WHEN COL_QSL_VIA != \'\' THEN COL_QSL_VIA ELSE COL_CALL END) AS COL_ROUTING, 
+								ADIF, 
+								ENTITY 
+								FROM '.$this->config->item('table_name').', dxcc_prefixes, station_profile 
+								WHERE 
+								COL_QSL_SENT LIKE \'R\' 
+								and (CASE WHEN COL_QSL_VIA != \'\' THEN COL_QSL_VIA ELSE COL_CALL END) like CONCAT(dxcc_prefixes.call,\'%\') 
+								and (end is null or end > now()) 
+								and '.$this->config->item('table_name').'.station_id = '.$station_id.'
+								and '.$this->config->item('table_name').'.station_id = station_profile.station_id
+								ORDER BY adif, col_routing');
     return $query;
   }
 

--- a/application/models/Qslprint_model.php
+++ b/application/models/Qslprint_model.php
@@ -8,6 +8,10 @@ class Qslprint_model extends CI_Model {
 	}
 
 	function mark_qsos_printed() {
+		$CI =& get_instance();
+		$CI->load->model('Stations');
+		$station_id = $CI->Stations->find_active();
+		
 		$data = array(
 	        'COL_QSLSDATE' => date('Y-m-d'),
 	        'COL_QSL_SENT' => "Y",
@@ -15,6 +19,7 @@ class Qslprint_model extends CI_Model {
 		);
 
 		$this->db->where("COL_QSL_SENT", "R");
+		$this->db->where("station_id", $station_id);
 		$this->db->update($this->config->item('table_name'), $data);
 	}
 }

--- a/application/views/qslprint/index.php
+++ b/application/views/qslprint/index.php
@@ -16,7 +16,7 @@
 	  <div class="card-body">
 	    <h5 class="card-title"></h5>
 	    <p class="card-text">
-	    	Here you can export requested QSLs as CSV-file or ADIF and mark them as sent via buro in a mass transaction if you like.
+	    	Here you can export requested QSLs as CSV-file or ADIF and mark them as sent via buro in a mass transaction if you like. The considered QSOs for this functions would be those of the active station profile.
 	    </p>
 		
 		    


### PR DESCRIPTION
After making cloudlog able to work with different logs on different station profiles, the print-export-function now only considers the qsos of the active station.