### PR TITLE
Use Club Log CDN for cty.xml

### DIFF
--- a/application/controllers/Clublog.php
+++ b/application/controllers/Clublog.php
@@ -135,7 +135,7 @@ class Clublog extends CI_Controller {
 	function find_dxcc($callsign) {
 		$clean_callsign = $this->security->xss_clean($callsign);
 		// Live lookup against Clublogs API
-		$url = "https://secure.clublog.org/dxcc?call=".$clean_callsign."&api=a11c3235cd74b88212ce726857056939d52372bd&full=1";
+		$url = "https://clublog.org/dxcc?call=".$clean_callsign."&api=a11c3235cd74b88212ce726857056939d52372bd&full=1";
 
 		$json = file_get_contents($url);
 		$data = json_decode($json, TRUE);

--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -148,7 +148,7 @@ class Update extends CI_Controller {
 	    return $count;	
 	}
 
-	// Updates the DXCC & Exceptions from the Clublog Cty.xml file.
+	// Updates the DXCC & Exceptions from the Club Log Cty.xml file.
 	public function dxcc() {
 	    $this->update_status("Downloading file");
 
@@ -161,7 +161,7 @@ class Update extends CI_Controller {
 		$this->migration->latest();
 
 		// Download latest file.
-		$url = "https://secure.clublog.org/cty.php?api=a11c3235cd74b88212ce726857056939d52372bd";
+		$url = "https://cdn.clublog.org/cty.php?api=a11c3235cd74b88212ce726857056939d52372bd";
 		
 		$gz = gzopen($url, 'r');
 		$data = "";

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -122,15 +122,15 @@
 			</div>
 
 			<div class="form-group">
-				<label>Clublog Email/Callsign</label>
+				<label>Club Log Email/Callsign</label>
 				<input class="form-control" type="text" name="user_clublog_name" value="<?php if(isset($user_clublog_name)) { echo $user_clublog_name; } ?>" />
-					<div class="small">This is the Email or Callsign you use to login to Clublog</div></td>
+					<div class="small">This is the Email or Callsign you use to login to Club Log</div></td>
 					<?php if(isset($userclublogname_error)) { echo "<div class=\"small error\">".$userclublogname_error."</div>"; } ?>
 
 			</div>
 
 			<div class="form-group">
-				<label>Clublog Password</label>
+				<label>Club Log Password</label>
 				<input class="form-control" type="password" name="user_clublog_password" />
 					<?php if(isset($clublogpassword_error)) { echo "<div class=\"small error\">".$clublogpassword_error."</div>"; } else { ?>
 					<div class="small">Leave blank to keep existing password</div></td>


### PR DESCRIPTION
Change the URL for collecting Club Log's cty.xml definitions to use https://cdn.clublog.org (Content Delivery Network, faster). Remove reference to secure.clublog.org and update string "Clublog" to be "Club Log".

Getting my hands dirty for the first time so very minor stuff!