### PR TITLE
Add support for Club Log SCP

### DIFF
--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -33,7 +33,7 @@ class Lookup extends CI_Controller {
 			echo $log_calls ." ";
 		}
 
-
+		$arCalls = array();
 
 		// SCP results from master scp db
 		$file = 'updates/masterscp.txt';
@@ -46,10 +46,30 @@ class Lookup extends CI_Controller {
 			$result = preg_grep('~' . $input . '~', $lines, 0);
 
 			foreach ($result as &$value) {
-				echo " ".$value. " ";
+				$arCalls[] = $value;
 			}
 		}
-		
-	}
 
+		// SCP from Club Log
+		$file = "updates/clublog_scp.txt";
+		if (is_readable($file)) {
+
+			$lines = file($file, FILE_IGNORE_NEW_LINES);
+			
+			foreach ($lines as $strCall) 
+			{
+				if (in_array($strCall, $arCalls) == false)
+				{
+					$arCalls[] = $value;
+				}
+			}
+		}
+
+		sort($arCalls);
+
+		foreach ($arCalls as $strCall)
+		{
+			echo " " . $strCall . " ";
+		}
+	}
 }

--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -148,6 +148,40 @@ class Update extends CI_Controller {
 	    return $count;	
 	}
 
+    public function update_clublog_scp() {
+
+        $strFile = "./updates/clublog_scp.txt";
+        $url = "https://cdn.clublog.org/clublog.scp.gz";
+        set_time_limit(300);
+
+        $this->update_status("Downloading Club Log SCP file");
+        $gz = gzopen($url, 'r');
+        if ($gz)
+        {
+            $data = "";
+            while (!gzeof($gz)) {
+                $data .= gzgetc($gz);
+            }
+            gzclose($gz);
+            file_put_contents($strFile, $data);
+
+            if (file_exists($strFile))
+            {
+                $nCount = count(file($strFile));
+                if ($nCount > 0)
+                {
+                    $this->update_status("DONE: " . number_format($nCount) . " callsigns loaded" );
+                } else {
+                    $this->update_status("FAILED: Empty file");
+                }
+            } else {
+                $this->update_status("FAILED: Could not create Club Log SCP file locally");
+            }
+        } else {
+            $this->update_status("FAILED: Could not connect to Club Log");
+        }
+    }
+
 	// Updates the DXCC & Exceptions from the Club Log Cty.xml file.
 	public function dxcc() {
 	    $this->update_status("Downloading file");
@@ -172,7 +206,7 @@ class Update extends CI_Controller {
 		
 		file_put_contents('./updates/cty.xml', $data);
 	
-	    // Clear the tables, ready for new data
+  	    // Clear the tables, ready for new data
 		$this->db->empty_table("dxcc_entities");
 		$this->db->empty_table("dxcc_exceptions");
 		$this->db->empty_table("dxcc_prefixes");
@@ -205,7 +239,6 @@ class Update extends CI_Controller {
 
         file_put_contents('./updates/status.html', $html);
 	}
-
 
 	private function fix_migrations(){
         $res = $this->db->query("select version from migrations");


### PR DESCRIPTION
Add update_clublog_scp() method for fetching the Club Log SCP file.  Update Lookup to merge masterscp.txt and clublog_scp.txt together when both are available.