### PR TITLE
Multi client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 .idea/*
 .DS_Store
 sync.sh
+/.buildpath
+/.project
+/.dbeaver

--- a/Scripts/.gitignore
+++ b/Scripts/.gitignore
@@ -1,0 +1,1 @@
+/Script.sql

--- a/Scripts/add_column_user.sql
+++ b/Scripts/add_column_user.sql
@@ -1,0 +1,1 @@
+alter table users add column user_station_id integer not null default 0;

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -41,8 +41,19 @@ class Logbook extends CI_Controller {
 		} else {
 				$data['qra'] = "none";
 		}
-
-
+		$CI =& get_instance();
+		$CI->load->model('Stations');
+		$station_id = $CI->Stations->find_active();
+        $this->db->where('station_id',$station_id);
+        $query = $this->db->get('station_profile');
+        if($query->num_rows() >= 1) {
+            foreach ($query->result() as $row)
+            {
+                $data['title']  = "Logbook of station '" . $row->station_profile_name ."'";
+            }
+        } else {
+            $data['title'] = "Logbook";
+        }
 
 		// load the view
 		$data['page_title'] = "Logbook";

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -268,8 +268,11 @@ class Logbook_model extends CI_Model {
   }
 
   /* Show custom number of qsos */
-  function last_custom($num) {
+  function last_custom($num,$station_profile_id) {
     $this->db->select('COL_CALL, COL_BAND, COL_TIME_ON, COL_RST_RCVD, COL_RST_SENT, COL_MODE, COL_NAME, COL_COUNTRY, COL_PRIMARY_KEY, COL_SAT_NAME');
+    if ($station_profile_id > 0) {
+       $this->db->where('station_id',$station_profile_id);
+    }
     $this->db->order_by("COL_TIME_ON", "desc");
     $this->db->limit($num);
 
@@ -433,10 +436,20 @@ class Logbook_model extends CI_Model {
   }
 
   function get_qsos($num, $offset) {
-    $this->db->select(''.$this->config->item('table_name').'.COL_CALL, '.$this->config->item('table_name').'.COL_BAND, '.$this->config->item('table_name').'.COL_TIME_ON, '.$this->config->item('table_name').'.COL_RST_RCVD, '.$this->config->item('table_name').'.COL_RST_SENT, '.$this->config->item('table_name').'.COL_MODE, '.$this->config->item('table_name').'.COL_NAME, '.$this->config->item('table_name').'.COL_COUNTRY, '.$this->config->item('table_name').'.COL_PRIMARY_KEY, '.$this->config->item('table_name').'.COL_SAT_NAME, '.$this->config->item('table_name').'.COL_GRIDSQUARE, '.$this->config->item('table_name').'.COL_QSL_RCVD, '.$this->config->item('table_name').'.COL_EQSL_QSL_RCVD, '.$this->config->item('table_name').'.COL_EQSL_QSL_SENT, '.$this->config->item('table_name').'.COL_QSL_SENT, '.$this->config->item('table_name').'.COL_STX, '.$this->config->item('table_name').'.COL_STX_STRING, '.$this->config->item('table_name').'.COL_SRX, '.$this->config->item('table_name').'.COL_SRX_STRING, '.$this->config->item('table_name').'.COL_LOTW_QSL_SENT, '.$this->config->item('table_name').'.COL_LOTW_QSL_RCVD, '.$this->config->item('table_name').'.COL_VUCC_GRIDS, station_profile.*');
+    $CI =& get_instance();
+    $CI->load->model('Stations');
+    $station_id = $CI->Stations->find_active();
+    //$this->db->select(''.$this->config->item('table_name').'.COL_CALL, '.$this->config->item('table_name').'.COL_BAND, '.$this->config->item('table_name').'.COL_TIME_ON, '.$this->config->item('table_name').'.COL_RST_RCVD, '.$this->config->item('table_name').'.COL_RST_SENT, '.$this->config->item('table_name').'.COL_MODE, '.$this->config->item('table_name').'.COL_NAME, '.$this->config->item('table_name').'.COL_COUNTRY, '.$this->config->item('table_name').'.COL_PRIMARY_KEY, '.$this->config->item('table_name').'.COL_SAT_NAME, '.$this->config->item('table_name').'.COL_GRIDSQUARE, '.$this->config->item('table_name').'.COL_QSL_RCVD, '.$this->config->item('table_name').'.COL_EQSL_QSL_RCVD, '.$this->config->item('table_name').'.COL_EQSL_QSL_SENT, '.$this->config->item('table_name').'.COL_QSL_SENT, '.$this->config->item('table_name').'.COL_STX, '.$this->config->item('table_name').'.COL_STX_STRING, '.$this->config->item('table_name').'.COL_SRX, '.$this->config->item('table_name').'.COL_SRX_STRING, '.$this->config->item('table_name').'.COL_LOTW_QSL_SENT, '.$this->config->item('table_name').'.COL_LOTW_QSL_RCVD, '.$this->config->item('table_name').'.COL_VUCC_GRIDS, station_profile.*');
+    $table = $this->config->item('table_name');
+    $this->db->select("$table.COL_CALL, $table.COL_BAND, $table.COL_TIME_ON, $table.COL_RST_RCVD, $table.COL_RST_SENT, $table.COL_MODE, " .
+        "$table.COL_NAME, $table.COL_COUNTRY, $table.COL_PRIMARY_KEY, $table.COL_SAT_NAME, $table.COL_GRIDSQUARE, " .
+        "$table.COL_QSL_RCVD, $table.COL_EQSL_QSL_RCVD, $table.COL_EQSL_QSL_SENT, $table.COL_QSL_SENT, $table.COL_STX, " .
+        "$table.COL_STX_STRING, $table.COL_SRX, $table.COL_SRX_STRING, $table.COL_LOTW_QSL_SENT, $table.COL_LOTW_QSL_RCVD, " .
+        "$table.COL_VUCC_GRIDS, $table.COL_OPERATOR, station_profile.*");
     $this->db->from($this->config->item('table_name'));
 
     $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+    $this->db->where('station_profile.station_id',$station_id);
     $this->db->order_by(''.$this->config->item('table_name').'.COL_TIME_ON', "desc");
 
     $this->db->limit($num);

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -84,24 +84,34 @@ class Stations extends CI_Model {
 		$clean_new = $this->security->xss_clean($new);
 
         // Deselect current default
-		$current_default = array(
-				'station_active' => null,
-		);
-		$this->db->where('station_id', $clean_current);
-		$this->db->update('station_profile', $current_default);
-		
+		//$current_default = array(
+		//		'station_active' => null,
+		//);
+		//$this->db->where('station_id', $clean_current);
+		//$this->db->update('station_profile', $current_default);
+		//
 		// Deselect current default	
-		$newdefault = array(
-			'station_active' => 1,
+		//$newdefault = array(
+		//	'station_active' => 1,
+		//);
+		//$this->db->where('station_id', $clean_new);
+		//$this->db->update('station_profile', $newdefault);
+		$newstation = array(
+		    'user_station_id' => $clean_new,
 		);
-		$this->db->where('station_id', $clean_new);
-		$this->db->update('station_profile', $newdefault);
+		$this->db->where('user_id',$this->session->userdata('user_id'));
+		$this->db->update('users',$newstation);
+		$this->session->set_userdata('station_profile_id',$clean_new);
     }
 
     public function find_active() {
-        $this->db->where('station_active', 1);
-       	$query = $this->db->get('station_profile');
-        
+        //$this->db->where('station_active', 1);
+       	//$query = $this->db->get('station_profile');
+        $this->db->select('station_profile.*');
+        $this->db->from('users');
+        $this->db->join('station_profile','users.user_station_id = station_profile.station_id');
+        $this->db->where('users.user_id',$this->session->userdata('user_id'));
+        $query = $this->db->get();
         if($query->num_rows() >= 1) {
         	foreach ($query->result() as $row)
 			{

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -241,7 +241,8 @@ class User_Model extends CI_Model {
 			'user_eqsl_qth_nickname' => $u->row()->user_eqsl_qth_nickname,
 			'user_hash'		 => $this->_hash($u->row()->user_id."-".$u->row()->user_type),
 			'radio' => isset($_COOKIE["radio"])?$_COOKIE["radio"]:"",
-			'station_profile_id' => isset($_COOKIE["station_profile_id"])?$_COOKIE["station_profile_id"]:""
+			//'station_profile_id' => isset($_COOKIE["station_profile_id"])?$_COOKIE["station_profile_id"]:""
+		    'station_profile_id' => $u->row()->user_station_id
 		);
 
 		$this->session->set_userdata($userdata);

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -161,7 +161,7 @@
           <div class="tab-pane fade" id="station" role="tabpanel" aria-labelledby="station-tab">
             <div class="form-group">
               <label for="inputStationProfile">Station Profile</label>
-              <select id="stationProfile" class="custom-select" name="station_profile">
+              <select id="stationProfile" class="custom-select" name="station_profile" onchange="this.form.submit()">
                 <option value="0" selected="selected">None</option>
                 <?php foreach ($stations->result() as $stationrow) { ?>
                 <option value="<?php echo $stationrow->station_id; ?>" <?php if($this->session->userdata('station_profile_id') == $stationrow->station_id) { echo "selected=\"selected\""; } ?>><?php echo $stationrow->station_profile_name; ?></option>
@@ -321,7 +321,13 @@
     </div>
 
     <div class="card previous-qsos">
-      <div class="card-header"><h4 class="card-title">Previous Contacts</h4></div>
+      <div class="card-header"><h4 class="card-title">Previous Contacts
+      <?php { 
+          foreach ($active_station->result() as $row) {; 
+                echo " of station '" . $row->station_profile_name . "'";
+          }
+      }?>
+      </h4></div>
 
         <div id="partial_view">
 

--- a/application/views/station_profile/index.php
+++ b/application/views/station_profile/index.php
@@ -56,7 +56,7 @@
 					<td><?php echo $row->station_city;?></td>	
 					<td><?php echo $row->qso_total;?></td>
 					<td>
-						<?php if($row->station_active != 1) { ?>			
+						<?php if ($row->station_id != $current_active) { ?>			
 							<a href="<?php echo site_url('station/set_active/').$current_active."/".$row->station_id; ?>" class="btn btn-outline-secondary btn-sm" onclick="return confirm('Are you sure you want to make logbook <?php echo $row->station_profile_name; ?> the active logbook?');">Set Active</a>
 						<?php } else { ?>
 							<span class="badge badge-success">Active Logbook</span>

--- a/application/views/view_log/index.php
+++ b/application/views/view_log/index.php
@@ -2,7 +2,7 @@
 
 <div class="container logbook">
 
-	<h2>Logbook</h2>
+	<h2><?php echo $title?></h2>
 
 	<?php if($this->session->flashdata('notice')) { ?>
 	<div class="alert alert-info" role="alert">

--- a/application/views/view_log/partial/log.php
+++ b/application/views/view_log/partial/log.php
@@ -20,6 +20,7 @@
 			<td>LoTW</td>
 			<?php } ?>
 			<td>Station</td>
+			<td>Operator</td>
 			<td></td>
 			<?php } ?>
 		</tr>
@@ -83,7 +84,7 @@
 			    <?php } ?>
 			</td>
 			<?php } ?>
-
+			
 			<?php if($this->config->item('callsign_tags') == true) { ?>
 				<?php if(isset($row->station_callsign)) { ?>
 				<td>
@@ -91,7 +92,9 @@
 				</td>
 				<?php } ?>
 			<?php } ?>
-
+			<td>
+				<span class="badge badge-light"><?php echo $row->COL_OPERATOR; ?></span>
+			</td>
 			<td>
 				<div class="dropdown">
 				  <a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
Hi Peter,
first of all, many thanks for creating, maintaining and sharing CloudLog as an OpenSource-Project. We're currently evaluating it for our local radio club (DARC O54), and during the evaluation, we've noticed that it would be nice to add multi-client functionality. This would make it possible to provide a web-based logbook for our members, providing CloudLog as a kind of SaaS (or maybe better "LaaS", Logbook as a service).
So, I tried to make the necessary changes to make CloudLog able to handle connections from different users at the same time, who are working with the same profile (think of club stations) or with different station profiles.
I've tested it a bit, and as far as I can see it is working as expected:
- I've added a column "user_station_id" to the users table to store the active station id for this user which is updated when the user changes the station profile,
- I've changed the logbook views in Logbook and QSO to show only the QSOs of the active station,
- I've added an onchange event to the station option list in the QSO view which sets the new statio 
 id as active and reloads the page to show the last QSOs etc. for the new station,
- oh, and since I'm using Eclipse with the DBeaver-Plugin, I've added their special files etc. to .gitignore since I obviously don't want to check them in

If you like, please take a look at my changes, I'm looking forward to any feedback from your side.

Have a nice hackin' and vy 73 from Harald, DH9DAT