### PR TITLE
Added ESC-Key for resetting all QSO-Fields (quick-delete at qso-entry)

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -358,6 +358,13 @@ $(document).on('keypress',function(e) {
       reset_fields();
     }
   });
+  
+  $(document).keyup(function(e) {
+     if (e.key === "Escape") { // escape key maps to keycode `27`
+       reset_fields();
+	   $('#callsign').val("");
+    }
+});
 });
 
 


### PR DESCRIPTION
Enables ESC-Key in QSO-Window to reset all entered fields (including callsign) for quick delete after frequency change for example.