### PR TITLE
Increased size of fancybox for better readability

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -19,9 +19,11 @@ thead > tr > td {
 }
 
 .fancybox-content {
-    width  : 710px !important;
-    height : 310px !important;
     margin: 0;
+}
+
+.fancybox-iframe, .fancybox-video {
+    padding: 15px !important;
 }
 
 .dashboard {


### PR DESCRIPTION
The fancybox is really small especially on retina displays. This commit
increases the size of the fancybox to the maximum such that it is more
confortable to change the QSO or see the details.