### PR TITLE
Allow for spaces in eQSL QTH nicknames

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -143,7 +143,7 @@ class eqsl extends CI_Controller {
 			$eqsl_url .= "&Password=" . $data['user_eqsl_password'];
 			
 			$eqsl_url .= "&RcvdSince=" . $eqsl_last_qsl_date;
-			$eqsl_url .= "&QTHNickname=" . $active_station_info->eqslqthnickname;
+			$eqsl_url .= "&QTHNickname=" . urlencode($active_station_info->eqslqthnickname);
 			
 			// Pull back only confirmations
 			$eqsl_url .= "&ConfirmedOnly=1";


### PR DESCRIPTION
Fixes #404 

This made it work for me.