### PR TITLE
Fix HamQTH session expiry

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -124,6 +124,13 @@ class Logbook extends CI_Controller {
 		}
 
 		$callbook = $this->hamqth->search($callsign, $this->session->userdata('hamqth_session_key'));
+
+		// If HamQTH session has expired, start a new session and retry the search.
+		if($callbook['error'] == "Session does not exist or expired") {
+			$hamqth_session_key = $this->hamqth->session($this->config->item('hamqth_username'), $this->config->item('hamqth_password'));
+			$this->session->set_userdata('hamqth_session_key', $hamqth_session_key);
+			$callbook = $this->hamqth->search($callsign, $this->session->userdata('hamqth_session_key'));
+		}
 	}
 
 	if (isset($callbook))

--- a/application/libraries/Hamqth.php
+++ b/application/libraries/Hamqth.php
@@ -79,6 +79,7 @@ class Hamqth {
 		$data['lat'] = (string) $xml->search->latitude;
 		$data['long'] = (string) $xml->search->longitude;
 		$data['iota'] = (string) $xml->search->iota;
+		$data['error'] = (string) $xml->session->error;
 
 		return $data;
 	}


### PR DESCRIPTION
Noticed HamQTH callbook search stopped working after a while. Turns out the session expires after an hour.

https://www.hamqth.com/developers.php

Logbook controller:

- If HamQTH session has expired, start a new session and retry the search.

HamQTH library:

- Return error from HamQTH in search results