### PR TITLE
URL-Encoding fixed

### DIFF
--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -191,7 +191,7 @@ class DXCC extends CI_Model {
 			if ($postdata['worked'] != NULL) {
 				$workedDXCC = $this->getDxccBandWorked($station_id, $band, $postdata);
 				foreach ($workedDXCC as $wdxcc) {
-					$dxccMatrix[$wdxcc->dxcc][$band] = '<div class="alert-danger"><a href=\'dxcc_details?Country="'.$wdxcc->name.'"&Band="'. $band . '"\'>W</a></div>';;
+					$dxccMatrix[$wdxcc->dxcc][$band] = '<div class="alert-danger"><a href=\'dxcc_details?Country="'.str_replace("&", "%26", $wdxcc->name).'"&Band="'. $band . '"\'>W</a></div>';;
 				}
 			}
 
@@ -199,7 +199,7 @@ class DXCC extends CI_Model {
 			if ($postdata['confirmed'] != NULL) {
 				$confirmedDXCC = $this->getDxccBandConfirmed($station_id, $band, $postdata);
 				foreach ($confirmedDXCC as $cdxcc) {
-					$dxccMatrix[$cdxcc->dxcc][$band] = '<div class="alert-success"><a href=\'dxcc_details?Country="'.$cdxcc->name.'"&Band="'. $band . '"\'>C</a></div>';;
+					$dxccMatrix[$cdxcc->dxcc][$band] = '<div class="alert-success"><a href=\'dxcc_details?Country="'.str_replace("&", "%26", $cdxcc->name).'"&Band="'. $band . '"\'>C</a></div>';;
 				}
 			}
 		}


### PR DESCRIPTION
This fixes a problem with URL-Encoding of some entities with & in the name like Agalega & St Brandon Islands or similiar.
Problem was, that the & was misinterpreted within the browser-url and does not show the correct results.