### PR TITLE
Also show 6-digit grids worked and confirmed

### DIFF
--- a/application/config/cloudlog.php
+++ b/application/config/cloudlog.php
@@ -109,3 +109,18 @@ $config['callsign_tags'] = TRUE;
 */
 
 $config['qso_date_format'] = "d/m/y";
+
+/*
+|--------------------------------------------------------------------------
+| Show 6-digit Grid Squares on Maps
+|--------------------------------------------------------------------------
+|
+| Setting this to TRUE allows the map functions to also show worked and
+| confirmed 6-digit grid squares. As this may consume much memory with large
+| logs this is disabled by default. Use at your own risk.
+|
+| Default is: FALSE
+|
+*/
+
+$config['map_6digit_grids'] = FALSE;

--- a/application/controllers/Gridsquares.php
+++ b/application/controllers/Gridsquares.php
@@ -33,16 +33,20 @@ class Gridsquares extends CI_Controller {
 
 		$array_grid_2char = array();
 		$array_grid_4char = array();
+		$array_grid_6char = array();
 
 
 		$array_confirmed_grid_2char = array();
 		$array_confirmed_grid_4char = array();
+		$array_confirmed_grid_6char = array();
 
 		$grid_2char = "";
 		$grid_4char = "";
+		$grid_6char = "";
 
 		$grid_2char_confirmed = "";
 		$grid_4char_confirmed = "";
+		$grid_6char_confirmed = "";
 
 
 		// Get Confirmed LOTW & Paper Squares (non VUCC)
@@ -56,6 +60,9 @@ class Gridsquares extends CI_Controller {
 
 				$grid_2char_confirmed = strtoupper(substr($row->SAT_SQUARE,0,2));
 				$grid_4char_confirmed = strtoupper(substr($row->SAT_SQUARE,0,4));
+				if ($this->config->item('map_6digit_grids')) {
+					$grid_6char_confirmed = strtoupper(substr($row->SAT_SQUARE,0,6));
+				}
 
 				// Check if 2 Char is in array
 				if(!in_array($grid_2char_confirmed, $array_confirmed_grid_2char)){
@@ -65,6 +72,13 @@ class Gridsquares extends CI_Controller {
 
 				if(!in_array($grid_4char_confirmed, $array_confirmed_grid_4char)){
 					array_push($array_confirmed_grid_4char, $grid_4char_confirmed);	
+				}
+
+
+				if ($this->config->item('map_6digit_grids')) {
+					if(!in_array($grid_6char_confirmed, $array_confirmed_grid_6char)){
+						array_push($array_confirmed_grid_6char, $grid_6char_confirmed);	
+					}
 				}
 
 
@@ -81,6 +95,9 @@ class Gridsquares extends CI_Controller {
 
 				$grid_two = strtoupper(substr($row->SAT_SQUARE,0,2));
 				$grid_four = strtoupper(substr($row->SAT_SQUARE,0,4));
+				if ($this->config->item('map_6digit_grids')) {
+					$grid_six = strtoupper(substr($row->SAT_SQUARE,0,6));
+				}
 
 				// Check if 2 Char is in array
 				if(!in_array($grid_two, $array_grid_2char)){
@@ -90,6 +107,13 @@ class Gridsquares extends CI_Controller {
 
 				if(!in_array($grid_four, $array_grid_4char)){
 					array_push($array_grid_4char, $grid_four);	
+				}
+
+
+				if ($this->config->item('map_6digit_grids')) {
+					if(!in_array($grid_six, $array_grid_6char)){
+						array_push($array_grid_6char, $grid_six);	
+					}
 				}
 
 
@@ -106,7 +130,7 @@ class Gridsquares extends CI_Controller {
 				$grids = explode(",", $row->COL_VUCC_GRIDS);
 
 				foreach($grids as $key) {    
-				    $grid_two = strtoupper(substr($key,0,2));
+					$grid_two = strtoupper(substr($key,0,2));
 					$grid_four = strtoupper(substr($key,0,4));
 
 					// Check if 2 Char is in array
@@ -133,7 +157,7 @@ class Gridsquares extends CI_Controller {
 				$grids = explode(",", $row->COL_VUCC_GRIDS);
 
 				foreach($grids as $key) {    
-				    $grid_2char_confirmed = strtoupper(substr($key,0,2));
+					$grid_2char_confirmed = strtoupper(substr($key,0,2));
 					$grid_4char_confirmed = strtoupper(substr($key,0,4));
 
 					// Check if 2 Char is in array
@@ -164,10 +188,11 @@ class Gridsquares extends CI_Controller {
 
 		$data['grid_2char_confirmed'] = js_array($array_confirmed_grid_2char);
 		$data['grid_4char_confirmed'] = js_array($array_confirmed_grid_4char);
+		$data['grid_6char_confirmed'] = js_array($array_confirmed_grid_6char);
 
 		$data['grid_2char'] = js_array($array_grid_2char);
 		$data['grid_4char'] = js_array($array_grid_4char);
-
+		$data['grid_6char'] = js_array($array_grid_6char);
 
 
 		$this->load->view('interface_assets/header', $data);
@@ -184,15 +209,19 @@ class Gridsquares extends CI_Controller {
 
 		$array_grid_2char = array();
 		$array_grid_4char = array();
+		$array_grid_6char = array();
 
 		$array_grid_2char_confirmed = array();
 		$array_grid_4char_confirmed = array();
+		$array_grid_6char_confirmed = array();
 
 		$grid_2char = "";
 		$grid_4char = "";
+		$grid_6char = "";
 
 		$grid_2char_confirmed = "";
 		$grid_4char_confirmed = "";
+		$grid_6char_confirmed = "";
 
 		$query = $this->gridsquares_model->get_band_confirmed($band);
 
@@ -202,6 +231,9 @@ class Gridsquares extends CI_Controller {
 			{
 				$grid_2char_confirmed = strtoupper(substr($row->GRID_SQUARES,0,2));
 				$grid_4char_confirmed = strtoupper(substr($row->GRID_SQUARES,0,4));
+				if ($this->config->item('map_6digit_grids')) {
+					$grid_6char_confirmed = strtoupper(substr($row->GRID_SQUARES,0,6));
+				}
 
 				// Check if 2 Char is in array
 				if(!in_array($grid_2char_confirmed, $array_grid_2char_confirmed)){
@@ -210,6 +242,12 @@ class Gridsquares extends CI_Controller {
 
 				if(!in_array($grid_4char_confirmed, $array_grid_4char_confirmed)){
 					array_push($array_grid_4char_confirmed, $grid_4char_confirmed);	
+				}
+
+				if ($this->config->item('map_6digit_grids')) {
+					if(!in_array($grid_6char_confirmed, $array_grid_6char_confirmed)){
+						array_push($array_grid_6char_confirmed, $grid_6char_confirmed);	
+					}
 				}
 			}
 		}
@@ -223,6 +261,9 @@ class Gridsquares extends CI_Controller {
 
 				$grid_two = strtoupper(substr($row->GRID_SQUARES,0,2));
 				$grid_four = strtoupper(substr($row->GRID_SQUARES,0,4));
+				if ($this->config->item('map_6digit_grids')) {
+					$grid_six = strtoupper(substr($row->GRID_SQUARES,0,6));
+				}
 
 				// Check if 2 Char is in array
 				if(!in_array($grid_two, $array_grid_2char)){
@@ -232,6 +273,13 @@ class Gridsquares extends CI_Controller {
 
 				if(!in_array($grid_four, $array_grid_4char)){
 					array_push($array_grid_4char, $grid_four);	
+				}
+
+
+				if ($this->config->item('map_6digit_grids')) {
+					if(!in_array($grid_six, $array_grid_6char)){
+						array_push($array_grid_6char, $grid_six);	
+					}
 				}
 
 
@@ -251,9 +299,11 @@ class Gridsquares extends CI_Controller {
 
 		$data['grid_2char_confirmed'] = js_array($array_grid_2char_confirmed);
 		$data['grid_4char_confirmed'] = js_array($array_grid_4char_confirmed);
+		$data['grid_6char_confirmed'] = js_array($array_grid_6char_confirmed);
 
 		$data['grid_2char'] = js_array($array_grid_2char);
 		$data['grid_4char'] = js_array($array_grid_4char);
+		$data['grid_6char'] = js_array($array_grid_6char);
 
 		$data['bands_available'] = js_array($this->config->item('bands_available'));
 

--- a/application/models/Gridsquares_model.php
+++ b/application/models/Gridsquares_model.php
@@ -15,7 +15,7 @@ class Gridsquares_model extends CI_Model {
 
         $this->db->where("station_id", $station_id);
 
-        return $this->db->query('SELECT distinct substring(COL_GRIDSQUARE,1,4) as SAT_SQUARE, COL_SAT_NAME FROM '.$this->config->item('table_name').' WHERE station_id = "'.$station_id.'" AND COL_GRIDSQUARE != "" AND COL_SAT_NAME != ""');
+        return $this->db->query('SELECT distinct substring(COL_GRIDSQUARE,1,6) as SAT_SQUARE, COL_SAT_NAME FROM '.$this->config->item('table_name').' WHERE station_id = "'.$station_id.'" AND COL_GRIDSQUARE != "" AND COL_SAT_NAME != ""');
 	}
 
 
@@ -24,7 +24,7 @@ class Gridsquares_model extends CI_Model {
         $CI->load->model('Stations');
         $station_id = $CI->Stations->find_active();
 
-        return $this->db->query('SELECT distinct substring(COL_GRIDSQUARE,1,4) as SAT_SQUARE, COL_SAT_NAME FROM '.$this->config->item('table_name').' WHERE station_id = "'.$station_id.'" AND COL_GRIDSQUARE != "" AND COL_SAT_NAME != "" AND (COL_LOTW_QSL_RCVD = "Y" OR COL_QSL_RCVD = "Y")');
+        return $this->db->query('SELECT distinct substring(COL_GRIDSQUARE,1,6) as SAT_SQUARE, COL_SAT_NAME FROM '.$this->config->item('table_name').' WHERE station_id = "'.$station_id.'" AND COL_GRIDSQUARE != "" AND COL_SAT_NAME != "" AND (COL_LOTW_QSL_RCVD = "Y" OR COL_QSL_RCVD = "Y")');
     }
 
     function get_confirmed_sat_vucc_squares() {
@@ -51,7 +51,7 @@ class Gridsquares_model extends CI_Model {
         $CI =& get_instance();
         $CI->load->model('Stations');
         $station_id = $CI->Stations->find_active();
-        return $this->db->query('SELECT distinct substring(COL_GRIDSQUARE,1,4) as GRID_SQUARES, COL_BAND FROM '.$this->config->item('table_name').'
+        return $this->db->query('SELECT distinct substring(COL_GRIDSQUARE,1,6) as GRID_SQUARES, COL_BAND FROM '.$this->config->item('table_name').'
             WHERE station_id = "'.$station_id.'" AND COL_GRIDSQUARE != "" 
             AND COL_BAND = "'.$band.'"
             AND COL_PROP_MODE != "SAT"
@@ -67,7 +67,7 @@ class Gridsquares_model extends CI_Model {
         $CI->load->model('Stations');
         $station_id = $CI->Stations->find_active();
 
-        return $this->db->query('SELECT distinct substring(COL_GRIDSQUARE,1,4) as GRID_SQUARES, COL_BAND FROM '.$this->config->item('table_name').' WHERE station_id = "'.$station_id.'" AND COL_GRIDSQUARE != "" AND COL_BAND = "'.$band.'" 
+        return $this->db->query('SELECT distinct substring(COL_GRIDSQUARE,1,6) as GRID_SQUARES, COL_BAND FROM '.$this->config->item('table_name').' WHERE station_id = "'.$station_id.'" AND COL_GRIDSQUARE != "" AND COL_BAND = "'.$band.'" 
             AND COL_PROP_MODE != "SAT"
             AND COL_PROP_MODE != "INTERNET"
             AND COL_PROP_MODE != "ECH"

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -885,9 +885,11 @@ $(document).ready(function(){
   
   var grid_two = <?php echo $grid_2char; ?>;
   var grid_four = <?php echo $grid_4char; ?>;
+  var grid_six = <?php echo $grid_6char; ?>;
 
   var grid_two_confirmed = <?php echo $grid_2char_confirmed; ?>;
   var grid_four_confirmed = <?php echo $grid_4char_confirmed; ?>;
+  var grid_six_confirmed = <?php echo $grid_6char_confirmed; ?>;
 
   var maidenhead = L.maidenhead().addTo(map);
 

--- a/assets/js/leaflet/L.MaidenheadColoured.js
+++ b/assets/js/leaflet/L.MaidenheadColoured.js
@@ -58,9 +58,9 @@ L.Maidenhead = L.LayerGroup.extend({
 			for (var lat = bottom; lat < top; lat += unit) {
 			var bounds = [[lat,lon],[lat+unit,lon+(unit*2)]];
 	
-			if(grid_two.includes(this._getLocator(lon,lat)) || grid_four.includes(this._getLocator(lon,lat))) {
+			if(grid_two.includes(this._getLocator(lon,lat)) || grid_four.includes(this._getLocator(lon,lat)) || grid_six.includes(this._getLocator(lon,lat))) {
 
-				if(grid_two_confirmed.includes(this._getLocator(lon,lat)) || grid_four_confirmed.includes(this._getLocator(lon,lat))) {
+				if(grid_two_confirmed.includes(this._getLocator(lon,lat)) || grid_four_confirmed.includes(this._getLocator(lon,lat)) || grid_six_confirmed.includes(this._getLocator(lon,lat))) {
 					
 					this.addLayer(L.rectangle(bounds, {color: 'rgb(144,238,144)', weight: 1, fillOpacity: 0.6, fill:true, interactive: false}));
 				} else {


### PR DESCRIPTION
Added a config option that allows for 6-digit grids to be shown worked/confirmed on the maps for band and sat map functions. As this may consume much CPU power for the browser this is disabled by default.