### PR TITLE
Added option if you want to import missing QSOs. If yes, try to locat…

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -60,11 +60,21 @@ class Lotw extends CI_Controller {
 				}
 
 				$status = $this->logbook_model->import_check($time_on, $record['call'], $record['band']);
+				$skipNewQso = $this->input->post('importMissing'); // If import missing was checked
 
-				if($status == "No Match") {
-					// Create the Entry
-                    $station_id = $this->input->post('station_profile');
-					$this->logbook_model->import($record, $station_id, NULL, NULL, NULL);
+				if($status == "No Match" && $skipNewQso != NULL) {
+
+                    $station_id = $this->logbook_model->find_correct_station_id($record['station_callsign'], $record['my_gridsquare']);
+
+                    if ($station_id != NULL) {
+                        $result = $this->logbook_model->import($record, $station_id, NULL, NULL, NULL);  // Create the Entry
+                        if ($result == "") {
+                            $lotw_status = 'QSO imported';
+                        } else {
+                            $lotw_status = $result;
+                        }
+                    }
+
 				} else {
 					$lotw_status = $this->logbook_model->lotw_update($time_on, $record['call'], $record['band'], $qsl_date, $record['qsl_rcvd']);
 				}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1844,6 +1844,9 @@ class Logbook_model extends CI_Model {
       return 0;
     }
 
+    /*
+     * This function returns the the whole list of dxcc_entities used in various places
+     */
     function fetchDxcc() {
         $sql = "select adif, prefix, name, date(end) Enddate, date(start) Startdate from dxcc_entities";
 
@@ -1853,6 +1856,9 @@ class Logbook_model extends CI_Model {
         return $query->result();
     }
 
+    /*
+     * This function returns the whole list of iotas used in various places
+     */
     function fetchIota() {
         $sql = "select tag, name from iota";
 
@@ -1860,6 +1866,28 @@ class Logbook_model extends CI_Model {
         $query = $this->db->query($sql);
 
         return $query->result();
+    }
+
+    /*
+     * This function tries to locate the correct station_id used for importing QSOs from the downloaded LoTWreport
+     * $station_callsign is the call listed for the qso in lotwreport
+     * $my_gridsquare is the gridsquare listed for the qso in lotwreport
+     * Returns station_id if found
+     */
+    function find_correct_station_id($station_callsign, $my_gridsquare) {
+        $sql = 'select station_id from station_profile
+            where station_callsign = "' . $station_callsign . '" and station_gridsquare like "%' . substr($my_gridsquare,0, 4) . '%"';
+
+        $query = $this->db->query($sql);
+
+        $result = $query->row();
+
+        if ($result) {
+            return $result->station_id;
+        }
+        else {
+            return null;
+        }
     }
     
 }
@@ -1869,8 +1897,4 @@ function validateADIFDate($date, $format = 'Ymd')
   $d = DateTime::createFromFormat($format, $date);
   return $d && $d->format($format) == $date;
 }
-
-
-
-
 ?>

--- a/application/views/lotw/import.php
+++ b/application/views/lotw/import.php
@@ -36,6 +36,15 @@
               </div>
           </div>
       </div>
+      <br/>
+      <div class="form-group row">
+          <div class="col-md-10">
+              <div class="form-check-inline">
+                  <input class="form-check-input" type="checkbox" name="importMissing" value="1" id="importMissing">
+                  <label class="form-check-label" for="importMissing">Import missing QSOs into the log. Call and gridsquare will be checked to try to find the correct profile to import the QSO into. If not found, the QSO will be skipped.</label>
+              </div>
+          </div>
+      </div>
 
 		<p class="form-text text-muted">Cloudlog will use the LoTW username and password stored in your user profile to download a report from LoTW for you. The report Cloudlog downloads will have all confirmations since chosen date, or since your last LoTW confirmation (fetched from your log), up until now.</p>
 


### PR DESCRIPTION
…e station_id. If not found, do not import. Chose to use only 4 chars in gridsquare, and like in query, to have the highest success in finding a station_id, since 6 char gridsquares can be entered, as well as multiple gridsquares. Fixes #407.