### PR TITLE
reworked QSL-Indicators and print-functions 

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -425,8 +425,14 @@ class Logbook extends CI_Controller {
 						case "Y":
 							$html .= "green";
 							break;
+						case "Q":
+							$html .= "yellow";
+							break;
 						case "R":
 							$html .= "yellow";
+							break;
+						case "I":
+							echo "grey";
 							break;
 						default:
 						   $html .= "red";
@@ -437,8 +443,14 @@ class Logbook extends CI_Controller {
 						case "Y":
 							$html .= "green";
 							break;
+						case "Q":
+							$html .= "yellow";
+							break;
 						case "R":
 							$html .= "yellow";
+							break;
+						case "I":
+							echo "grey";
 							break;
 						default:
 						   $html .= "red";

--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -24,7 +24,7 @@ class adif_data extends CI_Model {
         $active_station_id = $this->stations->find_active();
 
         $this->db->where('station_id', $active_station_id);
-        $this->db->where('COL_QSL_SENT', 'R');
+        $this->db->where_in('COL_QSL_SENT', array('R', 'Q'));
         $this->db->order_by("COL_TIME_ON", "ASC"); 
         $query = $this->db->get($this->config->item('table_name'));
         

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -780,7 +780,7 @@ class Logbook_model extends CI_Model {
 								ENTITY 
 								FROM '.$this->config->item('table_name').', dxcc_prefixes, station_profile 
 								WHERE 
-								COL_QSL_SENT LIKE \'R\' 
+								COL_QSL_SENT in (\'R\', \'Q\')
 								and (CASE WHEN COL_QSL_VIA != \'\' THEN COL_QSL_VIA ELSE COL_CALL END) like CONCAT(dxcc_prefixes.call,\'%\') 
 								and (end is null or end > now()) 
 								and '.$this->config->item('table_name').'.station_id = '.$station_id.'

--- a/application/models/Qslprint_model.php
+++ b/application/models/Qslprint_model.php
@@ -18,7 +18,7 @@ class Qslprint_model extends CI_Model {
 	        'COL_QSL_SENT_VIA' => "B",
 		);
 
-		$this->db->where("COL_QSL_SENT", "R");
+		$this->db->where_in("COL_QSL_SENT", array("R","Q"));
 		$this->db->where("station_id", $station_id);
 		$this->db->update($this->config->item('table_name'), $data);
 	}

--- a/application/views/qslprint/index.php
+++ b/application/views/qslprint/index.php
@@ -16,7 +16,7 @@
 	  <div class="card-body">
 	    <h5 class="card-title"></h5>
 	    <p class="card-text">
-	    	Here you can export requested QSLs as CSV-file or ADIF and mark them as sent via buro in a mass transaction if you like. The considered QSOs for this functions would be those of the active station profile.
+	    	Here you can export requested QSLs as CSV-file or ADIF and mark them as sent via buro in a mass transaction if you like. Requested QSOs are QSOs marked as "Requested" or "Queued" in the QSL-sent-field. The considered QSOs for this functions would be those of the active station profile.
 	    </p>
 		
 		    

--- a/application/views/view_log/partial/log.php
+++ b/application/views/view_log/partial/log.php
@@ -49,6 +49,9 @@
 					case "Y":
 						echo "green";
 						break;
+					case "Q":
+						echo "yellow";
+						break;
 					case "R":
 						echo "yellow";
 						break;
@@ -63,6 +66,9 @@
 				switch ($row->COL_QSL_RCVD) {
 					case "Y":
 						echo "green";
+						break;
+					case "Q":
+						echo "yellow";
 						break;
 					case "R":
 						echo "yellow";


### PR DESCRIPTION
reworked QSL-Indicators and print-functions to not only use "R" but also
look for "Q" (Queued)... this is logically better if you initiate QSL-sending
by your own... R is for requested by other station to send...

Now we are back to ADIF-Specs-logic :-)