### PR TITLE
Add .htaccess sample file

### DIFF
--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -1,0 +1,8 @@
+# If you want to hide 'index.php' from the URL, rename this file to '.htaccess' on your server
+# Then change the following variable in /application/config/config.php
+#   $config['index_page'] = '';
+
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.*)$ /index.php?/$1 [L]


### PR DESCRIPTION
To make life easier for anyone else out there, who's like getting rid of the `index.php` in the URL (using Apache), I'd like to see adding this `.htaccess` sample file to the root dir of this project.

If you merge this into master I'll also add the following lines in [Cloudlog.php Configuration File](https://github.com/magicbug/Cloudlog/wiki/Cloudlog.php-Configuration-File) Wiki page.

## Remove `index.php` from your URL
To get rid of the `index.php` in your URL (using Apache with mod_rewrite) you can rename the example file `.htaccess.sample` to `.htaccess` in the root directory of your server.
Change 

| URL | Config | Example URL |
|-----|--------|----------|
| default | `$config['index_page'] = 'index.php';` | [https://cloudlog.example.com/index.php/logbook](#) |
| mod_rewrite | `$config['index_page'] = '';` | [https://cloudlog.example.com/logbook](#) |