### PR TITLE
Updating requested-counter to include queued QSLs also

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1156,14 +1156,14 @@ class Logbook_model extends CI_Model {
         }
     }
 
-    /* Return total number of QSL Cards requested */
+    /* Return total number of QSL Cards requested for printing - that means "requested" or "queued" */
     function total_qsl_requested() {
 
       $CI =& get_instance();
       $CI->load->model('Stations');
       $station_id = $CI->Stations->find_active();
 
-        $query = $this->db->query('SELECT DISTINCT (COL_QSL_SENT) AS band, count(COL_QSL_SENT) AS count FROM '.$this->config->item('table_name').' WHERE station_id = '.$station_id.' AND COL_QSL_SENT = "R" GROUP BY band');
+        $query = $this->db->query('SELECT DISTINCT (COL_QSL_SENT) AS band, count(COL_QSL_SENT) AS count FROM '.$this->config->item('table_name').' WHERE station_id = '.$station_id.' AND COL_QSL_SENT in ("Q", "R") GROUP BY band');
 
         $row = $query->row();
 


### PR DESCRIPTION
As if we extended the coloring of outgoing QSL cards to include queued cards also to get yellow and include them also to the list of "to be printed" cards, we have to count them also in the summary.