### PR TITLE
removed php-warnings on LoTW-Import...

### DIFF
--- a/application/views/lotw/analysis.php
+++ b/application/views/lotw/analysis.php
@@ -5,7 +5,7 @@
 if (isset ($lotw_table_headers)) {
 	echo $lotw_table_headers;
 } else {
-	echo 'No data imported. please check selected date. must be in the past!';
+	echo 'No data imported. please check selected date. Must be in the past!';
 }
 ?>
 <?php if (isset ($lotw_table)) {echo $lotw_table;} ?>

--- a/application/views/lotw/analysis.php
+++ b/application/views/lotw/analysis.php
@@ -1,7 +1,13 @@
 <div class="container">
 <h2><?php echo $page_title; ?></h2>
 
-<?php echo $lotw_table_headers; ?>
-<?php echo $lotw_table; ?>
+<?php 
+if (isset ($lotw_table_headers)) {
+	echo $lotw_table_headers;
+} else {
+	echo 'No data imported. please check selected date. must be in the past!';
+}
+?>
+<?php if (isset ($lotw_table)) {echo $lotw_table;} ?>
 
 </div>


### PR DESCRIPTION
If selected date is today or date in future, php notices appear and these iritates users. This patch removes the warnings on unset variables and puts out a clear message to check selected date.