### PR TITLE
Fixed QSO Tab Problems in Safari

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -208,3 +208,7 @@ background: -webkit-linear-gradient(to right, #2C5364, #203A43, #0F2027);  /* Ch
 background: linear-gradient(to right, #2C5364, #203A43, #0F2027); /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
 color: #ffffff;
 }
+
+#myTab .nav-link {
+    padding: 8px !important;
+}


### PR DESCRIPTION
In Safari on macOS the tabs are not shown corretly. This commit changes the
padding of the QSO-Tabs such that they are shown correctly in the Safari
browser.

Related discussion in the Forum
https://forum.cloudlog.co.uk/d/45-qso-panel-tabs-changing-text-to-icons/6