### PR TITLE
Normalise styles of admin pages

### DIFF
--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -139,7 +139,7 @@ class adif extends CI_Controller {
 	public function index() {
 		$this->load->model('stations');
 
-		$data['page_title'] = "ADIF Import";
+		$data['page_title'] = "ADIF Import / Export";
 		$data['max_upload'] = ini_get('upload_max_filesize');
 
 		$data['station_profile'] = $this->stations->all();

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -50,7 +50,7 @@ class API extends CI_Controller {
 
 		$data['api_keys'] = $this->api_model->keys();
 
-		$data['page_title'] = "API Options";
+		$data['page_title'] = "API";
 
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('api/help');

--- a/application/controllers/Qslprint.php
+++ b/application/controllers/Qslprint.php
@@ -16,7 +16,7 @@ class QSLPrint extends CI_Controller {
 		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
 	
-		$data['page_title'] = "Export requested QSLs for printing";
+		$data['page_title'] = "Print Requested QSLs";
 
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('qslprint/index');

--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -9,7 +9,7 @@
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
 		
 		// load the view
-		$data['page_title'] = "Radio Status";
+		$data['page_title'] = "Radio Interface";
 
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('radio/index');

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -10,7 +10,7 @@ class User extends CI_Controller {
 
 		$data['results'] = $this->user_model->users();
 
-		$data['page_title'] = "Users";
+		$data['page_title'] = "User Accounts";
 
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('user/main');

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -1,11 +1,11 @@
 
 <div class="container adif">
 
-	<h1>ADIF Functions</h1>
+	<h2><?php echo $page_title; ?></h2>
 
 	<div class="card">
 	  <div class="card-header">
-	    <h5 class="card-title"><?php echo $page_title; ?></h5>
+	    ADIF Import
 	  </div>
 
 	  <div class="card-body">
@@ -66,7 +66,7 @@
 
 <div class="card">
   <div class="card-header">
-    <h5 class="card-title">ADIF Export</h5>
+    ADIF Export
   </div>
 
 	<div class="alert alert-warning" role="alert">

--- a/application/views/api/help.php
+++ b/application/views/api/help.php
@@ -7,13 +7,16 @@
 </div>
 <?php } ?>
 
+<h2><?php echo $page_title; ?></h2>
+
 <div class="card">
   <div class="card-header">
-    <?php echo $page_title; ?>
+    API Keys
   </div>
   <div class="card-body">
-    <h5 class="card-title">API or Application Programming Interface lets third party systems access Cloudlog</h5>
-    <p class="card-text">You will need to generate API keys if you wish to use tools like CloudlogCAT.</p>
+	<p class="card-text">The Cloudlog API (Application Programming Interface) lets third party systems access Cloudlog in a controlled way. Access to the API is managed via API Keys.</p>
+	<p class="card-text">You will need to generate an API key for each tool you wish to use (e.g. CloudlogCAT). Generate a read-write key if the application needs to send data to Cloudlog. Generate a read-only key if the application only needs to obtain data from Cloudlog.</p>
+	<p class="card-text"><span class="badge badge-info">Info</span> It's good practice to delete a key if you are no longer using the associated application.</p>
 
 		<?php if ($api_keys->num_rows() > 0) { ?>
 

--- a/application/views/backup/adif_view.php
+++ b/application/views/backup/adif_view.php
@@ -1,17 +1,16 @@
 <div class="container">
-
-<h2>Backup - ADIF</h2>
+<h2><?php echo $page_title; ?></h2>
 
 
 <?php if($status == true) { ?>
 
-<p>Backing up your log has been completed successfully and can be found at <a href="<?php echo base_url(); ?>backup/logbook.adi"><?php echo base_url(); ?>backup/logbook.adi</a></a></p>
+<p>The backup of your log completed successfully. The output can be found at: <a href="<?php echo base_url(); ?>backup/logbook.adi"><?php echo base_url(); ?>backup/logbook.adi</a></a></p>
 
 <p>You could automate this process by making it a cronjob.</p>
 
 <?php } else { ?>
 
-<p>Something went wrong backing up check that the backup folder exists and has write permissions.</p>
+<p>Something went wrong during the backup process. Check that the backup folder exists and is writeable by your web server user / group.</p>
 
 <?php } ?>
 

--- a/application/views/backup/main.php
+++ b/application/views/backup/main.php
@@ -7,13 +7,16 @@
 		</div>
 	<?php } ?>
 
+<h2><?php echo $page_title; ?></h2>
+
 <div class="card">
   <div class="card-header">
     Backup
   </div>
   <div class="card-body">
-    <h5 class="card-title">You can export parts of Cloudlog like Notes</h5>
-    <p class="card-text">Backup options.</p>
+    <p class="card-text">Some of the data stored in Cloudlog can be exported so that you can keep a backup copy elsewhere.</p>
+    <p class="card-text">It's recommended to create backups on a regular basis to protect your data.</p>
+    <p class="card-text">Choose an option from the list below:</p>
 	<ul>
 		<li><a href="<?php echo site_url('backup/adif'); ?>">Backup ADIF</a></li>
 		<li><a href="<?php echo site_url('backup/notes'); ?>">Backup Notes</a></li>

--- a/application/views/backup/notes_view.php
+++ b/application/views/backup/notes_view.php
@@ -1,17 +1,16 @@
-
 <div class="container">
-<h2>Backup - Notes XML</h2>
+<h2><?php echo $page_title; ?></h2>
 
 
 <?php if($status == true) { ?>
 
-<p>Backing up your notes have been completed successfully and can be found at <a href="<?php echo base_url(); ?>backup/notes.xml"><?php echo base_url(); ?>backup/notes.xml</a></p>
+<p>The backup of your notes completed successfully. The output can be found at: <a href="<?php echo base_url(); ?>backup/notes.xml"><?php echo base_url(); ?>backup/notes.xml</a></p>
 
 <p>You could automate this process by making it a cronjob.</p>
 
 <?php } else { ?>
 
-<p>Something went wrong backing up check that the backup folder exists and has write permissions.</p>
+<p>Something went wrong during the backup process. Check that the backup folder exists and is writeable by your web server user / group.</p>
 
 <?php } ?>
 

--- a/application/views/eqsl/export.php
+++ b/application/views/eqsl/export.php
@@ -1,8 +1,9 @@
 
 <div class="container eqsl">
+<h2><?php echo $page_title; ?></h2>
 <div class="card">
   <div class="card-header">
-  	<h5 class="card-title"><?php echo $page_title; ?></h5>
+  	<div class="card-title">eQSL QSO Upload</div>
     <ul class="nav nav-tabs card-header-tabs">
       <li class="nav-item">
         <a class="nav-link" href="<?php echo site_url('eqsl/import');?>">Download QSOs</a>

--- a/application/views/eqsl/import.php
+++ b/application/views/eqsl/import.php
@@ -1,7 +1,8 @@
 <div class="container eqsl">
+<h2><?php echo $page_title; ?></h2>
 <div class="card">
   <div class="card-header">
-  	<h5 class="card-title"><?php echo $page_title; ?></h5>
+  	<div class="card-title">eQSL Import</div>
     <ul class="nav nav-tabs card-header-tabs">
       <li class="nav-item">
         <a class="nav-link active" href="<?php echo site_url('eqsl/import');?>">Download QSOs</a>

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -116,39 +116,39 @@
 				<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin</a>
 				
 				<div class="dropdown-menu" aria-labelledby="navbarDropdown">
-					<a class="dropdown-item" href="<?php echo site_url('user');?>" title="Accounts"><i class="fas fa-user"></i> Accounts</a>
+					<a class="dropdown-item" href="<?php echo site_url('user');?>" title="Manage user accounts"><i class="fas fa-user"></i> User Accounts</a>
 					
 					<div class="dropdown-divider"></div>
 					
-					<a class="dropdown-item" href="<?php echo site_url('api/help');?>" title="API Interface"><i class="fas fa-key"></i> API</a>
+					<a class="dropdown-item" href="<?php echo site_url('api/help');?>" title="Manage API keys"><i class="fas fa-key"></i> API</a>
 					
 					<div class="dropdown-divider"></div>					
 					
-					<a class="dropdown-item" href="<?php echo site_url('station');?>" title="Station Profiles"><i class="fas fa-home"></i> Station Profiles</a>
+					<a class="dropdown-item" href="<?php echo site_url('station');?>" title="Manage station profiles"><i class="fas fa-home"></i> Station Profiles</a>
 					
 					<div class="dropdown-divider"></div>
 					
-					<a class="dropdown-item" href="<?php echo site_url('mode');?>" title="QSO Modes"><i class="fas fa-broadcast-tower"></i> QSO Modes</a>
+					<a class="dropdown-item" href="<?php echo site_url('mode');?>" title="Manage QSO modes"><i class="fas fa-broadcast-tower"></i> Modes</a>
 					
 					<div class="dropdown-divider"></div>
 					
-					<a class="dropdown-item" href="<?php echo site_url('radio');?>" title="External Radios"><i class="fas fa-broadcast-tower"></i> Radio Interface</a>
+					<a class="dropdown-item" href="<?php echo site_url('radio');?>" title="Interface with one or more radios"><i class="fas fa-broadcast-tower"></i> Radio Interface</a>
 					
 					<div class="dropdown-divider"></div>	
 					
-					<a class="dropdown-item" href="<?php echo site_url('adif');?>" title="ADIF Import/Export"><i class="fas fa-sync"></i> ADIF Import/Export</a>
+					<a class="dropdown-item" href="<?php echo site_url('adif');?>" title="Amateur Data Interchange Format (ADIF) import / export"><i class="fas fa-sync"></i> ADIF Import / Export</a>
 					
 					<div class="dropdown-divider"></div>
 					
-					<a class="dropdown-item" href="<?php echo site_url('lotw');?>" title="LoTW Import"><i class="fas fa-sync"></i> Logbook of the World</a>
+					<a class="dropdown-item" href="<?php echo site_url('lotw');?>" title="Synchronise with Logbook of the World (LotW)"><i class="fas fa-sync"></i> Logbook of the World</a>
 					
 					<div class="dropdown-divider"></div>
 					
-					<a class="dropdown-item" href="<?php echo site_url('eqsl/import');?>" title="eQSL Import/Export"><i class="fas fa-sync"></i> eQSL</a>
+					<a class="dropdown-item" href="<?php echo site_url('eqsl/import');?>" title="eQSL import / export"><i class="fas fa-sync"></i> eQSL Import / Export</a>
 					
 					<div class="dropdown-divider"></div>
 
-                    <a class="dropdown-item" href="<?php echo site_url('qrz/export');?>" title="QRZ.com Export"><i class="fas fa-sync"></i> QRZ Logbook</a>
+                    <a class="dropdown-item" href="<?php echo site_url('qrz/export');?>" title="Upload to QRZ.com logbook"><i class="fas fa-sync"></i> QRZ Logbook</a>
 
                     <div class="dropdown-divider"></div>
 					
@@ -156,7 +156,7 @@
 
 					<div class="dropdown-divider"></div>
 					
-					<a class="dropdown-item" href="<?php echo site_url('backup');?>" title="Backup Cloudlog"><i class="fas fa-save"></i> Backup</a>
+					<a class="dropdown-item" href="<?php echo site_url('backup');?>" title="Backup Cloudlog content"><i class="fas fa-save"></i> Backup</a>
 
 					<div class="dropdown-divider"></div>
 					

--- a/application/views/lotw/import.php
+++ b/application/views/lotw/import.php
@@ -1,6 +1,6 @@
 <div class="container lotw">
 
-	<h1>LOTW Import</h1>
+  <h2><?php echo $page_title; ?></h2>
   
 <div class="card">
 	<div class="card-header">Import Options</div>

--- a/application/views/lotw_views/index.php
+++ b/application/views/lotw_views/index.php
@@ -1,6 +1,7 @@
 <div class="container lotw">
 <br>
-	<a class="btn btn-outline-primary btn-sm float-right" href="<?php echo site_url('/lotw/import'); ?>" role="button"><i class="fas fa-cloud-download-alt"></i> LoTW Import</a><h1><?php echo $page_title; ?></h1>
+	<a class="btn btn-outline-primary btn-sm float-right" href="<?php echo site_url('/lotw/import'); ?>" role="button"><i class="fas fa-cloud-download-alt"></i> LoTW Import</a>
+	<h2><?php echo $page_title; ?></h2>
 
 	<div class="alert alert-danger" role="alert">
 	  <i class="fas fa-exclamation-triangle"></i> Please be aware that LoTW Sync is BETA, you might get errors, this isn't fully production ready.

--- a/application/views/lotw_views/upload_cert.php
+++ b/application/views/lotw_views/upload_cert.php
@@ -1,6 +1,6 @@
 <div class="container lotw">
 
-	<h1><?php echo $page_title; ?></h1>
+	<h2><?php echo $page_title; ?></h2>
 
 	<!-- Card Starts -->
 	<div class="card">

--- a/application/views/mode/index.php
+++ b/application/views/mode/index.php
@@ -8,9 +8,11 @@
 		</div>
 	<?php } ?>
 
+<h2><?php echo $page_title; ?></h2>
+
 <div class="card">
   <div class="card-header">
-    <?php echo $page_title; ?>
+    Modes
   </div>
   <div class="card-body">
     <p class="card-text">This is the place you can customize your modes-list by activating/deactivating modes to be shown in the select-list.</p>

--- a/application/views/qrz/export.php
+++ b/application/views/qrz/export.php
@@ -1,19 +1,19 @@
 
 <div class="container adif">
 
-    <h1>QRZ Logbook</h1>
+    <h2><?php echo $page_title; ?></h2>
 
     <div class="card">
         <div class="card-header">
-            <h5 class="card-title">Upload Logbook</h5>
+            Upload Logbook
         </div>
 
         <div class="card-body">
 
-            <p>Here you can upload all QSOs to QRZ Logbook, which have not been previously uploaded. This might take a while, since only 1 QSO is uploaded at a time.</p>
+            <p>Here you can see and upload all QSOs which have not been previously uploaded to a QRZ logbook.</p>
+            <p>You need to set a QRZ Logbook API key in your station profile. Only station profiles with an API Key set are displayed.</p>
+            <p><span class="badge badge-warning">Warning</span>This might take a while as QSO uploads are processed sequentially.</p>
             
-            <p>You need to set a QRZ Logbook API Key in your station profile. Only a station profile with an API Key set, is diplayed in the table below.</p>
-
 <?php
             if ($station_profile->result()) {
             echo '

--- a/application/views/qslprint/index.php
+++ b/application/views/qslprint/index.php
@@ -13,7 +13,7 @@
 
 	<div class="card">
 	  <div class="card-header">
-	    Export Files
+	    Export Requested QSLs for Printing
 	  </div>
 	  <div class="card-body">
 	    <p class="card-text">Here you can export requested QSLs as CSV or ADIF files for printing and, optionally, mark them as sent via bureau.</p>

--- a/application/views/qslprint/index.php
+++ b/application/views/qslprint/index.php
@@ -9,16 +9,16 @@
 			</div>
 		<?php } ?>
 
+	<h2><?php echo $page_title; ?></h2>
+
 	<div class="card">
 	  <div class="card-header">
-	    <?php echo $page_title; ?>
+	    Export Files
 	  </div>
 	  <div class="card-body">
-	    <h5 class="card-title"></h5>
-	    <p class="card-text">
-	    	Here you can export requested QSLs as CSV-file or ADIF and mark them as sent via buro in a mass transaction if you like. Requested QSOs are QSOs marked as "Requested" or "Queued" in the QSL-sent-field. The considered QSOs for this functions would be those of the active station profile.
-	    </p>
-		
+	    <p class="card-text">Here you can export requested QSLs as CSV or ADIF files for printing and, optionally, mark them as sent via bureau.</p>
+	    <p class="card-text">Requested QSLs are any QSOs with a value of "Requested" or "Queued" in their "QSL Sent" field.</p>
+	    <p class="card-text">Only QSOs under the active station profile will be exported.</p>
 		    
     <a href="<?php echo site_url('qslprint/exportcsv'); ?>" title="Export CSV-file" target="_blank" class="btn btn-outline-secondary btn-sm">Export requested QSLs to CSV-file</a>
     

--- a/application/views/radio/index.php
+++ b/application/views/radio/index.php
@@ -9,16 +9,15 @@
 			</div>
 		<?php } ?>
 
+	<h2><?php echo $page_title; ?></h2>
+
 	<div class="card">
 	  <div class="card-header">
-	    <?php echo $page_title; ?>
+	    Active Radios
 	  </div>
 	  <div class="card-body">
-	    <h5 class="card-title"></h5>
-	    <p class="card-text">
-	    	These are active radios that are connected to Cloudlog via the API.
-	    </p>
-
+	    <p class="card-text">Below is a list of active radios that are connected to Cloudlog.</p>
+	    <p class="card-text">If you haven't connected any radios yet, see the API page to generate API keys.</p>
 	    <div class="table-responsive">
 		    <!-- Display Radio Statuses -->	  
 			<table class="table table-striped status"></table>

--- a/application/views/station_profile/index.php
+++ b/application/views/station_profile/index.php
@@ -8,13 +8,16 @@
 		</div>
 	<?php } ?>
 
+<h2><?php echo $page_title; ?></h2>
+
 <div class="card">
   <div class="card-header">
-    <?php echo $page_title; ?>
+    Station Profiles
   </div>
   <div class="card-body">
-    <p class="card-text">Station Profiles define locations of operating, useful for portable operating or using a friends QTH.</p>
-    <p class="card-text">Within Cloudlog these act in a similar way to logbooks, a Station Profile keeps a set of QSOs together.</p>
+    <p class="card-text">Station Profiles define operating locations, such as your QTH, a friend's QTH, or a portable station.</p>
+	<p class="card-text">Similar to logbooks, a Station Profile keeps a set of QSOs together.</p>
+	<p class="card-text">Only one logbook may be active at a time. In the table below this is shown with the "Active Logbook" badge.</p>
 
 		<?php if ($stations->num_rows() > 0) { ?>
 

--- a/application/views/update/index.php
+++ b/application/views/update/index.php
@@ -1,29 +1,36 @@
 <div class="container">
 	<h2><?php echo $page_title; ?></h2>
 
-	<?php if(!extension_loaded('xml')) { ?>
-
-	<div class="alert alert-danger" role="alert">
-	  You must install php-xml for this to work.
-	</div>
-
-	<?php } else { ?>
-
-		<input type="submit" id="btn_update_dxcc" value="Update Dxcc" />
-
-		<div id="dxcc_update_status">Status:</br></div>
+	<div class="card">
+		<div class="card-header">
+    		DXCC Lookup Data
+		 </div>
+		<div class="card-body">
+			<p class="card-text">Here you can update the DXCC lookup data that is used for displaying callsign information.</p>
+			<p class="card-text">This data is provided by <a href="https://clublog.org/">Clublog</a>.</p>
 			
-		<br/>
-		    
-		<a href="<?php echo site_url('update/check_missing_dxcc');?>">Check missing DXCC/Countries values</a>
-		<a href="<?php echo site_url('update/check_missing_dxcc/all');?>">[Re-Check ALL]</a>
+			<?php if(!extension_loaded('xml')) { ?>
+				<div class="alert alert-danger" role="alert">
+				You must install php-xml for this to work.
+				</div>
+			<?php } else { ?>
+				<input type="submit" id="btn_update_dxcc" value="Update Dxcc" />
 
-		<style>
-			#dxcc_update_status{
-			   display: None;
-			}
-		</style>
-	<?php } ?>
+				<div id="dxcc_update_status">Status:</br></div>
+					
+				<br/>
+					
+				<a href="<?php echo site_url('update/check_missing_dxcc');?>">Check missing DXCC/Countries values</a>
+				<a href="<?php echo site_url('update/check_missing_dxcc/all');?>">[Re-Check ALL]</a>
+
+				<style>
+					#dxcc_update_status{
+					display: None;
+					}
+				</style>
+			<?php } ?>
+		</div>
+	</div>
 </div>
 
 

--- a/application/views/user/main.php
+++ b/application/views/user/main.php
@@ -7,13 +7,16 @@
 	</div>
 <?php } ?>
 
+<h2><?php echo $page_title; ?></h2>
+
 <div class="card">
   <div class="card-header">
-    <?php echo $page_title; ?>
+    User List
   </div>
   <div class="card-body">
-    <h5 class="card-title">Cloudlog Needs Users You make them here.</h5>
-    <p class="card-text"></p>
+    <p class="card-text">Cloudlog needs at least one user configured in order to operate.</p>
+    <p class="card-text">Users can be assigned roles which give them different permissions, such as adding QSOs to the logbook and accessing Cloudlog APIs.</p>
+    <p class="card-text">The currently logged in user is displayed at the upper-right of each page.</p>
     <div class="table-responsive">
 		<table class="table table-striped">
 		  <thead>


### PR DESCRIPTION
Resolves #652 , at least for pages under the Admin menu drop-down. This PR uses the LotW page style (H2 headings, title taken from $data['page_title']) with non-bold card headings and plain card description text. I tweaked the card descriptions for certain pages. For the Updates page I added a card to wrap the content as there wasn't one already.