### PR TITLE
Use icon next to logged-in username

### DIFF
--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -196,7 +196,7 @@
 			<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fas fa-user"></i> <?php echo $this->session->userdata('user_callsign'); ?></a>
 			
 			<div class="dropdown-menu" aria-labelledby="navbarDropdown">
-				<a class="dropdown-item" href="<?php echo site_url('user/edit')."/".$this->session->userdata('user_id'); ?>" title="Profile"><i class="far fa-user"></i> Profile</a>
+				<a class="dropdown-item" href="<?php echo site_url('user/edit')."/".$this->session->userdata('user_id'); ?>" title="Account"><i class="fas fa-user"></i> Account</a>
 				
 				<div class="dropdown-divider"></div>
 				

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -193,7 +193,7 @@
         <ul class="navbar-nav">
         <!-- Logged in As -->
         <li class="nav-item dropdown">
-			<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Logged in as <?php echo $this->session->userdata('user_callsign'); ?></a>
+			<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fas fa-user"></i> <?php echo $this->session->userdata('user_callsign'); ?></a>
 			
 			<div class="dropdown-menu" aria-labelledby="navbarDropdown">
 				<a class="dropdown-item" href="<?php echo site_url('user/edit')."/".$this->session->userdata('user_id'); ?>" title="Profile"><i class="far fa-user"></i> Profile</a>


### PR DESCRIPTION
I noticed that on smaller screens (iPad, etc) the header bar gets a bit squashed. This PR doesn't fix that entirely but we can save a little space by using an icon instead of "Logged in as" text next to the callsign of the logged-in user. I think it gives a nice visual hint about where to find the profile settings.