### PR TITLE
adds qslcard dir to assets dir

### DIFF
--- a/assets/qslcard/index.html
+++ b/assets/qslcard/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>


### PR DESCRIPTION
This should fix #692

assets/qslcard is ignored by .gitignore, but if there is no folder PHP complains when accessing QSL view