### PR TITLE
Dark Themes CSS Tweaks

### DIFF
--- a/assets/css/cyborg/overrides.css
+++ b/assets/css/cyborg/overrides.css
@@ -2,6 +2,10 @@
  * No overrides for the default theme as it aligns with general.css
 */
 
+/*
+*	Dark Maps
+*/
+
 .leaflet-tile {
 	filter: invert() hue-rotate(180deg) grayscale(0.8) !important;
 }
@@ -23,4 +27,47 @@ path.grid-confirmed {
 path.grid-worked {
 	fill: rgba(220, 50, 50, 0.25) !important;
 	stroke: rgba(220, 50, 50, 0.25) !important;
+}
+
+#map, 
+#qsomap{
+	background-color: #000;
+}
+
+
+/* 
+*	Dark Navigation 
+*/
+
+/* Navigation background */
+.navbar.bg-light {
+    background-color: #000 !important;
+}
+
+/* Inactive Links */
+.navbar-light .navbar-nav .nav-link {
+    color: rgba(255,255,255,.6);
+}
+
+/* Active Links and Logo */
+.navbar-light .navbar-brand,
+.navbar-light .navbar-brand:focus,
+.navbar-light .navbar-brand:hover,
+.navbar-light .navbar-nav .active>.nav-link,
+.navbar-light .navbar-nav .nav-link:focus,
+.navbar-light .navbar-nav .nav-link:hover {
+    color: #fff;
+}
+
+/* 
+*	Dark inputs 
+*/
+
+.form-control, 
+.form-control:focus,
+.form-control:disabled,
+.custom-select {
+	background-color: #151515;
+	color: #eeeeee; 
+	border: 1px solid #333;
 }

--- a/assets/css/cyborg/overrides.css
+++ b/assets/css/cyborg/overrides.css
@@ -59,6 +59,11 @@ path.grid-worked {
     color: #fff;
 }
 
+/* Hamburger Menu */
+.navbar-light .navbar-toggler-icon {
+	background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.6%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e")
+}
+
 /* 
 *	Dark inputs 
 */

--- a/assets/css/darkly/overrides.css
+++ b/assets/css/darkly/overrides.css
@@ -2,6 +2,10 @@
  * No overrides for the default theme as it aligns with general.css
 */
 
+/*
+*	Dark Maps
+*/
+
 .leaflet-tile {
 	filter: invert() hue-rotate(180deg) grayscale(0.8) brightness(1.2) !important;
 }
@@ -23,4 +27,45 @@ path.grid-confirmed {
 path.grid-worked {
 	fill: rgba(220, 50, 50, 0.25) !important;
 	stroke: rgba(220, 50, 50, 0.25) !important;
+}
+
+#map, 
+#qsomap{
+	background-color: #222;
+}
+
+/* 
+*	Dark Navigation 
+*/
+
+/* Navigation background */
+.bg-light {
+    background-color: #303030!important;
+}
+
+/* Inactive Links */
+.navbar-light .navbar-nav .nav-link {
+    color: rgba(255,255,255,.6);
+}
+
+/* Active Links and Logo */
+.navbar-light .navbar-brand,
+.navbar-light .navbar-brand:focus,
+.navbar-light .navbar-brand:hover,
+.navbar-light .navbar-nav .active>.nav-link,
+.navbar-light .navbar-nav .nav-link:focus,
+.navbar-light .navbar-nav .nav-link:hover {
+    color: #fff;
+}
+
+/* 
+*	Dark inputs 
+*/
+
+.form-control,
+.form-control:focus,
+.form-control:disabled,
+.custom-select {
+	background-color: rgba(20,20,20,.5);
+	color: #eee; 
 }

--- a/assets/css/darkly/overrides.css
+++ b/assets/css/darkly/overrides.css
@@ -58,6 +58,11 @@ path.grid-worked {
     color: #fff;
 }
 
+/* Hamburger Menu */
+.navbar-light .navbar-toggler-icon {
+	background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.6%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e")
+}
+
 /* 
 *	Dark inputs 
 */

--- a/assets/css/superhero/overrides.css
+++ b/assets/css/superhero/overrides.css
@@ -66,6 +66,6 @@ path.grid-worked {
 .form-control:focus,
 .form-control:disabled,
 .custom-select {
-	background-color: rgba(20,20,20,.25);
+	background-color: rgba(20, 41, 62, 0.6);
 	color: #fff; 
 }

--- a/assets/css/superhero/overrides.css
+++ b/assets/css/superhero/overrides.css
@@ -2,6 +2,10 @@
  * No overrides for the default theme as it aligns with general.css
 */
 
+/*
+*	 Maps
+*/
+
 .leaflet-tile {
 	filter: brightness(0.7) grayscale(0.6) !important;
 }
@@ -24,3 +28,44 @@ path.grid-worked {
 	stroke: rgba(220, 50, 50, 0.4) !important;
 }
 
+#map, 
+#qsomap{
+	background-color: #2E3E50;
+}
+
+/* 
+*	Dark Navigation 
+*/
+
+/* Navigation background */
+.bg-light {
+    background-color: #4e5d6c !important;
+}
+
+/* Inactive Links */
+.navbar-light .navbar-nav .nav-link {
+    color: rgba(255,255,255,.6);
+}
+
+/* Active Links and Logo */
+.navbar-light .navbar-brand,
+.navbar-light .navbar-brand:focus,
+.navbar-light .navbar-brand:hover,
+.navbar-light .navbar-nav .active>.nav-link,
+.navbar-light .navbar-nav .nav-link:focus,
+.navbar-light .navbar-nav .nav-link:hover {
+    color: #fff;
+}
+
+
+/* 
+*	Dark inputs 
+*/
+
+.form-control,
+.form-control:focus,
+.form-control:disabled,
+.custom-select {
+	background-color: rgba(20,20,20,.25);
+	color: #fff; 
+}

--- a/assets/css/superhero/overrides.css
+++ b/assets/css/superhero/overrides.css
@@ -57,6 +57,10 @@ path.grid-worked {
     color: #fff;
 }
 
+/* Hamburger Menu */
+.navbar-light .navbar-toggler-icon {
+	background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.6%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e")
+}
 
 /* 
 *	Dark inputs 


### PR DESCRIPTION
Adjusted overrides to complete the dark themes. Now much easier on the eyes with dark inputs, navigation, and maps when loading. 

Now I can stay up even later on the radio 😉

### Darkly 
![image](https://user-images.githubusercontent.com/1933848/102970604-cfc56b80-44c5-11eb-9842-0be34fceaa71.png)

### Cyborg
![image](https://user-images.githubusercontent.com/1933848/102970617-d7851000-44c5-11eb-9821-05c075e8c87b.png)

### Superhero
![image](https://user-images.githubusercontent.com/1933848/102971272-15ceff00-44c7-11eb-81ca-f88d47e1a48d.png)
