### PR TITLE
Add editorconfig file for setting coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# Automatic editor configuration for the Cloudlog coding style.
+# See https://editorconfig.org/#download to check for support in your editor of
+# choice.
+
+# This is the root configuration file (there are no others in subdirectories).
+root = true
+
+# These global rules affect all files under the repository root.
+[*]
+charset = utf-8
+end_of_line = lf
+
+# These rules affect the listed file types only. Global rules still apply and
+# are overridden if the same key is assigned a different value here.
+[*.{php,js,html,xml,css}]
+indent_style = tab
+indent_size = 4
+
+# These rules are specifically for code
+[*.{php,js}]
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
While cleaning up my last PR I realised that I had to set some editor style settings. In previous projects I've used an editorconfig file to automate this.

Editorconfig is a standard that helps set editor settings automatically to support the project's coding style. It's not related to linting or auto-formatting directly, focusing instead on setting the style for newly-written or modified code.

Supported editors will pick up and apply these settings for the Cloudlog source directory, not interfering with other project folders or user settings in other locations.

This config specifies UTF-8 encoding and LF line-endings for all project files, tabbed indentation for source and data files and, finally, trailing newlines and whitespace trimming just for source files. These rules are based on what I saw in https://github.com/magicbug/Cloudlog/wiki/Development-Notes and from the dominant formatting options in the existing source files. All open to changes, of course, which is why this is a draft PR.

If an editor is set up to perform reformatting of code automatically (e.g. on save or on paste) then these rules will influence that behaviour, but applying them won't cause an editor to reformat existing code en-masse.