### PR TITLE
Minor dark fixes

### DIFF
--- a/assets/css/cyborg/overrides.css
+++ b/assets/css/cyborg/overrides.css
@@ -69,6 +69,7 @@ path.grid-worked {
 */
 
 .form-control, 
+.form-control-sm,
 .form-control:focus,
 .form-control:disabled,
 .custom-select {

--- a/assets/css/darkly/overrides.css
+++ b/assets/css/darkly/overrides.css
@@ -68,9 +68,15 @@ path.grid-worked {
 */
 
 .form-control,
+.form-control-sm,
 .form-control:focus,
 .form-control:disabled,
 .custom-select {
 	background-color: rgba(20,20,20,.5);
 	color: #eee; 
+}
+
+select optgroup,
+select option {
+	background-color: #222;
 }

--- a/assets/css/superhero/overrides.css
+++ b/assets/css/superhero/overrides.css
@@ -67,6 +67,7 @@ path.grid-worked {
 */
 
 .form-control,
+.form-control-sm,
 .form-control:focus,
 .form-control:disabled,
 .custom-select {


### PR DESCRIPTION
Fixes the contest dropdown and Darkly dropdown background. The other themes style the dropdown background properly by default.

![image](https://user-images.githubusercontent.com/1933848/103029312-86a60380-4527-11eb-9456-1b979c050c85.png)
