### PR TITLE
[WIP] Add support for translations

### DIFF
--- a/application/config/autoload.php
+++ b/application/config/autoload.php
@@ -110,6 +110,7 @@ $autoload['language'] = array(
     'pagination',
     'upload',
     'qso',
+    'notes',
     'station'
     );
 

--- a/application/config/autoload.php
+++ b/application/config/autoload.php
@@ -109,6 +109,8 @@ $autoload['language'] = array(
     'number',
     'pagination',
     'upload',
+    'qso',
+    'station'
     );
 
 

--- a/application/config/autoload.php
+++ b/application/config/autoload.php
@@ -64,7 +64,7 @@ $autoload['libraries'] = array('database', 'session', 'curl', 'OptionsLib');
 |	$autoload['helper'] = array('url', 'file');
 */
 
-$autoload['helper'] = array('url', 'security');
+$autoload['helper'] = array('url', 'security', 'language');
 
 
 /*

--- a/application/config/autoload.php
+++ b/application/config/autoload.php
@@ -96,7 +96,20 @@ $autoload['config'] = array('cloudlog', 'bands', 'lotw');
 |
 */
 
-$autoload['language'] = array('general_words');
+$autoload['language'] = array(
+    'general_words',
+    'calendar',
+    'date',
+    'db',
+    'email',
+    'form_validation',
+    'ftp',
+    'imglib',
+    'migration',
+    'number',
+    'pagination',
+    'upload',
+    );
 
 
 /*

--- a/application/language/english/general_words_lang.php
+++ b/application/language/english/general_words_lang.php
@@ -37,3 +37,8 @@ $lang['dashboard_you_have_had'] = 'You have had';
 $lang['dashboard_qsos_today'] = 'QSOs Today!';
 $lang['dashboard_qso_breakdown'] = 'QSOs Breakdown';
 $lang['dashboard_countries_breakdown'] = 'Countries Breakdown';
+
+//Other
+$lang['general_yes'] = 'Yes';
+$lang['general_no'] = 'No';
+$lang['general_info'] = 'Info';

--- a/application/language/english/notes_lang.php
+++ b/application/language/english/notes_lang.php
@@ -1,0 +1,26 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['notes'] = 'Notes';
+$lang['notes_note'] = 'Note';
+$lang['notes_create'] = 'Create Note';
+$lang['notes_heading'] = 'Your Notes';
+$lang['notes_none_yet'] = <<<EOD
+You don't currently have any notes, these are a fantastic way of storing data
+like ATU settings, beacons and general station notes and its better than paper
+as you can't lose them!
+EOD;
+$lang['notes_info_message'] = <<<EOD
+Note content is used within Cloudlog only and is not exported to other
+services.
+EOD;
+$lang['notes_title'] = 'Title';
+$lang['notes_category'] = 'Category';
+$lang['notes_category_general'] = 'General';
+$lang['notes_category_antennas'] = 'Antennas';
+$lang['notes_category_satellites'] = 'Satellites';
+$lang['notes_content'] = 'Note Contents';
+$lang['notes_save'] = 'Save Note';
+$lang['notes_edit'] = 'Edit Note';
+$lang['notes_delete'] = 'Delete Note';

--- a/application/language/english/qso_lang.php
+++ b/application/language/english/qso_lang.php
@@ -1,0 +1,79 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['qso'] = 'QSO';
+$lang['qso_live'] = 'Live QSO';
+$lang['qso_post'] = 'Post QSO';
+//Signal report
+
+$lang['qso_rst_sent'] = 'RST (S)';
+$lang['qso_rst_recv'] = 'RST (R)';
+$lang['qso_name'] = 'Name';
+$lang['qso_location'] = 'Location';
+$lang['qso_locator'] = 'Locator';
+$lang['qso_comment'] = 'Comment';
+
+//Station panel
+
+$lang['qso_inputStationProfile'] = 'Station Profile';
+$lang['qso_inputRadio'] = 'Radio';
+$lang['qso_frequency'] = 'Frequency';
+$lang['qso_frequencyRx'] = 'Frequency (RX)';
+$lang['qso_rxBand'] = 'Band';
+$lang['qso_microwave'] = 'Microwave';
+$lang['qso_transmitPower'] = 'Transmit Power (W)';
+$lang['qso_powerHelp'] = 'Give power value in Watts. Include only numbers in the input.';
+
+//General Items
+$lang['qso_general'] = 'General';
+$lang['qso_dxcc'] = 'DXCC';
+$lang['qso_cqz'] = 'CQ Zone';
+$lang['qso_propagationMode'] = 'Propagation Mode';
+$lang['qso_prop_AUR'] = 'Aurora';
+$lang['qso_prop_AUE'] = 'Aurora-E';
+$lang['qso_prop_BS'] = 'Back scatter';
+$lang['qso_prop_ECH'] = 'EchoLink<';
+$lang['qso_prop_EME'] = 'Earth-Moon-Earth';
+$lang['qso_prop_ES'] = 'Sporadic E';
+$lang['qso_prop_FAI'] = 'Field Aligned Irregularities';
+$lang['qso_prop_F2'] = 'F2 Reflection';
+$lang['qso_prop_INTERNET'] = 'Internet-assisted';
+$lang['qso_prop_ION'] = 'Ionoscatter';
+$lang['qso_prop_IRL'] = 'IRLP';
+$lang['qso_prop_MS'] = 'Meteor scatter';
+$lang['qso_prop_RPT'] = 'Terrestrial or atmospheric repeater or transponder';
+$lang['qso_prop_RS'] = 'Rain scatter';
+$lang['qso_prop_SAT'] = 'Satellite';
+$lang['qso_prop_TEP'] = 'Trans-equatorial';
+$lang['qso_prop_TR'] = 'Tropospheric ducting';
+
+$lang['qso_iota_ref'] = 'IOTA Reference';
+$lang['qso_sota_ref'] = 'SOTA Reference';
+$lang['qso_sota_help'] = 'For example: GM/NS-001';
+$lang['qso_sig'] = 'Sig';
+$lang['qso_sig_help'] = 'For example: WWFF or POTA';
+$lang['qso_sig_info'] = 'Sig Info';
+$lang['qso_sig_info_help'] = 'For example: DLFF-0029';
+$lang['qso_darc_dok'] = 'DOK';
+$lang['qso_dok_help'] = 'For example: Q03';
+
+//Satellite Panel
+
+$lang['qso_sat'] = 'Satellite';
+$lang['qso_sat_name'] = 'Satellite Name';
+$lang['qso_sat_mode'] = 'Satellite Mode';
+$lang['qso_qsl'] = 'QSL';
+$lang['qso_qsl_method'] = 'Method';
+$lang['qso_qsl_direct'] = 'Direct';
+$lang['qso_qsl_bureau'] = 'Bureau';
+$lang['qso_qsl_via'] = 'Via';
+
+//Buttons
+
+$lang['qso_reset_button'] = 'Reset';
+$lang['qso_save_button'] = 'Save';
+
+$lang['qso_map'] = 'QSO Map';
+$lang['qso_suggestions'] = 'Suggestions';
+$lang['qso_prev_contacts'] = 'Previous Contacts';

--- a/application/language/english/station_lang.php
+++ b/application/language/english/station_lang.php
@@ -1,0 +1,5 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['station'] = 'Station';

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -61,11 +61,17 @@
         <?php if(($this->config->item('use_auth')) && ($this->session->userdata('user_type') >= 2)) { ?>
         	<!-- QSO Menu Dropdown -->
         	<li class="nav-item dropdown">
-						<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">QSO</a>
+						<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                                    <?php echo lang('qso'); ?>
+                                                </a>
 						<div class="dropdown-menu" aria-labelledby="navbarDropdown">
-							<a class="dropdown-item" href="<?php echo site_url('qso?manual=0');?>" title="Log Live QSOs">Live QSO</a>
+							<a class="dropdown-item" href="<?php echo site_url('qso?manual=0');?>" title="Log Live QSOs">
+                                                            <?php echo lang('qso_live'); ?>
+                                                        </a>
 							<div class="dropdown-divider"></div>
-							<a class="dropdown-item" href="<?php echo site_url('qso?manual=1');?>" title="Log QSO made in the past">Post QSO</a>
+							<a class="dropdown-item" href="<?php echo site_url('qso?manual=1');?>" title="Log QSO made in the past">
+                                                            <?php echo lang('qso_post'); ?>
+                                                        </a>
                             <div class="dropdown-divider"></div>
                             <a class="dropdown-item" href="<?php echo site_url('contesting');?>" title="Log contest QSOs">Contest Logging</a>
                             <div class="dropdown-divider"></div>

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -80,7 +80,9 @@
         	</li>
 
         	<!-- Notes -->
-        	<a class="nav-link" href="<?php echo site_url('notes');?>">Notes</a>
+		<a class="nav-link" href="<?php echo site_url('notes');?>">
+                    <?php echo lang('notes'); ?>
+                </a>
  
         	<li class="nav-item dropdown">
 				<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Analytics</a>

--- a/application/views/notes/add.php
+++ b/application/views/notes/add.php
@@ -3,15 +3,19 @@
 
 <div class="card">
   <div class="card-header">
-    <h2 class="card-title">Create Note</h2>
+  <h2 class="card-title"><?php echo lang('notes_create'); ?></h2>
     <ul class="nav nav-tabs card-header-tabs">
 	    <li class="nav-item">
-	    	<a class="nav-link" href="<?php echo site_url('notes'); ?>">Notes</a>
+		<a class="nav-link" href="<?php echo site_url('notes'); ?>">
+                    <?php echo lang('notes'); ?>
+                </a>
 	    </li>
 	    <li class="nav-item">
-	    	<a class="nav-link active" href="<?php echo site_url('notes/add'); ?>">Create Note</a>
+		<a class="nav-link active" href="<?php echo site_url('notes/add'); ?>">
+                    <?php echo lang('notes_create'); ?>
+                </a>
 	    </li>
-	</ul>
+    </ul>
   </div>
 
   <div class="card-body">
@@ -26,26 +30,26 @@
     <form method="post" action="<?php echo site_url('notes/add'); ?>" name="notes_add" id="notes_add">
 
 	<div class="form-group">
-		<label for="inputTitle">Title</label>
+	<label for="inputTitle"><?php echo lang('notes_title'); ?></label>
 		<input type="text" name="title" class="form-control" id="inputTitle">
 	</div>
 
 	<div class="form-group">
-	   <label for="catSelect">Category</label>
+	<label for="catSelect"><?php echo lang('notes_category'); ?></label>
 	   <select name="category" class="form-control" id="catSelect">
-	   	<option value="General" selected="selected">General</option>
-		<option value="Antennas">Antennas</option>
-		<option value="Satellites">Satellites</option>
+	   <option value="General" selected="selected"><?php echo lang('notes_category_general'); ?></option>
+	   <option value="General"><?php echo lang('notes_category_antennas'); ?></option>
+	   <option value="General"><?php echo lang('notes_category_satellites'); ?></option>
 	   </select>
 	</div>
 
 	<div class="form-group">
-		<label for="inputTitle">Note Contents</label>
+	<label for="inputTitle"><?php echo lang('notes_content'); ?></label>
 		<div id="quillArea"></div>
 		<textarea name="content" style="display:none" id="hiddenArea"></textarea>
 	</div>
 
-	<button type="submit" value="Submit" class="btn btn-primary">Save Note</button>
+	<button type="submit" value="Submit" class="btn btn-primary"><?php echo lang('notes_save'); ?></button>
 	</form>
   </div>
 </div>

--- a/application/views/notes/edit.php
+++ b/application/views/notes/edit.php
@@ -4,15 +4,19 @@
 <?php foreach ($note->result() as $row) { ?>
 <div class="card">
   <div class="card-header">
-    <h2 class="card-title">Edit Note</h2>
-	<ul class="nav nav-tabs card-header-tabs">
-	    <li class="nav-item">
-	    	<a class="nav-link" href="<?php echo site_url('notes'); ?>">Notes</a>
-	    </li>
-	    <li class="nav-item">
-	    	<a class="nav-link" href="<?php echo site_url('notes/add'); ?>">Create Note</a>
-	    </li>
-	</ul>
+  <h2 class="card-title"><?php echo lang('notes_edit'); ?></h2>
+        <ul class="nav nav-tabs card-header-tabs">
+            <li class="nav-item">
+            	<a class="nav-link" href="<?php echo site_url('notes'); ?>">
+                        <?php echo lang('notes'); ?>
+                    </a>
+            </li>
+            <li class="nav-item">
+            	<a class="nav-link active" href="<?php echo site_url('notes/add'); ?>">
+                    <?php echo lang('notes_create'); ?>
+                </a>
+            </li>
+        </ul>
   </div>
 
   <div class="card-body">
@@ -27,27 +31,27 @@
 	<form method="post" action="<?php echo site_url('notes/edit'); ?>/<?php echo $id; ?>" name="notes_add" id="notes_add">
 
 	<div class="form-group">
-		<label for="inputTitle">Title</label>
+	<label for="inputTitle"><?php echo lang('notes_title'); ?></label>
 		<input type="text" name="title" class="form-control" value="<?php echo $row->title; ?>" id="inputTitle">
 	</div>
 
 	<div class="form-group">
-	   <label for="catSelect">Category</label>
-	   <select name="category" class="form-control" id="catSelect">
-	   	<option value="General" selected="selected">General</option>
-		<option value="Antennas">Antennas</option>
-		<option value="Satellites">Satellites</option>
-	   </select>
+	    <label for="catSelect"><?php echo lang('notes_category'); ?></label>
+	       <select name="category" class="form-control" id="catSelect">
+	           <option value="General" selected="selected"><?php echo lang('notes_category_general'); ?></option>
+	           <option value="General"><?php echo lang('notes_category_antennas'); ?></option>
+	           <option value="General"><?php echo lang('notes_category_satellites'); ?></option>
+	        </select>
 	</div>
 
 	<div class="form-group">
-		<label for="inputTitle">Note Contents</label>
+	<label for="inputTitle"><?php echo lang('notes_content'); ?></label>
 		<div id="quillArea"><?php echo $row->note; ?></div>
 		<textarea name="content" style="display:none" id="hiddenArea"></textarea>
 	</div>
 
 	<input type="hidden" name="id" value="<?php echo $id; ?>" />
-	<button type="submit" value="Submit" class="btn btn-primary">Save Note</button>
+	<button type="submit" value="Submit" class="btn btn-primary"><?php echo lang('notes_save'); ?></button>
 	</form>
   </div>
 

--- a/application/views/notes/main.php
+++ b/application/views/notes/main.php
@@ -2,13 +2,13 @@
 
 	<div class="card">
 	  <div class="card-header">
-	  	<h2 class="card-title">Notes</h2>
+	        <h2 class="card-title"><?php echo lang('notes_heading'); ?></h2>
 	    <ul class="nav nav-tabs card-header-tabs">
 	      <li class="nav-item">
-	        <a class="nav-link active" href="<?php echo site_url('notes'); ?>">Notes</a>
+	        <a class="nav-link active" href="<?php echo site_url('notes'); ?>"><?php echo lang('notes'); ?></a>
 	      </li>
 	      <li class="nav-item">
-	        <a class="nav-link" href="<?php echo site_url('notes/add'); ?>">Create Note</a>
+	        <a class="nav-link" href="<?php echo site_url('notes/add'); ?>"><?php echo lang('notes_create'); ?></a>
 	      </li>
 	    </ul>
 	  </div>
@@ -19,7 +19,7 @@
 
 				if ($notes->num_rows() > 0)
 				{
-					echo "<h3>Your Notes</h3>";
+					echo "<h3>" . lang('notes_yours') ."</h3>";
 					echo "<ul class=\"list-group\">";
 					foreach ($notes->result() as $row)
 					{
@@ -29,9 +29,8 @@
 					}
 					echo "</ul>";
 				} else {
-					echo "<p>You don't currently have any notes, these are a fantastic way of storing data like ATU settings, beacons and general station notes and its better than paper as you can't lose them!</p>";
+					echo "<p>" . lang('notes_none_yet') . "</p>";
 				}
-
 			?>
 	  </div>
 	</div>

--- a/application/views/notes/view.php
+++ b/application/views/notes/view.php
@@ -2,23 +2,31 @@
 
 	<div class="card">
 	<?php foreach ($note->result() as $row) { ?>
-		<div class="card-header">
-    		<h2 class="card-title">Note - <?php echo $row->title; ?></h2>
-    			<ul class="nav nav-tabs card-header-tabs">
-	    <li class="nav-item">
-	    	<a class="nav-link" href="<?php echo site_url('notes'); ?>">Notes</a>
-	    </li>
-	    <li class="nav-item">
-	    	<a class="nav-link" href="<?php echo site_url('notes/add'); ?>">Create Note</a>
-	    </li>
-	</ul>
-		</div>
+            <div class="card-header">
+		<h2 class="card-title"><?php echo lang('notes_note'); ?> - <?php echo $row->title; ?></h2>
+                <ul class="nav nav-tabs card-header-tabs">
+                    <li class="nav-item">
+                    	<a class="nav-link" href="<?php echo site_url('notes'); ?>">
+                                <?php echo lang('notes'); ?>
+                            </a>
+                    </li>
+                    <li class="nav-item">
+                    	<a class="nav-link active" href="<?php echo site_url('notes/add'); ?>">
+                            <?php echo lang('notes_create'); ?>
+                        </a>
+                    </li>
+                </ul>
+          </div>
 	  <div class="card-body">
 	    <p class="card-text"><?php echo nl2br($row->note); ?></p>
 
-	    <a href="<?php echo site_url('notes/edit'); ?>/<?php echo $row->id; ?>" class="btn btn-primary"><i class="fas fa-edit"></i> Edit Note</a>
+	    <a href="<?php echo site_url('notes/edit'); ?>/<?php echo $row->id; ?>" class="btn btn-primary">
+	        <i class="fas fa-edit"></i> <?php echo lang('notes_edit'); ?>
+            </a>
 
-	    <a href="<?php echo site_url('notes/delete'); ?>/<?php echo $row->id; ?>" class="btn btn-danger"><i class="fas fa-trash-alt"></i> Delete Note</a>
+	    <a href="<?php echo site_url('notes/delete'); ?>/<?php echo $row->id; ?>" class="btn btn-danger">
+	        <i class="fas fa-trash-alt"></i> <?php echo lang('notes_delete'); ?>
+            </a>
 	    <?php } ?>
 	  </div
 >	</div>

--- a/application/views/qso/edit.php
+++ b/application/views/qso/edit.php
@@ -52,23 +52,24 @@
 			<div class="tab-pane fade show active" id="nav-qso" role="tabpanel" aria-labelledby="nav-qso-tab">
                 <div class="form-row">
                     <div class="form-group col-sm-6">
-                      <label for="start_date">Start Date/Time</label>
+                      <?php echo lang('general_word_date', 'start_date'); ?>
                       <input type="text" class="form-control form-control-sm input_date" name="time_on" id="time_on" value="<?php echo $qso->COL_TIME_ON; ?>">
                     </div>
 
                     <div class="form-group col-sm-6">
-                      <label for="start_time">End Date/Time</label>
+                      <?php echo lang('general_word_time', 'start_time'); ?>
                       <input type="text" class="form-control form-control-sm input_time" name="time_off" id="time_off" value="<?php echo $qso->COL_TIME_OFF; ?>">
                     </div>
                 </div>
 
 	            <div class="form-group">
-	            	<label for="callsign">Callsign</label>
+                        <?php echo lang('gen_hamradio_callsign', 'callsign'); ?>
 	                <input type="text" class="form-control" id="callsign" name="callsign" value="<?php echo $qso->COL_CALL; ?>">
 	            </div>
 
 	            
 	            <div class="form-group">
+                        <?php echo lang('gen_hamradio_callsign', 'callsign'); ?>
 	            	<label for="freq">Frequency</label>
 	                <input type="text" class="form-control" id="freq" name="freq" value="<?php echo $qso->COL_FREQ; ?>">
 	            </div>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -10,27 +10,39 @@
       <div class="card-header"> 
         <ul style="font-size: 15px;" class="nav nav-tabs card-header-tabs pull-right"  id="myTab" role="tablist">
           <li class="nav-item">
-           <a class="nav-link active" id="qsp-tab" data-toggle="tab" href="#qso" role="tab" aria-controls="qso" aria-selected="true">QSO</a>
+           <a class="nav-link active" id="qsp-tab" data-toggle="tab" href="#qso" role="tab" aria-controls="qso" aria-selected="true">
+             <?php echo lang('qso'); ?>
+            </a>
           </li>
 
           <li class="nav-item">
-            <a class="nav-link" id="station-tab" data-toggle="tab" href="#station" role="tab" aria-controls="station" aria-selected="false">Station</a>
+            <a class="nav-link" id="station-tab" data-toggle="tab" href="#station" role="tab" aria-controls="station" aria-selected="false">
+              <?php echo lang('station'); ?>
+            </a>
           </li>
 
           <li class="nav-item">
-            <a class="nav-link" id="general-tab" data-toggle="tab" href="#general" role="tab" aria-controls="general" aria-selected="false">General</a>
+            <a class="nav-link" id="general-tab" data-toggle="tab" href="#general" role="tab" aria-controls="general" aria-selected="false">
+              <?php echo lang('qso_general'); ?>
+            </a>
           </li>
 
           <li class="nav-item">
-            <a class="nav-link" id="satellite-tab" data-toggle="tab" href="#satellite" role="tab" aria-controls="satellite" aria-selected="false">Sat</a>
+            <a class="nav-link" id="satellite-tab" data-toggle="tab" href="#satellite" role="tab" aria-controls="satellite" aria-selected="false">
+              <?php echo lang('qso_sat'); ?>
+            </a>
           </li>
           
           <li class="nav-item">
-            <a class="nav-link" id="notes-tab" data-toggle="tab" href="#notes" role="tab" aria-controls="notes" aria-selected="false">Notes</a>
+            <a class="nav-link" id="notes-tab" data-toggle="tab" href="#notes" role="tab" aria-controls="notes" aria-selected="false">
+              <?php echo lang('notes'); ?>
+            </a>
           </li>
 
           <li class="nav-item">
-            <a class="nav-link" id="qsl-tab" data-toggle="tab" href="#qsl" role="tab" aria-controls="qsl" aria-selected="false">QSL</a>
+            <a class="nav-link" id="qsl-tab" data-toggle="tab" href="#qsl" role="tab" aria-controls="qsl" aria-selected="false">
+              <?php echo lang('qso_qsl'); ?>
+            </a>
           </li>
         </ul>
       </div>
@@ -41,12 +53,12 @@
                       <!-- HTML for Date/Time -->
               <div class="form-row">
                 <div class="form-group col-md-6">
-                  <label for="start_date">Date</label>
+                  <?php echo lang('general_word_date', 'start_date'); ?>
                   <input type="text" class="form-control form-control-sm input_date" name="start_date" id="start_date" value="<?php if (($this->session->userdata('start_date') != NULL && ((time() - $this->session->userdata('time_stamp')) < 24 * 60 * 60))) { echo $this->session->userdata('start_date'); } else { echo date('d-m-Y');}?>" <?php echo ($_GET['manual'] == 0 ? "disabled" : "");  ?> >
                 </div>
 
                 <div class="form-group col-md-6">
-                  <label for="start_time">Time</label>
+                  <?php echo lang('general_word_time', 'start_time'); ?>
                   <input type="text" class="form-control form-control-sm input_time" name="start_time" id="start_time" value="<?php if (($this->session->userdata('start_time') != NULL && ((time() - $this->session->userdata('time_stamp')) < 24 * 60 * 60))) { echo $this->session->userdata('start_time'); } else {echo date('H:i'); } ?>" size="7" <?php echo ($_GET['manual'] == 0 ? "disabled" : "");  ?>>
                 </div>
 
@@ -60,14 +72,14 @@
 
               <!-- Callsign Input -->
               <div class="form-group">
-                <label for="callsign">Callsign</label>
+                <?php echo lang('gen_hamradio_callsign', 'callsign'); ?>
                 <input type="text" class="form-control" id="callsign" name="callsign" required>
                 <small id="callsign_info" class="badge badge-secondary"></small> <small id="lotw_info" class="badge badge-light"></small>
               </div>
 
               <div class="form-row">
                 <div class="form-group col-md-6">
-                  <label for="mode">Mode</label>
+                  <?php echo lang('gen_hamradio_mode', 'mode'); ?>
                   <select id="mode" class="form-control mode form-control-sm" name="mode">
                   <?php
                       foreach($modes->result() as $mode){
@@ -82,7 +94,7 @@
                 </div>
 
                 <div class="form-group col-md-6">
-                  <label for="band">Band</label>
+                  <?php echo lang('gen_hamradio_band', 'band'); ?>
 
                   <select id="band" class="form-control form-control-sm" name="band">
                     <optgroup label="HF">
@@ -122,32 +134,32 @@
               <!-- Signal Report Information -->
               <div class="form-row">
                 <div class="form-group col-md-6">
-                  <label for="rst_sent">RST (S)</label>
+                  <?php echo lang('qso_rst_sent', 'rst_sent'); ?>
                   <input type="text" class="form-control form-control-sm" name="rst_sent" id="rst_sent" value="59">
                 </div>
 
                 <div class="form-group col-md-6">
-                  <label for="rst_recv">RST (R)</label>
+                 <?php echo lang('qso_rst_recv', 'rst_recv'); ?>
                   <input type="text" class="form-control form-control-sm" name="rst_recv" id="rst_recv" value="59">
                 </div>
               </div>
 
               <div class="form-group row">
-                  <label for="name" class="col-sm-3 col-form-label">Name</label>
+                <?php echo lang('qso_name', 'name', array('class' =>'col-sm-3 col-form-label')); ?>
                   <div class="col-sm-9">
                     <input type="text" class="form-control form-control-sm" name="name" id="name" value="">
                 </div>
               </div>
 
               <div class="form-group row">
-                <label for="qth" class="col-sm-3 col-form-label">Location</label>
+                <?php echo lang('qso_qth', 'qth', array('class' =>'col-sm-3 col-form-label')); ?>
                 <div class="col-sm-9">
                     <input type="text" class="form-control form-control-sm" name="qth" id="qth" value="">
                 </div>
               </div>
 
               <div class="form-group row">
-                  <label for="locator" class="col-sm-3 col-form-label">Locator</label>
+                <?php echo lang('qso_locator', 'locator', array('class' =>'col-sm-3 col-form-label')); ?>
                   <div class="col-sm-9">
                     <input type="text" class="form-control form-control-sm" name="locator" id="locator" value="">
                     <small id="locator_info" class="form-text text-muted"></small>
@@ -155,7 +167,7 @@
               </div>
 
               <div class="form-group row">
-                  <label for="comment" class="col-sm-3 col-form-label">Comment</label>
+               <?php echo lang('qso_comment', 'comment', array('class' =>'col-sm-3 col-form-label')); ?>
                   <div class="col-sm-9">
                     <input type="text" class="form-control form-control-sm" name="comment" id="comment" value="">
                 </div>
@@ -166,7 +178,7 @@
           <!-- Station Panel Data -->
           <div class="tab-pane fade" id="station" role="tabpanel" aria-labelledby="station-tab">
             <div class="form-group">
-              <label for="inputStationProfile">Station Profile</label>
+              <?php echo lang('station', 'inputStationProfile'); ?>
               <select id="stationProfile" class="custom-select" name="station_profile">
                 <?php foreach ($stations->result() as $stationrow) { ?>
                 <option value="<?php echo $stationrow->station_id; ?>" <?php if($active_station_profile == $stationrow->station_id) { echo "selected=\"selected\""; } ?>><?php echo $stationrow->station_profile_name; ?></option>
@@ -175,7 +187,7 @@
             </div>
 
             <div class="form-group">
-              <label for="inputRadio">Radio</label>
+              <?php echo lang('qso_inputRadio', 'inputRadio'); ?>
               <select class="custom-select radios" id="radio" name="radio">
                 <option value="0" selected="selected">None</option>
                 <?php foreach ($radios->result() as $row) { ?>
@@ -185,17 +197,17 @@
             </div>
 
             <div class="form-group">
-              <label for="frequency">Frequency</label>
+              <?php echo lang('qso_frequency', 'frequency'); ?>
               <input type="text" class="form-control" id="frequency" name="freq_display" value="<?php echo $this->session->userdata('freq'); ?>" />
             </div>
 
             <div class="form-group">
-              <label for="frequency_rx">Frequency (RX)</label>
+              <?php echo lang('qso_frequencyRx', 'frequency_rx'); ?>
               <input type="text" class="form-control" id="frequency_rx" name="freq_display_rx" value="<?php echo $this->session->userdata('freq_rx'); ?>" />
             </div>
 
             <div class="form-group">
-                  <label for="band">RX Band</label>
+                  <?php echo lang('qso_rxBand', 'band'); ?>
 
                   <select id="band_rx" class="form-control" name="band_rx">
                     <option value="" <?php if($this->session->userdata('band_rx') == "") { echo "selected=\"selected\""; } ?>></option>           
@@ -226,7 +238,7 @@
                       <option value="9cm" <?php if($this->session->userdata('band_rx') == "9cm") { echo "selected=\"selected\""; } ?>>9cm</option>
                     </optgroup>
 
-                    <optgroup label="Microwave">
+                    <optgroup label="<?php echo lang('qso_microwave');?>">
                       <option value="6cm" <?php if($this->session->userdata('band_rx') == "6cm") { echo "selected=\"selected\""; } ?>>6cm</option>
                       <option value="3cm" <?php if($this->session->userdata('band_rx') == "3cm") { echo "selected=\"selected\""; } ?>>3cm</option>
                     </optgroup>
@@ -234,16 +246,16 @@
             </div>
 
             <div class="form-group">
-              <label for="transmit_power">Transmit Power (W)</label>
+              <?php echo lang('qso_transmitPower', 'transmit_power'); ?>
               <input type="number" step="0.001" class="form-control" id="transmit_power" name="transmit_power" value="<?php echo $this->session->userdata('transmit_power'); ?>" />
-              <small id="powerHelp" class="form-text text-muted">Give power value in Watts. Include only numbers in the input.</small>
+              <small id="powerHelp" class="form-text text-muted"><?php echo lang('qso_powerHelp'); ?></small>
             </div>
           </div>
 
           <!-- General Items -->
           <div class="tab-pane fade" id="general" role="tabpanel" aria-labelledby="general-tab">
               <div class="form-group">
-                  <label for="dxcc_id">DXCC</label>
+              <?php echo lang('qso_dxcc', 'dxcc_id'); ?>
                   <select class="custom-select" id="dxcc_id" name="dxcc_id" required>
 
                       <?php
@@ -255,7 +267,7 @@
                   </select>
               </div>
               <div class="form-group">
-                  <label for="cqz">CQ Zone</label>
+                  <?php echo lang('qso_cqz', 'cqz'); ?>
                   <select class="custom-select" id="cqz" name="cqz" required>
                       <?php
                       for ($i = 1; $i<=40; $i++) {
@@ -266,26 +278,26 @@
               </div>
 
             <div class="form-group">
-              <label for="selectPropagation">Propagation Mode</label>
+              <label for="selectPropagation"><?php echo lang('qso_propagationMode'); ?></label>
               <select class="custom-select" id="selectPropagation" name="prop_mode">
                 <option value="" <?php if(!empty($this->session->userdata('prop_mode'))) { echo "selected=\"selected\""; } ?>></option>
-                <option value="AUR" <?php if($this->session->userdata('prop_mode') == "AUR") { echo "selected=\"selected\""; } ?>>Aurora</option>
-                <option value="AUE" <?php if($this->session->userdata('prop_mode') == "AUE") { echo "selected=\"selected\""; } ?>>Aurora-E</option>
-                <option value="BS" <?php if($this->session->userdata('prop_mode') == "BS") { echo "selected=\"selected\""; } ?>>Back scatter</option>
-                <option value="ECH" <?php if($this->session->userdata('prop_mode') == "ECH") { echo "selected=\"selected\""; } ?>>EchoLink</option>
-                <option value="EME" <?php if($this->session->userdata('prop_mode') == "EME") { echo "selected=\"selected\""; } ?>>Earth-Moon-Earth</option>
-                <option value="ES" <?php if($this->session->userdata('prop_mode') == "ES") { echo "selected=\"selected\""; } ?>>Sporadic E</option>
-                <option value="FAI" <?php if($this->session->userdata('prop_mode') == "FAI") { echo "selected=\"selected\""; } ?>>Field Aligned Irregularities</option>
-                <option value="F2" <?php if($this->session->userdata('prop_mode') == "F2") { echo "selected=\"selected\""; } ?>>F2 Reflection</option>
-                <option value="INTERNET" <?php if($this->session->userdata('prop_mode') == "INTERNET") { echo "selected=\"selected\""; } ?>>Internet-assisted</option>
-                <option value="ION" <?php if($this->session->userdata('prop_mode') == "ION") { echo "selected=\"selected\""; } ?>>Ionoscatter</option>
-                <option value="IRL" <?php if($this->session->userdata('prop_mode') == "IRL") { echo "selected=\"selected\""; } ?>>IRLP</option>
-                <option value="MS" <?php if($this->session->userdata('prop_mode') == "MS") { echo "selected=\"selected\""; } ?>>Meteor scatter</option>
-                <option value="RPT" <?php if($this->session->userdata('prop_mode') == "RPT") { echo "selected=\"selected\""; } ?>>Terrestrial or atmospheric repeater or transponder</option>
-                <option value="RS" <?php if($this->session->userdata('prop_mode') == "RS") { echo "selected=\"selected\""; } ?>>Rain scatter</option>
-                <option value="SAT" <?php if($this->session->userdata('prop_mode') == "SAT") { echo "selected=\"selected\""; } ?>>Satellite</option>
-                <option value="TEP" <?php if($this->session->userdata('prop_mode') == "TEP") { echo "selected=\"selected\""; } ?>>Trans-equatorial</option>
-                <option value="TR" <?php if($this->session->userdata('prop_mode') == "TR") { echo "selected=\"selected\""; } ?>>Tropospheric ducting</option>
+                <option value="AUR" <?php if($this->session->userdata('prop_mode') == "AUR") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_AUR'); ?></option>
+                <option value="AUE" <?php if($this->session->userdata('prop_mode') == "AUE") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_AUE'); ?></option>
+                <option value="BS" <?php if($this->session->userdata('prop_mode') == "BS") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_BS'); ?></option>
+                <option value="ECH" <?php if($this->session->userdata('prop_mode') == "ECH") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_ECH'); ?></option>
+                <option value="EME" <?php if($this->session->userdata('prop_mode') == "EME") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_EME'); ?></option>
+                <option value="ES" <?php if($this->session->userdata('prop_mode') == "ES") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_ES'); ?></option>
+                <option value="FAI" <?php if($this->session->userdata('prop_mode') == "FAI") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_FAI'); ?></option>
+                <option value="F2" <?php if($this->session->userdata('prop_mode') == "F2") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_F2'); ?></option>
+                <option value="INTERNET" <?php if($this->session->userdata('prop_mode') == "INTERNET") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_INTERNET'); ?></option>
+                <option value="ION" <?php if($this->session->userdata('prop_mode') == "ION") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_ION'); ?></option>
+                <option value="IRL" <?php if($this->session->userdata('prop_mode') == "IRL") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_IRL'); ?></option>
+                <option value="MS" <?php if($this->session->userdata('prop_mode') == "MS") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_MS'); ?></option>
+                <option value="RPT" <?php if($this->session->userdata('prop_mode') == "RPT") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_RPT'); ?></option>
+                <option value="RS" <?php if($this->session->userdata('prop_mode') == "RS") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_RS'); ?></option>
+                <option value="SAT" <?php if($this->session->userdata('prop_mode') == "SAT") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_SAT'); ?></option>
+                <option value="TEP" <?php if($this->session->userdata('prop_mode') == "TEP") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_TEP'); ?></option>
+                <option value="TR" <?php if($this->session->userdata('prop_mode') == "TR") { echo "selected=\"selected\""; } ?>><?php echo lang('qso_prop_TR'); ?></option>
               </select>
             </div>
 
@@ -348,7 +360,7 @@
             </div>
 
             <div class="form-group">
-              <label for="iota_ref">IOTA Reference</label>
+               <?php echo lang('qso_iota_ref', 'iota_ref'); ?>
                     <select class="custom-select" id="iota_ref" name="iota_ref">
                         <option value =""></option>
 
@@ -362,34 +374,34 @@
             </div>
 
             <div class="form-group">
-              <label for="sota_ref">SOTA Reference</label>
+              <?php echo lang('qso_sota_ref', 'sota_ref'); ?>
               <input class="form-control" id="sota_ref" type="text" name="sota_ref" value="" />
-              <small id="sotaRefHelp" class="form-text text-muted">For example: GM/NS-001</small>
+              <small id="sotaRefHelp" class="form-text text-muted"><?php echo lang('qso_sota_help'); ?></small>
             </div>
 
             <div class="form-group">
-              <label for="sig">Sig</label>
+              <?php echo lang('qso_sig', 'sig'); ?>
               <input class="form-control" id="sig" type="text" name="sig" value="" />
-              <small id="sigHelp" class="form-text text-muted">For example: WWFF or POTA</small>
+              <small id="sigHelp" class="form-text text-muted"><?php echo lang('qso_sig_help'); ?></small>
             </div>
 
             <div class="form-group">
-              <label for="sig_info">Sig Info</label>
+              <?php echo lang('qso_sig_info', 'sig_info'); ?>
               <input class="form-control" id="sig_info" type="text" name="sig_info" value="" />
-              <small id="sigInfoHelp" class="form-text text-muted">For example: DLFF-0029</small>
+              <small id="sigInfoHelp" class="form-text text-muted"><?php echo lang('qso_sig_help'); ?></small>
             </div>
 
             <div class="form-group">
-              <label for="sota_ref">DOK</label>
+              <?php echo lang('qso_darc_dok', 'darc_dok'); ?>
               <input class="form-control" id="darc_dok" type="text" name="darc_dok" value="" />
-              <small id="dokHelp" class="form-text text-muted">For example: Q03</small>
+              <small id="dokHelp" class="form-text text-muted"><?php echo lang('qso_dok_help'); ?></small>
             </div>
           </div>
           
           <!-- Satellite Panel -->
           <div class="tab-pane fade" id="satellite" role="tabpanel" aria-labelledby="satellite-tab">
             <div class="form-group">
-              <label for="inputSatName">Satellite Name</label>
+              <?php echo lang('qso_sat_name', 'inputSatName'); ?>
 
               <input list="satellite_names" id="sat_name" type="text" name="sat_name" class="form-control" value="<?php echo $this->session->userdata('sat_name'); ?>">
 
@@ -397,7 +409,7 @@
             </div>
 
             <div class="form-group">
-              <label for="inputSatMode">Satellite Mode</label>
+            <?php echo lang('qso_sat_mode', 'inputSatMode'); ?>
 
               <input list="satellite_modes" id="sat_mode" type="text" name="sat_mode" class="form-control" value="<?php echo $this->session->userdata('sat_mode'); ?>">
 
@@ -408,10 +420,10 @@
           <!-- Notes Panel Contents -->
           <div class="tab-pane fade" id="notes" role="tabpanel" aria-labelledby="notes-tab">
             <div class="alert alert-info" role="alert">
-              <span class="badge badge-info">Info</span> Note content is used within Cloudlog only and is not exported to other services.
+              <span class="badge badge-info"><?php echo lang('general_info'); ?></span> <?php echo lang('notes_info_message'); ?>
             </div>
            <div class="form-group">
-              <label for="notes">Notes</label>
+           <?php echo lang('notes', 'notes'); ?>
               <textarea  type="text" class="form-control" id="notes" name="notes" rows="10"></textarea>
             </div>
           </div>
@@ -420,29 +432,29 @@
           <div class="tab-pane fade" id="qsl" role="tabpanel" aria-labelledby="qsl-tab">
             
             <div class="form-group row">
-              <label for="sent" class="col-sm-3 col-form-label">Sent</label>
+              <?php echo lang('general_word_sent', 'sent', array('class' =>'col-sm-3 col-form-label')); ?>
               <div class="col-sm-9">
                 <select class="custom-select" id="sent" name="qsl_sent">
-                  <option value="N" selected="selected">No</option>
-                  <option value="Y">Yes</option>
-                  <option value="R">Requested</option>
+                  <option value="N" selected="selected"><?php echo lang('general_no'); ?></option>
+                  <option value="Y"><?php echo lang('general_yes'); ?></option>
+                  <option value="R"><?php echo lang('general_word_requested'); ?></option>
                 </select>
               </div>
             </div>
 
             <div class="form-group row">
-              <label for="sent-method" class="col-sm-3 col-form-label">Method</label>
+              <?php echo lang('qso_qsl_method', 'sent-method', array('class' =>'col-sm-3 col-form-label')); ?>
               <div class="col-sm-9">
                 <select class="custom-select" id="sent-method" name="qsl_sent_method">
-                 <option value="" selected="selected">Method</option>
-                 <option value="D">Direct</option>
-                 <option value="B">Bureau</option>
+                 <option value="" selected="selected"><?php echo lang('qso_qsl_method'); ?></option>
+                 <option value="D"><?php echo lang('qso_qsl_direct'); ?></option>
+                 <option value="B"><?php echo lang('qso_qsl_bureau'); ?></option>
                 </select>
               </div>
             </div>
 
             <div class="form-group row">
-              <label for="qsl_via" class="col-sm-2 col-form-label">Via</label>
+              <?php echo lang('qso_qsl_via', 'qsl_via', array('class' =>'col-sm-2 col-form-label')); ?>
               <div class="col-sm-10">
                 <input type="text" id="qsl_via" class="form-control" name="qsl_via" value="" />
               </div>
@@ -457,8 +469,8 @@
           <input size="20" id="country" type="hidden" name="country" value="" />
         </div>
         
-        <button type="reset" class="btn btn-light" onclick="reset_fields()">Reset</button>
-        <button type="submit" class="btn btn-primary"><i class="fas fa-save"></i> Save QSO</button>
+        <button type="reset" class="btn btn-light" onclick="reset_fields()"><?php echo lang('qso_reset_button'); ?></button>
+        <button type="submit" class="btn btn-primary"><i class="fas fa-save"></i><?php echo lang('qso_save_button'); ?></button>
       </div>
     </form>
     </div>
@@ -481,20 +493,20 @@
 
     <div class="card qso-map">
         <div class="card-header">
-          <h4 class="card-title">QSO Map</h4>
+          <h4 class="card-title"><?php echo lang('qso_map'); ?></h4>
         </div>
 
             <div id="qsomap" style="width: 100%; height: 200px;"></div>
     </div>
 
     <div class="card callsign-suggest">
-        <div class="card-header"><h4 class="card-title">Suggestions</h4></div>
+        <div class="card-header"><h4 class="card-title"><?php echo lang('qso_suggestions'); ?></h4></div>
 
         <div class="card-body callsign-suggestions"></div>
     </div>
 
     <div class="card previous-qsos">
-      <div class="card-header"><h4 class="card-title">Previous Contacts</h4></div>
+      <div class="card-header"><h4 class="card-title"><?php echo lang('qso_prev_contacts'); ?></h4></div>
 
         <div id="partial_view"></div>
 
@@ -503,12 +515,12 @@
           <div class="table-responsive">
             <table class="table">
               <tr class="log_title titles">
-                <td>Date/Time</td>
-                <td>Call</td>
-                <td>Mode</td>
-                <td>Sent</td>
-                <td>Recv'd</td>
-                <td>Band</td>
+                <td><?php echo lang('general_word_date'); ?></td>
+                <td><?php echo lang('gen_hamradio_call'); ?></td>
+                <td><?php echo lang('gen_hamradio_mode'); ?></td>
+                <td><?php echo lang('gen_hamradio_rst_sent'); ?></td>
+                <td><?php echo lang('gen_hamradio_rst_recv'); ?></td>
+                <td><?php echo lang('gen_hamradio_band'); ?></td>
               </tr>
 
               <?php $i = 0; 


### PR DESCRIPTION
Hi there!

As said in #798, a few weeks ago @leroydiazg and I found Cloudlog and started thinking to use it after contributing to the project by adding the Spanish translations.

However, we realized that actually the application _didn't_ have support for internationalization... and we got on adding it last [Sunday, Jan 3rd](https://github.com/dgdavid/Cloudlog/commits/add-spanish-translations). ~~Unfortunately, we didn't saw that @magicbug had an open [project](https://github.com/magicbug/Cloudlog/projects/7) to address it and we couldn't join forces~~.

Nevertheless, I'm opening the PR with the changes done and notes we took, just in case it could be useful.

* System/Framework translations

  CodeIgniter documentation [suggest using _approved translations_](https://codeigniter.com/userguide3/libraries/language.html) that can be found in [CodeIgniter 3 Translations repositories](https://github.com/bcit-ci/codeigniter3-translations)


* Auto-loading language files

  Maybe there is a remarkable disadvantage of auto-loading all needed language files, but we were not able to find any mention of it in the documentation. So, we added all lang files to be [auto-loaded during system initialization](https://codeigniter.com/userguide3/libraries/language.html?highlight=autoload#auto-loading-languages). It looks as _better_ (?) than loading them per controller.
  
  For example, think in a translation located in a, let's say, _station_lang_ file that it is also needed in a QSO view. Why loading both lang files in the controller method instead of having them already available?
  
  However, it still not being clear to me the _right way_ to do it in case of having the language switcher feature.

* `lang` helper

  The [Language Class](https://codeigniter.com/userguide3/libraries/language.html) documentation has a reference to the [Language Helper](https://codeigniter.com/userguide3/helpers/language_helper.html) which has been auto-loaded and used, since
  
  * It's shorter to write `lang('whatever')` than `$this->lang->line('whatever')`
  * It allows to produce the form labels too (which is weird, BTW) using the second param as `for`: `lang('whatever', 'input-id')`
  

* Avoid crowding the `general_words` lang file

  Although we didn't know all the concepts you manage in the amateur radio world, we tried to use a lang file per _concept_ (QSO, QSL, Notes, Station).
  
* Missing translations

  As far as I could see, a not found translation will be an empty string. Probably because there is not a _fallback_ language since we are setting the language of our choice as a [default language](https://github.com/magicbug/Cloudlog/blob/e85c9a6ec0a2421ed54d9b34f76be93df86bcc6e/application/config/config.sample.php#L158). But not completely sure about it.
 
* A _user language_ feature would be nice.

  Maybe this [great article](https://www.sitepoint.com/multi-language-support-in-codeigniter/) could help (found in [an answer in StackOverflow](https://stackoverflow.com/questions/25343608/how-can-i-switch-languages-in-codeigniter#44917410))