### PR TITLE
Add Spanish translation

### DIFF
--- a/application/language/spanish/calendar_lang.php
+++ b/application/language/spanish/calendar_lang.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['cal_su']			= 'Do';
+$lang['cal_mo']			= 'Lu';
+$lang['cal_tu']			= 'Ma';
+$lang['cal_we']			= 'Mi';
+$lang['cal_th']			= 'Ju';
+$lang['cal_fr']			= 'Vi';
+$lang['cal_sa']			= 'Sá';
+$lang['cal_sun']		= 'Dom';
+$lang['cal_mon']		= 'Lun';
+$lang['cal_tue']		= 'Mar';
+$lang['cal_wed']		= 'Mié';
+$lang['cal_thu']		= 'Jue';
+$lang['cal_fri']		= 'Vie';
+$lang['cal_sat']		= 'Sáb';
+$lang['cal_sunday']		= 'Domingo';
+$lang['cal_monday']		= 'Lunes';
+$lang['cal_tuesday']	= 'Martes';
+$lang['cal_wednesday']	= 'Miércoles';
+$lang['cal_thursday']	= 'Jueves';
+$lang['cal_friday']		= 'Viernes';
+$lang['cal_saturday']	= 'Sábado';
+$lang['cal_jan']		= 'Ene';
+$lang['cal_feb']		= 'Feb';
+$lang['cal_mar']		= 'Mar';
+$lang['cal_apr']		= 'Abr';
+$lang['cal_may']		= 'May';
+$lang['cal_jun']		= 'Jun';
+$lang['cal_jul']		= 'Jul';
+$lang['cal_aug']		= 'Ago';
+$lang['cal_sep']		= 'Sep';
+$lang['cal_oct']		= 'Oct';
+$lang['cal_nov']		= 'Nov';
+$lang['cal_dec']		= 'Dic';
+$lang['cal_january']	= 'Enero';
+$lang['cal_february']	= 'Febrero';
+$lang['cal_march']		= 'Marzo';
+$lang['cal_april']		= 'Abril';
+$lang['cal_mayl']		= 'Mayo';
+$lang['cal_june']		= 'Junio';
+$lang['cal_july']		= 'Julio';
+$lang['cal_august']		= 'Agosto';
+$lang['cal_september']	= 'Septiembre';
+$lang['cal_october']	= 'Octubre';
+$lang['cal_november']	= 'Noviembre';
+$lang['cal_december']	= 'Diciembre';

--- a/application/language/spanish/contesting_lang.php
+++ b/application/language/spanish/contesting_lang.php
@@ -1,0 +1,18 @@
+<?php
+
+defined('BASEPATH') OR exit('Acceso directo a los scripts restringido');
+
+$lang['contesting_page_title'] = 'Registro de concurso';
+$lang['contesting_button_reset_contest_session'] = 'Resetar la sesión del concurso';
+
+$lang['contesting_exchange_type'] = 'Tipo de intercambio';
+$lang['contesting_exchange_type_serial'] = 'Serial';
+$lang['contesting_exchange_type_other'] = 'Other';
+
+$lang['contesting_contest_name'] = 'Nombre del concurso';
+
+$lang['contesting_btn_reset_qso'] = 'Resetear QSO';
+$lang['contesting_btn_save_qso'] = 'Guardar QSO';
+
+$lang['contesting_title_callsign_suggestions'] = 'Indicativos sugeridos';
+$lang['contesting_title_contest_logbook'] = 'Logbook del concurso';

--- a/application/language/spanish/date_lang.php
+++ b/application/language/spanish/date_lang.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['date_year'] = 'Año';
+$lang['date_years'] = 'Años';
+$lang['date_month'] = 'Mes';
+$lang['date_months'] = 'Meses';
+$lang['date_week'] = 'Semana';
+$lang['date_weeks'] = 'Semanas';
+$lang['date_day'] = 'Día';
+$lang['date_days'] = 'Días';
+$lang['date_hour'] = 'Hora';
+$lang['date_hours'] = 'Horas';
+$lang['date_minute'] = 'Minuto';
+$lang['date_minutes'] = 'Minutos';
+$lang['date_second'] = 'Segundo';
+$lang['date_seconds'] = 'Segundos';
+
+$lang['UM12']	= '(UTC -12:00) Isla Howland/Baker';
+$lang['UM11']	= '(UTC -11:00) Niue';
+$lang['UM10']	= '(UTC -10:00) Tiempo de Hawái-Aleutiano, Islas Cook, Tahití';
+$lang['UM95']	= '(UTC -9:30) Islas Marquesas';
+$lang['UM9']	= '(UTC -9:00) Tiempo de Alaska, Islas Gambier';
+$lang['UM8']	= '(UTC -8:00) Tiempo del Pacífico, Isla Clipperton';
+$lang['UM7']	= '(UTC -7:00) Tiempo de la montaña';
+$lang['UM6']	= '(UTC -6:00) Hora Estándar del Centro';
+$lang['UM5']	= '(UTC -5:00) Tiempo del Este, Hora Estándar del Caribe Occidental';
+$lang['UM45']	= '(UTC -4:30) Hora Estándar de Venezuela';
+$lang['UM4']	= '(UTC -4:00) Tiempo Estándar del Atlántico, Hora Estándar del Caribe Oriental';
+$lang['UM35']	= '(UTC -3:30) Tiempo de Terranova y Labrador';
+$lang['UM3']	= '(UTC -3:00) Argentina, Brasil, Guayana Francesa, Uruguay';
+$lang['UM2']	= '(UTC -2:00) Islas Georgias del Sur/Islas Sandwich del Sur';
+$lang['UM1']	= '(UTC -1:00) Azores, Islas de Cabo Verde';
+$lang['UTC']	= '(UTC) Tiempo medio de Greenwich, Hora de Europa Occidental';
+$lang['UP1']	= '(UTC +1:00) Hora Central Europea, Tiempo de África Occidental';
+$lang['UP2']	= '(UTC +2:00) Tiempo de África Central, Hora de Europa Oriental, Hora de Kaliningrado';
+$lang['UP3']	= '(UTC +3:00) Hora de Moscú, Tiempo de África Oriental, Hora Estándar de Arabia';
+$lang['UP35']	= '(UTC +3:30) Hora Estándar de Irán';
+$lang['UP4']	= '(UTC +4:00) Hora Estándar de Azerbaiyán, Hora de Samara';
+$lang['UP45']	= '(UTC +4:30) Afganistán';
+$lang['UP5']	= '(UTC +5:00) Hora Estándar de Pakistan, Hora de Ekaterimburgo';
+$lang['UP55']	= '(UTC +5:30) Hora Estándar de la India, Hora Estándar de Sri Lanka';
+$lang['UP575']	= '(UTC +5:45) Hora de Nepal';
+$lang['UP6']	= '(UTC +6:00) Hora Estándar de Bangladés, Hora de Bután, Hora de Omsk';
+$lang['UP65']	= '(UTC +6:30) Islas Cocos, Birmania';
+$lang['UP7']	= '(UTC +7:00) Hora de Krasnoyarsk, Camboya, Laos, Tailandia, Vietnam';
+$lang['UP8']	= '(UTC +8:00) Hora Estándar Occidental Australiana, Hora de Pekín, Hora de Irkutsk';
+$lang['UP875']	= '(UTC +8:45) Hora Estándar Centro Occidental Australiana';
+$lang['UP9']	= '(UTC +9:00) Hora Estándar de Japón, Hora Estándar de Corea, Hora de Yakutsk';
+$lang['UP95']	= '(UTC +9:30) Hora Estándar Central Australiana';
+$lang['UP10']	= '(UTC +10:00) Hora Estándar Oriental Australiana, Hora de Vladivostok';
+$lang['UP105']	= '(UTC +10:30) Isla de Lord Howe';
+$lang['UP11']	= '(UTC +11:00) Hora de Srednekolimsk, Islas Salomón, Vanuatu';
+$lang['UP115']	= '(UTC +11:30) Isla Norfolk';
+$lang['UP12']	= '(UTC +12:00) Fiji, Islas Gilbert, Horario de Kamchatka, Hora estandar de Nueva Zelanda';
+$lang['UP1275']	= '(UTC +12:45) Hora Estándar de las Islas Chatham';
+$lang['UP13']	= '(UTC +13:00) Zona horaria de Samoa, Hora de las Islas Fénix, Tonga';
+$lang['UP14']	= '(UTC +14:00) Islas de la Línea';

--- a/application/language/spanish/db_lang.php
+++ b/application/language/spanish/db_lang.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['db_invalid_connection_str'] = 'No ha sido posible determinar la configuración de la base de datos basada en la cadena de conexión introducida.';
+$lang['db_unable_to_connect'] = 'No ha sido posible conectar al servidor de la base de datos haciendo uso de la configuración proporcionada.';
+$lang['db_unable_to_select'] = 'No ha sido posible seleccionar la base de datos especificada: %s';
+$lang['db_unable_to_create'] = 'No ha sido posible crear la base de datos especificada: %s';
+$lang['db_invalid_query'] = 'La consulta introducida no es válida.';
+$lang['db_must_set_table'] = 'Debes fijar la tabla de la base de datos que será usada con tu consulta.';
+$lang['db_must_use_set'] = 'Debes usar el método "set" para actualizar una entrada.';
+$lang['db_must_use_index'] = 'Debes especificar un índice para emparejar las actualizaciones masivas.';
+$lang['db_batch_missing_index'] = 'A una o más filas introducidas para la actualización masiva le falta el índice especificado.';
+$lang['db_must_use_where'] = 'Las actualizaciones no están permitidas a no ser que contengan la cláusula "where".';
+$lang['db_del_must_use_where'] = 'Los borrados no están permitidos a no ser que contengan la cláusula "where" o "like".';
+$lang['db_field_param_missing'] = 'Para obtener campos se requiere el nombre de la tabla como parámetro.';
+$lang['db_unsupported_function'] = 'Esta característica no está disponible para la base de datos que estás usando.';
+$lang['db_transaction_failure'] = 'Fallo de transacción: Rollback realizado.';
+$lang['db_unable_to_drop'] = 'No ha sido posible borrar la base de datos especificada.';
+$lang['db_unsupported_feature'] = 'Característica no soportada de la plataforma de bases de datos que estás usando.';
+$lang['db_unsupported_compression'] = 'El formato de compresión elegido no está soportado por el servidor.';
+$lang['db_filepath_error'] = 'No ha sido posible escribir los datos en la ruta de archivo especificada.';
+$lang['db_invalid_cache_path'] = 'La ruta de la caché introducida no es válida o escribible.';
+$lang['db_table_name_required'] = 'Se requiere un nombre de tabla para esa operación.';
+$lang['db_column_name_required'] = 'Se requiere un nombre de columna para esa operación.';
+$lang['db_column_definition_required'] = 'Se requiere una definición de columna para esa operación.';
+$lang['db_unable_to_set_charset'] = 'No ha sido posible fijar en la conexión el conjunto de caracteres: %s';
+$lang['db_error_heading'] = 'Ha ocurrido un error con la base de datos';

--- a/application/language/spanish/email_lang.php
+++ b/application/language/spanish/email_lang.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['email_must_be_array'] = 'Debes pasar un array al método de validación de email.';
+$lang['email_invalid_address'] = 'Correo electrónico no válido: %s';
+$lang['email_attachment_missing'] = 'No ha sido posible encontrar este adjunto: %s';
+$lang['email_attachment_unreadable'] = 'No ha sido posible abrir este adjunto: %s';
+$lang['email_no_from'] = 'No se puede enviar un email sin la cabecera "From".';
+$lang['email_no_recipients'] = 'Debes incluir destinatarios: Para, Cc, o Cco';
+$lang['email_send_failure_phpmail'] = 'No ha sido posible enviar el correo usando PHP mail(). Tu servidor podría no estar configurado para enviar emails con este método.';
+$lang['email_send_failure_sendmail'] = 'No ha sido posible enviar el correo usando PHP Sendmail. Tu servidor podría no estar configurado para enviar emails con este método.';
+$lang['email_send_failure_smtp'] = 'No ha sido posible enviar el correo usando PHP SMTP. Tu servidor podría no estar configurado para enviar emails con este método.';
+$lang['email_sent'] = 'Tu mensaje ha sido enviado con éxito usando este protocolo: %s';
+$lang['email_no_socket'] = 'No ha sido posible abrir un socket a Sendmail. Por favor, comprueba la configuración.';
+$lang['email_no_hostname'] = 'No has especificado un servidor SMTP.';
+$lang['email_smtp_error'] = 'Se ha encontrado este error SMTP: %s';
+$lang['email_no_smtp_unpw'] = 'Error: Debes asignar un usuario y una contraseña SMTP.';
+$lang['email_failed_smtp_login'] = 'Fallo al enviar el comando AUTH LOGIN. Error: %s';
+$lang['email_smtp_auth_un'] = 'Fallo al autenticar el usuario. Error: %s';
+$lang['email_smtp_auth_pw'] = 'Fallo al autenticar la contraseña. Error: %s';
+$lang['email_smtp_data_failure'] = 'No ha sido posible enviar los datos: %s';
+$lang['email_exit_status'] = 'Código estado al salir: %s';

--- a/application/language/spanish/form_validation_lang.php
+++ b/application/language/spanish/form_validation_lang.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['form_validation_required']		= 'El campo {field} es obligatorio.';
+$lang['form_validation_isset']			= 'El campo {field} debe contener un valor.';
+$lang['form_validation_valid_email']		= 'El campo {field} debe contener un email válido.';
+$lang['form_validation_valid_emails']		= 'El campo {field} debe contener todos los emails válidos.';
+$lang['form_validation_valid_url']		= 'El campo {field} debe contener una URL válida.';
+$lang['form_validation_valid_ip']		= 'El campo {field} debe contener una IP válida.';
+$lang['form_validation_valid_base64']   = 'El campo {field} debe contener un Base64 válido.';
+$lang['form_validation_min_length']		= 'El campo {field} debe ser de al menos {param} caracteres de longitud.';
+$lang['form_validation_max_length']		= 'El campo {field} no puede superar los {param} caracteres de longitud.';
+$lang['form_validation_exact_length']		= 'El campo {field} debe ser de exactamente {param} caracteres de longitud.';
+$lang['form_validation_alpha']			= 'El campo {field} solo puede contener caracteres alfabéticos.';
+$lang['form_validation_alpha_numeric']		= 'El campo {field} solo puede contener caracteres alfanuméricos.';
+$lang['form_validation_alpha_numeric_spaces']	= 'El campo {field} solo puede contener caracteres alfanuméricos y espacios.';
+$lang['form_validation_alpha_dash']		= 'El campo {field} solo puede contener caracteres alfanuméricos, guiones bajos y guiones.';
+$lang['form_validation_numeric']		= 'El campo {field} solo puede contener números.';
+$lang['form_validation_is_numeric']		= 'El campo {field} solo puede contener caracteres numéricos.';
+$lang['form_validation_integer']		= 'El campo {field} debe contener un entero.';
+$lang['form_validation_regex_match']		= 'El campo {field} no está en el formato correcto.';
+$lang['form_validation_matches']		= 'El campo {field} no coincide con el campo {param}.';
+$lang['form_validation_differs']		= 'El campo {field} debe ser distinto al campo {param}.';
+$lang['form_validation_is_unique'] 		= 'El campo {field} debe contener un valor único.';
+$lang['form_validation_is_natural']		= 'El campo {field} solo puede contener dígitos.';
+$lang['form_validation_is_natural_no_zero']	= 'El campo {field} solo puede contener dígitos y debe ser mayor que cero.';
+$lang['form_validation_decimal']		= 'El campo {field} debe contener un número decimal.';
+$lang['form_validation_less_than']		= 'El campo {field} debe contener un número menor que {param}.';
+$lang['form_validation_less_than_equal_to']	= 'El campo {field} debe contener un número menor o igual a {param}.';
+$lang['form_validation_greater_than']		= 'El campo {field} debe contener un número mayor que {param}.';
+$lang['form_validation_greater_than_equal_to']	= 'El campo {field} debe contener un número mayor o igual a {param}.';
+$lang['form_validation_error_message_not_set']	= 'No se ha podido acceder al mensaje de error correspondiente para el campo {field}.';
+$lang['form_validation_in_list']		= 'El campo {field} debe contener uno de estos: {param}.';

--- a/application/language/spanish/ftp_lang.php
+++ b/application/language/spanish/ftp_lang.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['ftp_no_connection']		= 'No ha sido posible localizar una ID de conexión válida. Por favor, asegúrate de que estás conectado antes de realizar cualquier rutina de archivos.';
+$lang['ftp_unable_to_connect']		= 'No ha sido posible conectarse al servidor FTP usando el nombre de host proporcionado.';
+$lang['ftp_unable_to_login']		= 'No ha sido posible identificarse en el servidor. Por favor, comprueba el usuario y la contraseña.';
+$lang['ftp_unable_to_mkdir']		= 'No ha sido posible crear el directorio especificado.';
+$lang['ftp_unable_to_changedir']	= 'No ha sido posible cambiar de directorio.';
+$lang['ftp_unable_to_chmod']		= 'No ha sido posible configurar los permisos de archivo. Por favor, comprueba tu ruta.';
+$lang['ftp_unable_to_upload']		= 'No ha sido posible subir el archivo especificado. Por favor, comprueba tu ruta.';
+$lang['ftp_unable_to_download']		= 'No ha sido posible descargar el archivo especificado. Por favor, comprueba tu ruta.';
+$lang['ftp_no_source_file']		= 'No ha sido posible localizar el archivo fuente. Por favor, comprueba tu ruta.';
+$lang['ftp_unable_to_rename']		= 'No ha sido posible renombrar el archivo.';
+$lang['ftp_unable_to_delete']		= 'No ha sido posible borrar el archivo.';
+$lang['ftp_unable_to_move']		= 'No ha sido posible mover el archivo. Por favor, asegúrate de que la carpeta de destino existe.';

--- a/application/language/spanish/general_words_lang.php
+++ b/application/language/spanish/general_words_lang.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('BASEPATH') OR exit('Acceso directo a los scripts restringido');
+defined('BASEPATH') OR exit('No direct script access allowed');
 
 $lang['error_no_active_station_profile'] = 'Attention: you need to set an active station profile.';
 

--- a/application/language/spanish/general_words_lang.php
+++ b/application/language/spanish/general_words_lang.php
@@ -1,0 +1,99 @@
+<?php
+
+defined('BASEPATH') OR exit('Acceso directo a los scripts restringido');
+
+$lang['error_no_active_station_profile'] = 'Attention: you need to set an active station profile.';
+
+$lang['notice_turn_the_radio_on'] = 'No has realizado ninguna QSO hoy...¡Hora de encender la radio!';
+
+$lang['general_word_important'] = 'Importante';
+$lang['general_word_info'] = 'Información';
+$lang['general_word_choose_file'] = 'Elegir archivo';
+
+$lang['general_word_date'] = 'Fecha';
+$lang['general_word_time'] = 'Hora';
+$lang['general_word_none'] = 'Ninguno';
+$lang['general_word_name'] = 'Nombre';
+$lang['general_word_location'] = 'Localización';
+$lang['general_word_comment'] = 'Comentario';
+$lang['general_word_general'] = 'General';
+$lang['general_word_satellite'] = 'Satélite';
+$lang['general_word_satellite_short'] = 'Sat';
+$lang['general_word_notes'] = 'Notas';
+$lang['general_word_comment'] = 'Comentario';
+$lang['general_word_country'] = 'País';
+
+$lang['general_word_total'] = 'Total';
+$lang['general_word_year'] = 'Año';
+$lang['general_word_month'] = 'Mes';
+
+$lang['general_word_worked'] = 'Realizados';
+$lang['general_word_confirmed'] = 'Confirmados';
+$lang['general_word_needed'] = 'Solicitadas';
+
+$lang['general_word_no'] = 'No';
+$lang['general_word_yes'] = 'Si';
+$lang['general_word_method'] = 'Método';
+
+$lang['general_word_sent'] = 'Enviado';
+$lang['general_word_received'] = 'Recibido';
+$lang['general_word_requested'] = 'Solicitadas';
+$lang['general_word_qslcards'] = 'Tarjetas QSL';
+$lang['general_word_qslcard_direct'] = 'Directo';
+$lang['general_word_qslcard_bureau'] = 'Agencia';
+$lang['general_word_qslcard_via'] = 'Vía';
+
+$lang['general_edit_qso'] = 'Editar QSO';
+$lang['general_mark_qsl_rx_bureau'] = 'Marcar QSL Recibida (Agencia)';
+$lang['general_mark_qsl_rx_direct'] = 'Mark QSL Recibida (Directa)';
+
+$lang['general_delete_qso'] = 'Eliminar QSO';
+
+// Cloudlog Terms
+$lang['cloudlog_station_profile'] = 'Perfil de estación';
+
+// ham radio terms
+$lang['gen_hamradio_qso'] = 'QSO';
+$lang['gen_hamradio_station'] = 'Estación';
+
+$lang['gen_hamradio_call'] = 'Llamada';
+$lang['gen_hamradio_callsign'] = 'Indicativo';
+$lang['gen_hamradio_mode'] = 'Modo';
+$lang['gen_hamradio_rst_sent'] = 'Enviado';
+$lang['gen_hamradio_rst_recv'] = 'Recibido';
+$lang['gen_hamradio_band'] = 'Banda';
+$lang['gen_hamradio_band_rx'] = 'Banda (Recepción)';
+$lang['gen_hamradio_frequency'] = 'Frecuencia';
+$lang['gen_hamradio_frequency_rx'] = 'Frecuencia (Recepción)';
+$lang['gen_hamradio_radio'] = 'Radio';
+$lang['gen_hamradio_rsts'] = 'RST (Enviada)';
+$lang['gen_hamradio_rstr'] = 'RST (Recibida)';
+$lang['gen_hamradio_exchange_sent_short'] = 'Intercambio (Env)';
+$lang['gen_hamradio_exchange_recv_short'] = 'Intercambio (Recib)';
+$lang['gen_hamradio_qsl'] = 'QSL';
+$lang['gen_hamradio_locator'] = 'Localizador';
+$lang['gen_hamradio_transmit_power'] = 'Potencia de transmisión (W)';
+$lang['gen_hamradio_propagation_mode'] = 'Modo de propagación';
+
+$lang['gen_hamradio_satellite_name'] = 'Nombre del Satélite';
+$lang['gen_hamradio_satellite_mode'] = 'Modo del Satélite';
+
+$lang['gen_hamradio_logbook'] = 'Logbook';
+
+$lang['gen_hamradio_cq_zone'] = 'Zona CQ';
+$lang['gen_hamradio_dxcc'] = 'DXCC';
+$lang['gen_hamradio_usa_state'] = 'Estado USA';
+$lang['gen_hamradio_iota_reference'] = 'Referencia IOTA';
+$lang['gen_hamradio_sota_reference'] = 'Referencia SOTA';
+$lang['gen_hamradio_dok'] = 'DOK';
+
+$lang['gen_hamradio_sig'] = 'Señal';
+$lang['gen_hamradio_sig_info'] = 'Información de señal';
+
+// Dashboard Words
+$lang['dashboard_you_have_had'] = 'Has tenido';
+$lang['dashboard_qsos_today'] = 'QSOs hoy!';
+$lang['dashboard_qso_breakdown'] = 'Desglose de QSO';
+$lang['dashboard_countries_breakdown'] = 'Desglose por Países';
+
+$lang['gen_from_date'] = 'Desde la fecha:';

--- a/application/language/spanish/imglib_lang.php
+++ b/application/language/spanish/imglib_lang.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['imglib_source_image_required'] = 'Debes especificar una imagen fuente en las preferencias.';
+$lang['imglib_gd_required'] = 'Se requiere la librería de imagen GD para esta característica.';
+$lang['imglib_gd_required_for_props'] = 'El servidor debe soportar la librería de imagen GD para determinar las propiedades de la imagen.';
+$lang['imglib_unsupported_imagecreate'] = 'El servidor no soporta la función de GD requerida para procesar este tipo de imagen.';
+$lang['imglib_gif_not_supported'] = 'Las imágenes GIF no suelen estar soportadas habitualmente a causa de restricciones de licencias. Puede que debas usar imágenes JPG o PNG en su lugar.';
+$lang['imglib_jpg_not_supported'] = 'Las imágenes JPG no están soportadas.';
+$lang['imglib_png_not_supported'] = 'Las imágenes PNG no están soportadas.';
+$lang['imglib_jpg_or_png_required'] = 'El protocolo de redimensión de imagen especificado en las preferencias solo funciona con imágenes JPEG o PNG.';
+$lang['imglib_copy_error'] = 'Se ha encontrado un error al intentar reemplazar el archivo. Por favor, asegúrate de que la carpeta es escribible.';
+$lang['imglib_rotate_unsupported'] = 'Parece que la rotación de imágenes no está soportada en el servidor.';
+$lang['imglib_libpath_invalid'] = 'La ruta a la librería de imagen no es correcta. Por favor, configura la ruta correcta en las preferencias de imagen.';
+$lang['imglib_image_process_failed'] = 'Ha fallado el tratamiento de la imagen. Por favor, verifica que el servidor soporta el protocolo elegido y que la ruta a la librería de imagen es correcta.';
+$lang['imglib_rotation_angle_required'] = 'Se requiere un ángulo de rotación para rotar la imagen.';
+$lang['imglib_invalid_path'] = 'La ruta a la imagen no es correcta.';
+$lang['imglib_invalid_image'] = 'La imagen especificada no es válida.';
+$lang['imglib_copy_failed'] = 'La rutina de copia de imagen ha fallado.';
+$lang['imglib_missing_font'] = 'No se ha podido encontrar una fuente para su uso.';
+$lang['imglib_save_failed'] = 'No se ha podido guardar la imagen. Por favor, asegúrate de que la imagen y la carpeta son escribibles.';

--- a/application/language/spanish/index.html
+++ b/application/language/spanish/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/application/language/spanish/lotw_lang.php
+++ b/application/language/spanish/lotw_lang.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('BASEPATH') OR exit('Acceso directo a los scripts restringido');
+defined('BASEPATH') OR exit('No direct script access allowed');
 
 $lang['lotw_title'] = 'Logbook of the World';
 $lang['lotw_title_available_cert'] = 'Certificados disponibles';

--- a/application/language/spanish/lotw_lang.php
+++ b/application/language/spanish/lotw_lang.php
@@ -1,0 +1,49 @@
+<?php
+
+defined('BASEPATH') OR exit('Acceso directo a los scripts restringido');
+
+$lang['lotw_title'] = 'Logbook of the World';
+$lang['lotw_title_available_cert'] = 'Certificados disponibles';
+$lang['lotw_title_information'] = 'Información';
+$lang['lotw_title_upload_p12_cert'] = 'Subir certificado LoTW .p12';
+$lang['lotw_title_export_p12_file_instruction'] = 'Instrucciones para exportar archivos .p12';
+$lang['lotw_title_adif_import'] = 'Importar ADIF (Formato de Intercambio de Datos Amateur)';
+$lang['lotw_title_adif_import_options'] = 'Opciones de importación';
+
+$lang['lotw_beta_warning'] = 'Por favor, tenga en cuenta que la sincronización con LoTW está en fase de pruebas. Visite la wiki del proyecto si necesita ayuda o quire saber más.';
+$lang['lotw_no_certs_uploaded'] = 'Es necesario subir algunos certificatos LoTW p12 para usar este área.';
+
+$lang['lotw_date_created'] = 'Fecha de creación';
+$lang['lotw_date_expires'] = 'Fecha de caducidad';
+$lang['lotw_status'] = 'Estado';
+$lang['lotw_options'] = 'Opciones';
+$lang['lotw_valid'] = 'Válido';
+$lang['lotw_expired'] = 'Caducado';
+$lang['lotw_not_synced'] = 'No sincronizado';
+
+$lang['lotw_certificate_dxcc'] = 'Certificado DXCC';
+$lang['lotw_certificate_dxcc_help_text'] = 'Entidad del certificado DXCC. Por ejemplo: Escocia';
+
+$lang['lotw_input_a_file'] = 'Subir un archivo';
+
+$lang['lotw_upload_exported_adif_file_from_lotw'] = 'Suba el archivo ADIF exportado en LoTW a través del área <a href="https://p1k.arrl.org/lotwuser/qsos?qsoscmd=adif" target="_blank">Download Report</a> para marcar QSOs como confirmados en LoTW.';
+$lang['lotw_upload_type_must_be_adi'] = 'Los archivos de registro deben ser del tipo .adi';
+
+$lang['lotw_pull_lotw_data_for_me'] = 'Extraer los datos LoTW por mí';
+$lang['lotw_import_missing_qsos_text'] = 'Importar los QSOs faltantes en el registro. El indicativo y el <i>gridsquare</i> serán comprobados a fin de encontrar el perfil correcto para importar el QSO. Si no fueran encontrados, el QSO será omitido.';
+
+$lang['lotw_report_download_overview_helptext'] ='Cloudlog usará el usuario y contraseña de LoTW guardado en su perfil para descargar un informe de LoTW por usted. El informe contendrá todas las confirmaciones desde la fecha elegida o desde su última confirmación LoTW hasta ahora.';
+
+// Buttons
+$lang['lotw_btn_lotw_import'] = 'Importar LoTW';
+$lang['lotw_btn_upload_certificate'] = 'Subir certificado';
+$lang['lotw_btn_delete'] = 'Borrar';
+$lang['lotw_btn_manual_sync'] = 'Sincronización manual';
+$lang['lotw_btn_upload_file'] = 'Subir archivo';
+$lang['lotw_btn_import_matches'] = 'Importar coincidencias LoTW';
+
+// P12 Export Text
+$lang['lotw_p12_export_step_one'] = 'Abrir TQSL e ir a la pestaña "Callsign Certificates".';
+$lang['lotw_p12_export_step_two'] = 'Clic derecho en el indicativo deseado.';
+$lang['lotw_p12_export_step_three'] = 'Clic en "Save Callsign Certificate File" sin añadir la contraseña.';
+$lang['lotw_p12_export_step_four'] = 'Subir aquí el archivo descargado.';

--- a/application/language/spanish/migration_lang.php
+++ b/application/language/spanish/migration_lang.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['migration_none_found']		= 'No se ha encontrado ninguna migración.';
+$lang['migration_not_found']		= 'No se ha encontrado ninguna migración con el número de versión: %s.';
+$lang['migration_sequence_gap']		= 'Hay un vacío en la migración, cerca del número de versión: %s.';
+$lang['migration_multiple_version']	= 'Hay múltiples migraciones con el mismo número de versión: %s.';
+$lang['migration_class_doesnt_exist']	= 'La clase de migración "%s" no ha podido ser encontrada.';
+$lang['migration_missing_up_method']	= 'A la clase de migración "%s" le falta el método "up".';
+$lang['migration_missing_down_method']	= 'A la clase de migración "%s" le falta el método "down".';
+$lang['migration_invalid_filename']	= 'La migración "%s" tiene un nombre de archivo no válido.';

--- a/application/language/spanish/notes_lang.php
+++ b/application/language/spanish/notes_lang.php
@@ -1,0 +1,23 @@
+<?php
+
+defined('BASEPATH') OR exit('Acceso directo a los scripts restringido');
+
+$lang['notes_menu_notes'] = 'Notas';
+$lang['notes_edit_note'] = 'Editar nota';
+$lang['notes_your_notes'] = 'Sus notas';
+
+$lang['notes_welcome'] = 'Actualmente no tiene notas, las cuales son un buen recurso para guardar datos e información general. Además, son mejores que el papel ya no las perderá con facilidad :)';
+
+$lang['notes_create_note'] = 'Crear nota';
+
+$lang['notes_input_title'] = 'Título';
+$lang['notes_input_category'] = 'Categoría';
+$lang['notes_input_notes_content'] = 'Contenido de la nota';
+$lang['notes_input_btn_save_note'] = 'Guardar nota';
+$lang['notes_input_btn_edit_note'] = 'Editar nota';
+$lang['notes_input_btn_delete_note'] = 'Borrar nota';
+
+$lang['notes_selection_general'] = 'General';
+$lang['notes_selection_antennas'] = 'Antenas';
+$lang['notes_selection_satellites'] = 'Satélites';
+

--- a/application/language/spanish/notes_lang.php
+++ b/application/language/spanish/notes_lang.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('BASEPATH') OR exit('Acceso directo a los scripts restringido');
+defined('BASEPATH') OR exit('No direct script access allowed');
 
 $lang['notes_menu_notes'] = 'Notas';
 $lang['notes_edit_note'] = 'Editar nota';

--- a/application/language/spanish/number_lang.php
+++ b/application/language/spanish/number_lang.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['terabyte_abbr'] = 'TB';
+$lang['gigabyte_abbr'] = 'GB';
+$lang['megabyte_abbr'] = 'MB';
+$lang['kilobyte_abbr'] = 'KB';
+$lang['bytes'] = 'Bytes';

--- a/application/language/spanish/pagination_lang.php
+++ b/application/language/spanish/pagination_lang.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['pagination_first_link']	= '&lsaquo; Primera';
+$lang['pagination_next_link']	= '&gt;';
+$lang['pagination_prev_link']	= '&lt;';
+$lang['pagination_last_link']	= 'Última &rsaquo;';

--- a/application/language/spanish/profiler_lang.php
+++ b/application/language/spanish/profiler_lang.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['profiler_database']		= 'BASE DE DATOS';
+$lang['profiler_controller_info'] = 'CLASE/MÉTODO';
+$lang['profiler_benchmarks']	= 'PUNTOS DE REFERENCIA';
+$lang['profiler_queries']		= 'CONSULTAS';
+$lang['profiler_get_data']		= 'DATOS GET';
+$lang['profiler_post_data']		= 'DATOS POST';
+$lang['profiler_uri_string']	= 'CADENA URI';
+$lang['profiler_memory_usage']	= 'USO DE MEMORIA';
+$lang['profiler_config']		= 'VARIABLES DE CONFIGURACIÓN';
+$lang['profiler_session_data']	= 'DATOS DE SESIÓN';
+$lang['profiler_headers']		= 'CABECERAS HTTP';
+$lang['profiler_no_db']			= 'El driver de la base de datos no está cargado actualmente';
+$lang['profiler_no_queries']	= 'No hubo ninguna consulta';
+$lang['profiler_no_post']		= 'No hay ningún dato POST';
+$lang['profiler_no_get']		= 'No hay ningún dato GET';
+$lang['profiler_no_uri']		= 'No hay ningún dato de la URI';
+$lang['profiler_no_memory']		= 'Uso de memoria no disponible';
+$lang['profiler_no_profiles']	= 'No hay datos del perfilador - todas las secciones han sido deshabilitadas.';
+$lang['profiler_section_hide']	= 'Ocultar';
+$lang['profiler_section_show']	= 'Mostrar';
+$lang['profiler_seconds']		= 'segundos';

--- a/application/language/spanish/qslcard_lang.php
+++ b/application/language/spanish/qslcard_lang.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('BASEPATH') OR exit('Acceso directo a los scripts restringido');
+defined('BASEPATH') OR exit('No direct script access allowed');
 
 // Tiles
 $lang['qslcard_string_your_are_using'] = 'Está usando';

--- a/application/language/spanish/qslcard_lang.php
+++ b/application/language/spanish/qslcard_lang.php
@@ -1,0 +1,7 @@
+<?php
+
+defined('BASEPATH') OR exit('Acceso directo a los scripts restringido');
+
+// Tiles
+$lang['qslcard_string_your_are_using'] = 'Está usando';
+$lang['qslcard_string_disk_space'] = 'de espacio en disco para almacenar recursos relacionados con las tarjetas QSL';

--- a/application/language/spanish/qso_lang.php
+++ b/application/language/spanish/qso_lang.php
@@ -1,0 +1,25 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+// Tiles
+$lang['qso_title_qso_map'] = 'Mapa de QSO';
+$lang['qso_title_suggestions'] = 'Sugerencias';
+$lang['qso_title_pervious_contacts'] = 'Contactos previos';
+
+// Input Help Text on the /QSO Display
+$lang['qso_transmit_power_helptext'] = 'Especifique el valor de potencia en Watios (W). Incluya solo números.';
+
+$lang['qso_sota_ref_helptext'] = 'Por ejemplo: GM/NS-001.';
+
+$lang['qso_sig_helptext'] = 'Por ejemplo: WWFF or POTA';
+$lang['qso_sig_info_helptext'] = 'Por ejemplo: DLFF-0029';
+
+$lang['qso_dok_helptext'] = 'Por ejemplo: Q03';
+
+$lang['qso_notes_helptext'] = 'El contenido es usado solo dentro de Cloudlog y no es exportado a otros servicios.';
+
+// Button Text on /qso Display
+
+$lang['qso_btn_reset_qso'] = 'Resetear';
+$lang['qso_btn_save_qso'] = 'Guardar QSO';

--- a/application/language/spanish/unit_test_lang.php
+++ b/application/language/spanish/unit_test_lang.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['ut_test_name']		= 'Nombre del test';
+$lang['ut_test_datatype']	= 'Tipo de datos del test';
+$lang['ut_res_datatype']	= 'Tipo de datos esperado';
+$lang['ut_result']			= 'Resultado';
+$lang['ut_undefined']		= 'Nombre del test indefinido';
+$lang['ut_file']			= 'Nombre del archivo';
+$lang['ut_line']			= 'Número de línea';
+$lang['ut_passed']			= 'Correcto';
+$lang['ut_failed']			= 'Fallido';
+$lang['ut_boolean']			= 'Booleano';
+$lang['ut_integer']			= 'Entero';
+$lang['ut_float']			= 'Coma flotante';
+$lang['ut_double']			= 'Coma flotante'; // can be the same as float
+$lang['ut_string']			= 'Cadena';
+$lang['ut_array']			= 'Array';
+$lang['ut_object']			= 'Objeto';
+$lang['ut_resource']		= 'Recurso';
+$lang['ut_null']			= 'Nulo';
+$lang['ut_notes']			= 'Notas';

--- a/application/language/spanish/upload_lang.php
+++ b/application/language/spanish/upload_lang.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * System messages translation for CodeIgniter(tm)
+ *
+ * @author	CodeIgniter community
+ * @author	Iban Eguia
+ * @copyright	Copyright (c) 2014-2019, British Columbia Institute of Technology (https://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+$lang['upload_userfile_not_set'] = 'No ha sido posible encontrar una variable post llamada userfile.';
+$lang['upload_file_exceeds_limit'] = 'El archivo subido excede el tamaño máximo permitido por tu configuración de PHP.';
+$lang['upload_file_exceeds_form_limit'] = 'El archivo subido excede el tamaño máximo permitido por el formulario.';
+$lang['upload_file_partial'] = 'El archivo solo se subió parcialmente.';
+$lang['upload_no_temp_directory'] = 'No se encuentra el directorio temporal.';
+$lang['upload_unable_to_write_file'] = 'El archivo no pudo ser escrito en el disco.';
+$lang['upload_stopped_by_extension'] = 'La subida del archivo paró por extensión.';
+$lang['upload_no_file_selected'] = 'No seleccionaste un archivo para subir.';
+$lang['upload_invalid_filetype'] = 'El tipo de archivo que intentas subir no está permitido.';
+$lang['upload_invalid_filesize'] = 'El archivo que intentas subir es más grande que el tamaño permitido.';
+$lang['upload_invalid_dimensions'] = 'La imagen que intentas subir no encaja en las dimensiones permitidas.';
+$lang['upload_destination_error'] = 'Se encontró un problema al intentar mover el archivo subido a su destino final.';
+$lang['upload_no_filepath'] = 'La ruta de subida no parece válida.';
+$lang['upload_no_file_types'] = 'No has especificado ningún tipo de archivo permitido.';
+$lang['upload_bad_filename'] = 'El nombre de archivo que has proporcionado ya existe en el servidor.';
+$lang['upload_not_writable'] = 'La carpeta de destino de la subida no parece escribible.';


### PR DESCRIPTION
Translate the available language files to Spanish.

Note that, as recommended in https://github.com/bcit-ci/codeigniter3-translations , the system language files were placed into the application/language folder instead of the system/language folder,  although the other language translations were put there.

Let me know if you rather place them in the system folder.