### PR TITLE
Fix QSO form labels

### DIFF
--- a/application/views/qso/edit.php
+++ b/application/views/qso/edit.php
@@ -52,12 +52,12 @@
 			<div class="tab-pane fade show active" id="nav-qso" role="tabpanel" aria-labelledby="nav-qso-tab">
                 <div class="form-row">
                     <div class="form-group col-sm-6">
-                      <label for="start_date">Start Date/Time</label>
+                      <label for="time_on">Start Date/Time</label>
                       <input type="text" class="form-control form-control-sm input_date" name="time_on" id="time_on" value="<?php echo $qso->COL_TIME_ON; ?>">
                     </div>
 
                     <div class="form-group col-sm-6">
-                      <label for="start_time">End Date/Time</label>
+                      <label for="time_off">End Date/Time</label>
                       <input type="text" class="form-control form-control-sm input_time" name="time_off" id="time_off" value="<?php echo $qso->COL_TIME_OFF; ?>">
                     </div>
                 </div>
@@ -80,7 +80,7 @@
 	            
                 <div class="form-row">
                     <div class="form-group col-sm-6">
-                        <label for="freq">Mode</label>
+                        <label for="mode">Mode</label>
                             <select id="mode" class="form-control mode form-control-sm" name="mode">
                   <?php
                       foreach($modes->result() as $mode){
@@ -104,7 +104,7 @@
             </div>
 
                     <div class="form-group col-sm-6">
-                        <label for="freq">Band</label>
+                        <label for="band">Band</label>
                         <select id="band" class="form-control form-control-sm" name="band">
                             <optgroup label="HF">
                                 <option value="160m" <?php if(strtolower($qso->COL_BAND == "160m")) { echo "selected=\"selected\""; } ?>>160m</option>
@@ -270,7 +270,7 @@
 
 
 				<div class="form-group">
-	            	<label for="usa_state">USA State</label>
+	            	<label for="input_usa_state">USA State</label>
                     <select class="custom-select" id="input_usa_state" name="usa_state">
                         <option value=""></option>
                         <option value="AL" <?php if($qso->COL_STATE == "AL") { echo "selected=\"selected\""; } ?>>Alabama (AL)</option>
@@ -390,9 +390,9 @@
 				<div class="tab-content" id="myTabContent">
 				  <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
 				            <div class="form-group row">
-				              <label for="sent" class="col-sm-3 col-form-label">Sent</label>
+				              <label for="qsl_sent" class="col-sm-3 col-form-label">Sent</label>
 				              <div class="col-sm-9">
-				                <select class="custom-select" name="qsl_sent">
+				                <select class="custom-select" id="qsl_sent" name="qsl_sent">
 				          <option value="N" <?php if($qso->COL_QSL_SENT == "N") { echo "selected=\"selected\""; } ?>>No</option>
 				          <option value="Y" <?php if($qso->COL_QSL_SENT == "Y") { echo "selected=\"selected\""; } ?>>Yes</option>
 				          <option value="R" <?php if($qso->COL_QSL_SENT == "R") { echo "selected=\"selected\""; } ?>>Requested</option>
@@ -403,9 +403,9 @@
 				            </div>
 
 				            <div class="form-group row">
-				              <label for="sent-method" class="col-sm-3 col-form-label">Sent Method</label>
+				              <label for="qsl_sent_method" class="col-sm-3 col-form-label">Sent Method</label>
 				              <div class="col-sm-9">
-				                <select class="custom-select" name="qsl_sent_method">
+				                <select class="custom-select" id="qsl_sent_method" name="qsl_sent_method">
 				          <option value="" <?php if($qso->COL_QSL_SENT_VIA == "") { echo "selected=\"selected\""; } ?>>Method</option>
 				          <option value="D" <?php if($qso->COL_QSL_SENT_VIA == "D") { echo "selected=\"selected\""; } ?>>Direct</option>
 				          <option value="B" <?php if($qso->COL_QSL_SENT_VIA == "B") { echo "selected=\"selected\""; } ?>>Bureau</option>
@@ -423,9 +423,9 @@
 				            </div>
 
 				            <div class="form-group row">
-				              <label for="sent-method" class="col-sm-3 col-form-label">Received</label>
+				              <label for="qsl_recv" class="col-sm-3 col-form-label">Received</label>
 				              <div class="col-sm-9">
-				                <select class="custom-select" name="qsl_recv">
+				                <select class="custom-select" id="qsl_recv" name="qsl_recv">
 				          <option value="N" <?php if($qso->COL_QSL_RCVD == "N") { echo "selected=\"selected\""; } ?>>No</option>
 				          <option value="Y" <?php if($qso->COL_QSL_RCVD == "Y") { echo "selected=\"selected\""; } ?>>Yes</option>
 				          <option value="R" <?php if($qso->COL_QSL_RCVD == "R") { echo "selected=\"selected\""; } ?>>Requested</option>
@@ -436,9 +436,9 @@
 				            </div>
 
 				            <div class="form-group row">
-				              <label for="sent-method" class="col-sm-3 col-form-label">Received Method</label>
+				              <label for="qsl_recv_method" class="col-sm-3 col-form-label">Received Method</label>
 				              <div class="col-sm-9">
-				                <select class="custom-select" name="qsl_recv_method">
+				                <select class="custom-select" id="qsl_recv_method" name="qsl_recv_method">
 				          <option value="" <?php if($qso->COL_QSL_RCVD_VIA == "") { echo "selected=\"selected\""; } ?>>Method</option>
 				          <option value="D" <?php if($qso->COL_QSL_RCVD_VIA == "D") { echo "selected=\"selected\""; } ?>>Direct</option>
 				          <option value="B" <?php if($qso->COL_QSL_RCVD_VIA == "B") { echo "selected=\"selected\""; } ?>>Bureau</option>
@@ -451,9 +451,9 @@
 
 				  <div class="tab-pane fade" id="profile" role="tabpanel" aria-labelledby="profile-tab">
 				            <div class="form-group row">
-				              <label for="sent" class="col-sm-3 col-form-label">Sent</label>
+				              <label for="eqsl_sent" class="col-sm-3 col-form-label">Sent</label>
 				              <div class="col-sm-9">
-				              <select class="custom-select" name="eqsl_sent">
+				              <select class="custom-select" id="eqsl_sent" name="eqsl_sent">
 				            <option value="N" <?php if($qso->COL_EQSL_QSL_SENT == "N") { echo "selected=\"selected\""; } ?>>No</option>
 				            <option value="Y" <?php if($qso->COL_EQSL_QSL_SENT == "Y") { echo "selected=\"selected\""; } ?>>Yes</option>
 				            <option value="R" <?php if($qso->COL_EQSL_QSL_SENT == "R") { echo "selected=\"selected\""; } ?>>Requested</option>
@@ -464,9 +464,9 @@
 				            </div>
 
 				            <div class="form-group row">
-				              <label for="sent" class="col-sm-3 col-form-label">Received</label>
+				              <label for="eqsl_recv" class="col-sm-3 col-form-label">Received</label>
 				              <div class="col-sm-9">
-				              <select class="custom-select" name="eqsl_recv">
+				              <select class="custom-select" id="eqsl_recv" name="eqsl_recv">
 				            <option value="N" <?php if($qso->COL_EQSL_QSL_RCVD == "N") { echo "selected=\"selected\""; } ?>>No</option>
 				            <option value="Y" <?php if($qso->COL_EQSL_QSL_RCVD == "Y") { echo "selected=\"selected\""; } ?>>Yes</option>
 				            <option value="R" <?php if($qso->COL_EQSL_QSL_RCVD == "R") { echo "selected=\"selected\""; } ?>>Requested</option>
@@ -477,9 +477,9 @@
 				  </div>
 				  <div class="tab-pane fade" id="contact" role="tabpanel" aria-labelledby="contact-tab">
 				            <div class="form-group row">
-				              <label for="sent" class="col-sm-3 col-form-label">Sent</label>
+				              <label for="lotw_sent" class="col-sm-3 col-form-label">Sent</label>
 				              <div class="col-sm-9">
-				              <select class="custom-select" name="lotw_sent">
+				              <select class="custom-select" id="lotw_sent" name="lotw_sent">
 				            <option value="N" <?php if($qso->COL_LOTW_QSL_SENT == "N") { echo "selected=\"selected\""; } ?>>No</option>
 				            <option value="Y" <?php if($qso->COL_LOTW_QSL_SENT == "Y") { echo "selected=\"selected\""; } ?>>Yes</option>
 				            <option value="R" <?php if($qso->COL_LOTW_QSL_SENT == "R") { echo "selected=\"selected\""; } ?>>Requested</option>
@@ -489,9 +489,9 @@
 				            </div>
 
 				            <div class="form-group row">
-				              <label for="sent" class="col-sm-3 col-form-label">Received</label>
+				              <label for="lotw_recv" class="col-sm-3 col-form-label">Received</label>
 				              <div class="col-sm-9">
-				              <select class="custom-select" name="lotw_recv">
+				              <select class="custom-select" id="lotw_recv" name="lotw_recv">
 				            <option value="N" <?php if($qso->COL_LOTW_QSL_RCVD == "N") { echo "selected=\"selected\""; } ?>>No</option>
 				            <option value="Y" <?php if($qso->COL_LOTW_QSL_RCVD == "Y") { echo "selected=\"selected\""; } ?>>Yes</option>
 				            <option value="R" <?php if($qso->COL_LOTW_QSL_RCVD == "R") { echo "selected=\"selected\""; } ?>>Requested</option>
@@ -514,7 +514,7 @@
 		 ?>
 
 	            <div class="form-group">
-	              <label for="inputStationProfile">Change Station Profile</label>
+	              <label for="stationProfile">Change Station Profile</label>
 	              <select id="stationProfile" class="custom-select" name="station_profile">
 	                <?php foreach ($my_stations->result() as $stationrow) { ?>
 	                <option value="<?php echo $stationrow->station_id; ?>" <?php if($qso->station_id == $stationrow->station_id) { echo "selected=\"selected\""; } ?>><?php echo $stationrow->station_profile_name; ?></option>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -26,7 +26,7 @@
           </li>
           
           <li class="nav-item">
-            <a class="nav-link" id="notes-tab" data-toggle="tab" href="#notes" role="tab" aria-controls="notes" aria-selected="false"><?php echo $this->lang->line('general_word_notes'); ?></a>
+            <a class="nav-link" id="notes-tab" data-toggle="tab" href="#nav-notes" role="tab" aria-controls="notes" aria-selected="false"><?php echo $this->lang->line('general_word_notes'); ?></a>
           </li>
 
           <li class="nav-item">
@@ -406,7 +406,7 @@
           </div>
           
           <!-- Notes Panel Contents -->
-          <div class="tab-pane fade" id="notes" role="tabpanel" aria-labelledby="notes-tab">
+          <div class="tab-pane fade" id="nav-notes" role="tabpanel" aria-labelledby="notes-tab">
             <div class="alert alert-info" role="alert">
               <span class="badge badge-info"><?php echo $this->lang->line('general_word_info'); ?></span> <?php echo $this->lang->line('qso_notes_helptext'); ?>
             </div>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -166,7 +166,7 @@
           <!-- Station Panel Data -->
           <div class="tab-pane fade" id="station" role="tabpanel" aria-labelledby="station-tab">
             <div class="form-group">
-              <label for="inputStationProfile"><?php echo $this->lang->line('cloudlog_station_profile'); ?></label>
+              <label for="stationProfile"><?php echo $this->lang->line('cloudlog_station_profile'); ?></label>
               <select id="stationProfile" class="custom-select" name="station_profile">
                 <?php foreach ($stations->result() as $stationrow) { ?>
                 <option value="<?php echo $stationrow->station_id; ?>" <?php if($active_station_profile == $stationrow->station_id) { echo "selected=\"selected\""; } ?>><?php echo $stationrow->station_profile_name; ?></option>
@@ -175,7 +175,7 @@
             </div>
 
             <div class="form-group">
-              <label for="inputRadio"><?php echo $this->lang->line('gen_hamradio_radio'); ?></label>
+              <label for="radio"><?php echo $this->lang->line('gen_hamradio_radio'); ?></label>
               <select class="custom-select radios" id="radio" name="radio">
                 <option value="0" selected="selected"><?php echo $this->lang->line('general_word_none'); ?></option>
                 <?php foreach ($radios->result() as $row) { ?>
@@ -195,7 +195,7 @@
             </div>
 
             <div class="form-group">
-                  <label for="band"><?php echo $this->lang->line('gen_hamradio_band_rx'); ?></label>
+                  <label for="band_rx"><?php echo $this->lang->line('gen_hamradio_band_rx'); ?></label>
 
                   <select id="band_rx" class="form-control" name="band_rx">
                     <option value="" <?php if($this->session->userdata('band_rx') == "") { echo "selected=\"selected\""; } ?>></option>           
@@ -290,7 +290,7 @@
             </div>
 
             <div class="form-group">
-              <label for="usa_state"><?php echo $this->lang->line('gen_hamradio_usa_state'); ?></label>
+              <label for="input_usa_state"><?php echo $this->lang->line('gen_hamradio_usa_state'); ?></label>
               <select class="custom-select" id="input_usa_state" name="usa_state">
                 <option value=""></option>
                 <option value="AL">Alabama (AL)</option>
@@ -380,7 +380,7 @@
             </div>
 
             <div class="form-group">
-              <label for="sota_ref"><?php echo $this->lang->line('gen_hamradio_dok'); ?></label>
+              <label for="darc_dok"><?php echo $this->lang->line('gen_hamradio_dok'); ?></label>
               <input class="form-control" id="darc_dok" type="text" name="darc_dok" value="" />
               <small id="dokHelp" class="form-text text-muted"><?php echo $this->lang->line('qso_dok_helptext'); ?></small>
             </div>
@@ -389,7 +389,7 @@
           <!-- Satellite Panel -->
           <div class="tab-pane fade" id="satellite" role="tabpanel" aria-labelledby="satellite-tab">
             <div class="form-group">
-              <label for="inputSatName"><?php echo $this->lang->line('gen_hamradio_satellite_name'); ?></label>
+              <label for="sat_name"><?php echo $this->lang->line('gen_hamradio_satellite_name'); ?></label>
 
               <input list="satellite_names" id="sat_name" type="text" name="sat_name" class="form-control" value="<?php echo $this->session->userdata('sat_name'); ?>">
 
@@ -397,7 +397,7 @@
             </div>
 
             <div class="form-group">
-              <label for="inputSatMode"><?php echo $this->lang->line('gen_hamradio_satellite_mode'); ?></label>
+              <label for="sat_mode"><?php echo $this->lang->line('gen_hamradio_satellite_mode'); ?></label>
 
               <input list="satellite_modes" id="sat_mode" type="text" name="sat_mode" class="form-control" value="<?php echo $this->session->userdata('sat_mode'); ?>">
 


### PR DESCRIPTION
While testing Spanish translations #825 , I realized a lot of labels were wrong.

I fixed all of the form labels from QSO 'index' and 'edit' views. When I finished the edit view, I noticed the edit_ajax is almost identical but it has also wrong label `for` properties