### PR TITLE
Add support for QSO Detail translations

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -3,6 +3,18 @@
 
 class Logbook extends CI_Controller {
 
+	function __construct()
+	{
+		parent::__construct();
+
+		// Load language files
+		$this->lang->load(array(
+			'qslcard',
+			'lotw',
+			'qso'
+		));
+	}
+
 	function index()
 	{
 				$this->load->model('user_model');

--- a/application/language/english/general_words_lang.php
+++ b/application/language/english/general_words_lang.php
@@ -12,6 +12,7 @@ $lang['general_word_choose_file'] = 'Choose file';
 
 $lang['general_word_date'] = 'Date';
 $lang['general_word_time'] = 'Time';
+$lang['general_word_datetime'] = 'Date/Time';
 $lang['general_word_none'] = 'None';
 $lang['general_word_name'] = 'Name';
 $lang['general_word_location'] = 'Location';
@@ -37,6 +38,8 @@ $lang['general_word_method'] = 'Method';
 $lang['general_word_sent'] = 'Sent';
 $lang['general_word_received'] = 'Received';
 $lang['general_word_requested'] = 'Requested';
+$lang['general_word_qslcard'] = 'QSL Card';
+$lang['general_word_qslcard_management'] = 'QSL Management';
 $lang['general_word_qslcards'] = 'QSL Cards';
 $lang['general_word_qslcard_direct'] = 'Direct';
 $lang['general_word_qslcard_bureau'] = 'Bureau';
@@ -47,6 +50,8 @@ $lang['general_mark_qsl_rx_bureau'] = 'Mark QSL Received (Bureau)';
 $lang['general_mark_qsl_rx_direct'] = 'Mark QSL Received (Direct)';
 
 $lang['general_delete_qso'] = 'Delete QSO';
+
+$lang['general_total_distance'] = 'Total Distance';
 
 // Cloudlog Terms
 $lang['cloudlog_station_profile'] = 'Station Profile';

--- a/application/language/english/lotw_lang.php
+++ b/application/language/english/lotw_lang.php
@@ -2,6 +2,7 @@
 
 defined('BASEPATH') OR exit('No direct script access allowed');
 
+$lang['lotw_short'] = 'LoTW';
 $lang['lotw_title'] = 'Logbook of the World';
 $lang['lotw_title_available_cert'] = 'Available Certificates';
 $lang['lotw_title_information'] = 'Information';
@@ -47,3 +48,5 @@ $lang['lotw_p12_export_step_one'] = 'Open TQSL &amp; go to the Callsign Certific
 $lang['lotw_p12_export_step_two'] = 'Right click on desired Callsign';
 $lang['lotw_p12_export_step_three'] = 'Click "Save Callsign Certificate File" and do not add a password';
 $lang['lotw_p12_export_step_four'] = 'Upload File below.';
+
+$lang['lotw_confirmed'] = 'This QSO is confirmed on LoTW';

--- a/application/language/english/qslcard_lang.php
+++ b/application/language/english/qslcard_lang.php
@@ -5,3 +5,14 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 // Tiles
 $lang['qslcard_string_your_are_using'] = 'You are using';
 $lang['qslcard_string_disk_space'] = 'of disk space to store QSL Card assets';
+
+$lang['qslcard_info'] = 'QSL Info';
+$lang['qslcard_sent_bureau'] = 'QSL Card has been sent via the bureau';
+$lang['qslcard_sent_direct'] = 'QSL Card has been sent via direct';
+$lang['qslcard_recv_bureau'] = 'QSL Card has been received via the bureau';
+$lang['qslcard_recv_direct'] = 'QSL Card has been received via direct';
+
+$lang['qslcard_upload_front'] = 'Uploaded QSL Card front image';
+$lang['qslcard_upload_back'] = 'Uploaded QSL Card back image';
+
+$lang['qslcard_upload_button'] = 'Upload QSL Card image';

--- a/application/language/english/qso_lang.php
+++ b/application/language/english/qso_lang.php
@@ -23,6 +23,7 @@ $lang['qso_notes_helptext'] = 'Note content is used within Cloudlog only and is 
 
 $lang['qso_btn_reset_qso'] = 'Reset';
 $lang['qso_btn_save_qso'] = 'Save QSO';
+$lang['qso_btn_edit_qso'] = 'Edit QSO';
 
 // QSO Details
 

--- a/application/language/english/qso_lang.php
+++ b/application/language/english/qso_lang.php
@@ -23,3 +23,7 @@ $lang['qso_notes_helptext'] = 'Note content is used within Cloudlog only and is 
 
 $lang['qso_btn_reset_qso'] = 'Reset';
 $lang['qso_btn_save_qso'] = 'Save QSO';
+
+// QSO Details
+
+$lang['qso_details'] = 'QSO Details';

--- a/application/language/spanish/general_words_lang.php
+++ b/application/language/spanish/general_words_lang.php
@@ -12,6 +12,7 @@ $lang['general_word_choose_file'] = 'Elegir archivo';
 
 $lang['general_word_date'] = 'Fecha';
 $lang['general_word_time'] = 'Hora';
+$lang['general_word_datetime'] = 'Fecha/Hora';
 $lang['general_word_none'] = 'Ninguno';
 $lang['general_word_name'] = 'Nombre';
 $lang['general_word_location'] = 'Localización';
@@ -37,6 +38,8 @@ $lang['general_word_method'] = 'Método';
 $lang['general_word_sent'] = 'Enviado';
 $lang['general_word_received'] = 'Recibido';
 $lang['general_word_requested'] = 'Solicitadas';
+$lang['general_word_qslcard'] = 'Tarjeta QSL';
+$lang['general_word_qslcard_management'] = 'Gestión de QSL';
 $lang['general_word_qslcards'] = 'Tarjetas QSL';
 $lang['general_word_qslcard_direct'] = 'Directo';
 $lang['general_word_qslcard_bureau'] = 'Buró';
@@ -47,6 +50,8 @@ $lang['general_mark_qsl_rx_bureau'] = 'Marcar QSL Recibida (Buró)';
 $lang['general_mark_qsl_rx_direct'] = 'Marcar QSL Recibida (Directa)';
 
 $lang['general_delete_qso'] = 'Eliminar QSO';
+
+$lang['general_total_distance'] = 'Distancia total';
 
 // Cloudlog Terms
 $lang['cloudlog_station_profile'] = 'Perfil de estación';

--- a/application/language/spanish/lotw_lang.php
+++ b/application/language/spanish/lotw_lang.php
@@ -2,6 +2,7 @@
 
 defined('BASEPATH') OR exit('No direct script access allowed');
 
+$lang['lotw_short'] = 'LoTW';
 $lang['lotw_title'] = 'Logbook of the World';
 $lang['lotw_title_available_cert'] = 'Certificados disponibles';
 $lang['lotw_title_information'] = 'Información';
@@ -47,3 +48,5 @@ $lang['lotw_p12_export_step_one'] = 'Abrir TQSL e ir a la pestaña "Callsign Cer
 $lang['lotw_p12_export_step_two'] = 'Clic derecho en el indicativo deseado.';
 $lang['lotw_p12_export_step_three'] = 'Clic en "Save Callsign Certificate File" sin añadir la contraseña.';
 $lang['lotw_p12_export_step_four'] = 'Subir aquí el archivo descargado.';
+
+$lang['lotw_confirmed'] = 'Este QSO está confirmado en LoTW';

--- a/application/language/spanish/qslcard_lang.php
+++ b/application/language/spanish/qslcard_lang.php
@@ -5,3 +5,14 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 // Tiles
 $lang['qslcard_string_your_are_using'] = 'Está usando';
 $lang['qslcard_string_disk_space'] = 'de espacio en disco para almacenar recursos relacionados con las tarjetas QSL';
+
+$lang['qslcard_info'] = 'QSL info';
+$lang['qslcard_sent_bureau'] = 'La QSL se envió vía buró';
+$lang['qslcard_sent_direct'] = 'La QSL se envió via directa';
+$lang['qslcard_recv_bureau'] = 'La QSL se recibió via buró';
+$lang['qslcard_recv_direct'] = 'La QSL se recibió vía directa';
+
+$lang['qslcard_upload_front'] = 'Imagen delantera de la QSL subida';
+$lang['qslcard_upload_back'] = 'Imagen trasera de la QSL subida';
+
+$lang['qslcard_upload_button'] = 'Subir QSL';

--- a/application/language/spanish/qso_lang.php
+++ b/application/language/spanish/qso_lang.php
@@ -23,3 +23,7 @@ $lang['qso_notes_helptext'] = 'El contenido es usado solo dentro de Cloudlog y n
 
 $lang['qso_btn_reset_qso'] = 'Resetear';
 $lang['qso_btn_save_qso'] = 'Guardar QSO';
+
+// QSO Details
+
+$lang['qso_details'] = 'Detalles de QSO';

--- a/application/language/spanish/qso_lang.php
+++ b/application/language/spanish/qso_lang.php
@@ -23,6 +23,7 @@ $lang['qso_notes_helptext'] = 'El contenido es usado solo dentro de Cloudlog y n
 
 $lang['qso_btn_reset_qso'] = 'Resetear';
 $lang['qso_btn_save_qso'] = 'Guardar QSO';
+$lang['qso_btn_edit_qso'] = 'Editar QSO';
 
 // QSO Details
 

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -3,10 +3,10 @@
 
     <ul class="nav nav-tabs" id="myTab" role="tablist">
         <li class="nav-item">
-            <a class="nav-link active" id="table-tab" data-toggle="tab" href="#qsodetails" role="tab" aria-controls="table" aria-selected="true">QSO Details</a>
+            <a class="nav-link active" id="table-tab" data-toggle="tab" href="#qsodetails" role="tab" aria-controls="table" aria-selected="true"><?php echo $this->lang->line('qso_details'); ?></a>
         </li>
         <li class="nav-item">
-            <a id="station-tab" class="nav-link" data-toggle="tab" href="#stationdetails" role="tab" aria-controls="table" aria-selected="true">Station Details</a>
+            <a id="station-tab" class="nav-link" data-toggle="tab" href="#stationdetails" role="tab" aria-controls="table" aria-selected="true"><?php echo $this->lang->line('cloudlog_station_profile'); ?></a>
         </li>
         <?php
         if (($this->config->item('use_auth')) && ($this->session->userdata('user_type') >= 2)) {
@@ -16,11 +16,11 @@
                 echo 'hidden ';
             }
                 echo 'class="qslcardtab nav-item">
-                <a class="nav-link" id="qsltab" data-toggle="tab" href="#qslcard" role="tab" aria-controls="home" aria-selected="false">QSL Card</a>
+                <a class="nav-link" id="qsltab" data-toggle="tab" href="#qslcard" role="tab" aria-controls="home" aria-selected="false">'. $this->lang->line('general_words_qslcard') .'</a>
                 </li>';
 
             echo '<li class="nav-item">
-            <a class="nav-link" id="qslmanagementtab" data-toggle="tab" href="#qslupload" role="tab" aria-controls="home" aria-selected="false">QSL Card Management</a>
+            <a class="nav-link" id="qslmanagementtab" data-toggle="tab" href="#qslupload" role="tab" aria-controls="home" aria-selected="false">'. $this->lang->line('general_words_qslcard_management') .'</a>
             </li>';
         }
 
@@ -49,7 +49,7 @@
 
                         ?>
 
-                        <td>Date/Time:</td>
+                        <td><?php echo $this->lang->line('general_word_datetime'); ?></td>
                         <?php if(($this->config->item('use_auth') && ($this->session->userdata('user_type') >= 2)) || $this->config->item('use_auth') === FALSE || ($this->config->item('show_time'))) { ?>
                         <td><?php $timestamp = strtotime($row->COL_TIME_ON); echo date($custom_date_format, $timestamp); $timestamp = strtotime($row->COL_TIME_ON); echo " at ".date('H:i', $timestamp); ?></td>
                         <?php } else { ?>
@@ -58,39 +58,39 @@
                     </tr>
 
                     <tr>
-                        <td>Callsign:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_callsign'); ?></td>
                         <td><b><?php echo str_replace("0","&Oslash;",strtoupper($row->COL_CALL)); ?></b></td>
                     </tr>
 
                     <tr>
-                        <td>Band:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_band'); ?></td>
                         <td><?php echo $row->COL_BAND; ?></td>
                     </tr>
 
                     <?php if($this->config->item('display_freq') == true) { ?>
                     <tr>
-                        <td>Freq:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_frequency'); ?></td>
                         <td><?php echo frequency_display_string($row->COL_FREQ); ?></td>
                     </tr>
                     <?php if($row->COL_FREQ_RX != 0) { ?>
                     <tr>
-                        <td>Freq (RX):</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_frequency_rx'); ?></td>
                         <td><?php echo frequency_display_string($row->COL_FREQ_RX); ?></td>
                     </tr>
                     <?php }} ?>
 
                     <tr>
-                        <td>Mode:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_mode'); ?></td>
                         <td><?php echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE; ?></td>
                     </tr>
 
                     <tr>
-                        <td>RST Sent:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_rsts'); ?></td>
                         <td><?php echo $row->COL_RST_SENT; ?> <?php if ($row->COL_STX) { ?>(<?php echo $row->COL_STX;?>)<?php } ?> <?php if ($row->COL_STX_STRING) { ?>(<?php echo $row->COL_STX_STRING;?>)<?php } ?></td>
                     </tr>
 
                     <tr>
-                        <td>RST Recv'd:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_rstr'); ?></td>
                         <td><?php echo $row->COL_RST_RCVD; ?> <?php if ($row->COL_SRX) { ?>(<?php echo $row->COL_SRX;?>)<?php } ?> <?php if ($row->COL_SRX_STRING) { ?>(<?php echo $row->COL_SRX_STRING;?>)<?php } ?></td>
                     </tr>
 
@@ -104,7 +104,7 @@
                     <?php if($row->COL_GRIDSQUARE != null) { ?>
                     <!-- Total Distance Between the Station Profile Gridsquare and Logged Square -->
                     <tr>
-                        <td>Total Distance</td>
+                        <td><?php echo $this->lang->line('general_total_distance'); //Total distance ?></td>
                         <td>
                             <?php
                                 // Load the QRA Library
@@ -153,7 +153,7 @@
 
                     <?php if($row->COL_NAME != null) { ?>
                     <tr>
-                        <td>Name:</td>
+                        <td><?php echo $this->lang->line('general_word_name'); ?></td>
                         <td><?php echo $row->COL_NAME; ?></td>
                     </tr>
                     <?php } ?>
@@ -161,7 +161,7 @@
                     <?php if(($this->config->item('use_auth') && ($this->session->userdata('user_type') >= 2)) || $this->config->item('use_auth') === FALSE) { ?>
                     <?php if($row->COL_COMMENT != null) { ?>
                     <tr>
-                        <td>Comment:</td>
+                        <td><?php echo $this->lang->line('general_word_comment'); ?></td>
                         <td><?php echo $row->COL_COMMENT; ?></td>
                     </tr>
                     <?php } ?>
@@ -169,88 +169,88 @@
 
                     <?php if($row->COL_SAT_NAME != null) { ?>
                     <tr>
-                        <td>Sat Name:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_satellite_name'); ?></td>
                         <td><?php echo $row->COL_SAT_NAME; ?></td>
                     </tr>
                     <?php } ?>
 
                     <?php if($row->COL_SAT_MODE != null) { ?>
                     <tr>
-                        <td>Sat Mode:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_satellite_mode'); ?></td>
                         <td><?php echo $row->COL_SAT_MODE; ?></td>
                     </tr>
                     <?php } ?>
                     <?php if($row->COL_COUNTRY != null) { ?>
                     <tr>
-                        <td>Country:</td>
+                        <td><?php echo $this->lang->line('geneneral_word_country'); ?></td>
                         <td><?php echo ucwords(strtolower(($row->COL_COUNTRY))); ?></td>
                     </tr>
                     <?php } ?>
 
                     <?php if($row->COL_CONTEST_ID != null) { ?>
                     <tr>
-                        <td>Contest Name:</td>
+                        <td><?php echo $this->lang->line('contesting_contest_name'); ?></td>
                         <td><?php echo $row->COL_CONTEST_ID; ?></td>
                     </tr>
                     <?php } ?>
 
                     <?php if($row->COL_IOTA != null) { ?>
                     <tr>
-                        <td>IOTA Ref:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_iota_reference'); ?></td>
                         <td><?php echo $row->COL_IOTA; ?></td>
                     </tr>
                     <?php } ?>
 
                     <?php if($row->COL_SOTA_REF != null) { ?>
                     <tr>
-                        <td>SOTA Ref:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_sota_reference'); ?></td>
                         <td><?php echo $row->COL_SOTA_REF; ?></td>
                     </tr>
                     <?php } ?>
 
                     <?php if($row->COL_SIG != null) { ?>
                     <tr>
-                        <td>Sig:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_sig'); ?></td>
                         <td><?php echo $row->COL_SIG; ?></td>
                     </tr>
                     <?php } ?>
 
                     <?php if($row->COL_SIG_INFO != null) { ?>
                     <tr>
-                        <td>Sig Info:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_sig_info'); ?></td>
                         <td><?php echo $row->COL_SIG_INFO; ?></td>
                     </tr>
                     <?php } ?>
 
                     <?php if($row->COL_DARC_DOK != null) { ?>
                     <tr>
-                        <td>DOK:</td>
+                        <td><?php echo $this->lang->line('gen_hamradio_dok'); ?></td>
                         <td><a href="https://www.darc.de/<?php echo $row->COL_DARC_DOK; ?>" target="_new"><?php echo $row->COL_DARC_DOK; ?></a></td>
                     </tr>
                     <?php } ?>
 
                 </table>
                 <?php if($row->COL_QSL_SENT == "Y" || $row->COL_QSL_RCVD == "Y") { ?>
-                    <h3>QSL Info:</h3>
+                    <h3><?php echo $this->lang->line('qslcard_info'); ?></h3>
 
                     <?php if($row->COL_QSL_SENT == "Y" && $row->COL_QSL_SENT_VIA == "B") { ?>
-                    <p>QSL Card has been sent via the bureau</p>
+                    <p><?php echo $this->lang->line('qslcard_sent_bureau'); ?></p>
                     <?php } ?>
                     <?php if($row->COL_QSL_SENT == "Y" && $row->COL_QSL_SENT_VIA == "D") { ?>
-                    <p>QSL Card has been sent direct</p>
+                    <p><?php echo $this->lang->line('qslcard_sent_direct'); ?></p>
                     <?php } ?>
 
                     <?php if($row->COL_QSL_RCVD == "Y" && $row->COL_QSL_RCVD_VIA == "B") { ?>
-                    <p>QSL Card has been received via the bureau</p>
+                    <p><?php echo $this->lang->line('qslcard_recvd_bureau'); ?></p>
                     <?php } ?>
                     <?php if($row->COL_QSL_RCVD == "Y" && $row->COL_QSL_RCVD_VIA == "D") { ?>
-                    <p>QSL Card has been received direct</p>
+                    <p><?php echo $this->lang->line('qslcard_recvd_direct'); ?></p>
                     <?php } ?>
                 <?php } ?>
 
                     <?php if($row->COL_LOTW_QSL_RCVD == "Y") { ?>
-                    <h3>LoTW:</h3>
-                        <p>This QSO is confirmed on Lotw</p>
+                    <h3><?php echo $this->lang->line('lotw_short'); ?></h3>
+                        <p><?php echo $this->lang->line('lotw_confirmed'); ?></p>
                     <?php } ?>
             </div>
 
@@ -358,18 +358,18 @@
                 <fieldset>
 
                     <div class="form-group">
-                        <label for="qslcardfront">Upload QSL Card front image</label>
+                        <label for="qslcardfront"><?php echo $this->lang->line('qslcard_upload_front'); ?></label>
                         <input class="form-control-file" type="file" id="qslcardfront" name="qslcardfront" accept="image/*" >
                     </div>
 
                     <div class="form-group">
-                        <label for="qslcardback">Upload QSL Card back image</label>
+                        <label for="qslcardback"><?php echo $this->lang->line('qslcard_upload_back'); ?></label>
                         <input class="form-control-file" type="file" id="qslcardback" name="qslcardback" accept="image/*">
                     </div>
 
                     <input type="hidden" class="form-control" id="qsoinputid" name="qsoid" value="<?php echo $row->COL_PRIMARY_KEY; ?>">
 
-                    <button type="button" onclick="uploadQsl();" id="button1id"  name="button1id" class="btn btn-primary">Upload QSL card image</button>
+                    <button type="button" onclick="uploadQsl();" id="button1id"  name="button1id" class="btn btn-primary"><?php echo $this->lang->line('qslcard_upload_button'); ?></button>
 
                 </fieldset>
             </form>

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -260,7 +260,7 @@
 
                     <?php if(($this->config->item('use_auth') && ($this->session->userdata('user_type') >= 2)) || $this->config->item('use_auth') === FALSE) { ?>
                         <br>
-                            <p class="editButton"><a class="btn btn-primary" href="<?php echo site_url('qso/edit'); ?>/<?php echo $row->COL_PRIMARY_KEY; ?>" href="javascript:;"><i class="fas fa-edit"></i> Edit QSO</a></p>
+                            <p class="editButton"><a class="btn btn-primary" href="<?php echo site_url('qso/edit'); ?>/<?php echo $row->COL_PRIMARY_KEY; ?>" href="javascript:;"><i class="fas fa-edit"></i><?php echo $this->lang->line('qso_btn_edit_qso'); ?></a></p>
                     <?php } ?>
 
                     <?php

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -182,7 +182,7 @@
                     <?php } ?>
                     <?php if($row->COL_COUNTRY != null) { ?>
                     <tr>
-                        <td><?php echo $this->lang->line('geneneral_word_country'); ?></td>
+                        <td><?php echo $this->lang->line('general_word_country'); ?></td>
                         <td><?php echo ucwords(strtolower(($row->COL_COUNTRY))); ?></td>
                     </tr>
                     <?php } ?>

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -16,11 +16,11 @@
                 echo 'hidden ';
             }
                 echo 'class="qslcardtab nav-item">
-                <a class="nav-link" id="qsltab" data-toggle="tab" href="#qslcard" role="tab" aria-controls="home" aria-selected="false">'. $this->lang->line('general_words_qslcard') .'</a>
+                <a class="nav-link" id="qsltab" data-toggle="tab" href="#qslcard" role="tab" aria-controls="home" aria-selected="false">'. $this->lang->line('general_word_qslcard') .'</a>
                 </li>';
 
             echo '<li class="nav-item">
-            <a class="nav-link" id="qslmanagementtab" data-toggle="tab" href="#qslupload" role="tab" aria-controls="home" aria-selected="false">'. $this->lang->line('general_words_qslcard_management') .'</a>
+            <a class="nav-link" id="qslmanagementtab" data-toggle="tab" href="#qslupload" role="tab" aria-controls="home" aria-selected="false">'. $this->lang->line('general_word_qslcard_management') .'</a>
             </li>';
         }
 


### PR DESCRIPTION
To continue helping with translations, I decided to start by myself adding support for translations in the 'QSO Details' lightbox (as this is one of my father's most used view from Cloudlog).

Notes:
* I tried using already existing keywords, but also created the ones missing / incomplete.
* The "Station profile" is still hardcoded, becuase I've seen there are many parts of the project where these keywords are used (i.e. administration-> add station, or main view) and maybe it would be better to have all related keywords in one single lang file - perhapts station_lang.php? -

TO-DO:

* Station profile
* Gridsquare and Gridsquare (multi)
* USA-related fields
* File size warning
