### PR TITLE
Update log.php

### DIFF
--- a/application/views/view_log/partial/log.php
+++ b/application/views/view_log/partial/log.php
@@ -7,8 +7,8 @@
             <?php } ?>
             <td><?php echo $this->lang->line('gen_hamradio_call'); ?></td>
             <td><?php echo $this->lang->line('gen_hamradio_mode'); ?></td>
-            <td><?php echo $this->lang->line('general_word_sent'); ?></td>
-            <td><?php echo $this->lang->line('general_word_received'); ?></td>
+            <td><?php echo $this->lang->line('gen_hamradio_rsts'); ?></td>
+            <td><?php echo $this->lang->line('gen_hamradio_rstr'); ?></td>
             <td><?php echo $this->lang->line('gen_hamradio_band'); ?></td>
             <td><?php echo $this->lang->line('general_word_country'); ?></td>
             <?php if(($this->config->item('use_auth')) && ($this->session->userdata('user_type') >= 2)) { ?>


### PR DESCRIPTION
The RST fields at table header came from wrong lang line. It caused the illogicality of the translation, at least into Finnish. The page now looks consistent with the "Previous contacts" section in the QSO view.