### PR TITLE
[QSO Edit] Fix when editing a QSO with US County set. Selectize would…

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1335,6 +1335,7 @@ $(document).ready(function(){
         function selectize_usa_county() {
             var baseURL= "<?php echo base_url();?>";
             $('#stationCntyInput').selectize({
+				delimiter: ';',
                 maxItems: 1,
                 closeAfterSelect: true,
                 loadThrottle: 250,


### PR DESCRIPTION
… not let you erase everything, since comma is used as a delimiter.