### PR TITLE
Correct dxcc exceptions table name

### DIFF
--- a/application/models/Dok.php
+++ b/application/models/Dok.php
@@ -95,7 +95,7 @@ class DOK extends CI_Model {
 	{
 		$exceptions = $this->db->query('
 				SELECT *
-				FROM `dxccexceptions`
+				FROM `dxcc_exceptions`
 				WHERE `prefix` = \''.$callsign.'\'
 				LIMIT 1
 			');

--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -137,7 +137,7 @@ class DXCC extends CI_Model {
 	{
 		$exceptions = $this->db->query('
 				SELECT *
-				FROM `dxccexceptions`
+				FROM `dxcc_exceptions`
 				WHERE `prefix` = \''.$callsign.'\'
 				LIMIT 1
 			');


### PR DESCRIPTION
This corrects two models that were using the old dxcc exceptions table name.