### PR TITLE
Add timestamp to 'cat' update, to enforce timestamp update in mysql when other values have not changed.

### DIFF
--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -41,6 +41,7 @@
 						$data = array(
 						'frequency' => $result['frequency'],
 						'mode' => $result['mode'],
+						'timestamp' => $result['timestamp'],
 						);
 
 						$this->db->where('id', $radio_id);
@@ -65,7 +66,8 @@
 					$data = array(
 						'radio' => $result['radio'],
 						'frequency' => $result['frequency'],
-						'mode' => $result['mode']
+						'mode' => $result['mode'],
+						'timestamp' => $result['timestamp'],
 					);
 				}
 


### PR DESCRIPTION
In mysql, timestamp (with ON UPDATE CURRENT_TIMESTAMP) is not automatically updated when field values are same as in database. 

When posting radio info via /api/radio with no changes to frequency or mode, it does not change the timestamp value and after some time there will be a warning on QSO page: "Radio connection timed-out" while in fact it is updated frequently, there is just no change in frequency or mode.

My fix is to set timestamp to the value that was posted via api.  Maybe there is better solution?