### PR TITLE
Add the gridsquare from LotW QSL to the logbook

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -466,6 +466,7 @@ class Lotw extends CI_Controller {
 				$tableheaders .= "<td>LoTW QSL Received</td>";
 				$tableheaders .= "<td>Date LoTW Confirmed</td>";
 				$tableheaders .= "<td>State</td>";
+				$tableheaders .= "<td>Gridsquare</td>";
 				$tableheaders .= "<td>Log Status</td>";
 				$tableheaders .= "<td>LoTW Status</td>";
 			$tableheaders .= "</tr>";
@@ -512,8 +513,15 @@ class Lotw extends CI_Controller {
 					} else {
 						$state = "";
 					}
+					// Present only if the QSLing station specified a single valid grid square value in its station location uploaded to LoTW.
+					if (isset($record['gridsquare'])) {
+						$qsl_gridsquare = $record['gridsquare'];
+					} else {
+						$qsl_gridsquare = "";
+					}
 
-					$lotw_status = $this->logbook_model->lotw_update($time_on, $record['call'], $record['band'], $qsl_date, $record['qsl_rcvd'], $state);
+
+					$lotw_status = $this->logbook_model->lotw_update($time_on, $record['call'], $record['band'], $qsl_date, $record['qsl_rcvd'], $state, $qsl_gridsquare);
 				}
 
 
@@ -525,6 +533,7 @@ class Lotw extends CI_Controller {
 					$table .= "<td>".$record['qsl_rcvd']."</td>";
 					$table .= "<td>".$qsl_date."</td>";
 					$table .= "<td>".$state."</td>";
+					$table .= "<td>".$qsl_gridsquare."</td>";
 					$table .= "<td>QSO Record: ".$status."</td>";
 					$table .= "<td>LoTW Record: ".$lotw_status."</td>";
 				$table .= "</tr>";

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1436,6 +1436,10 @@ class Logbook_model extends CI_Model {
       $this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = "'.$datetime.'"');
       $this->db->where('COL_CALL', $callsign);
       $this->db->where('COL_BAND', $band);
+	  $this->db->group_start();
+	  $this->db->where('COL_VUCC_GRIDS');
+	  $this->db->or_where('COL_VUCC_GRIDS', '');
+	  $this->db->group_end();
       if(strlen($qsl_gridsquare) > 4) {
         $this->db->group_start();
         $this->db->where('COL_GRIDSQUARE', "");


### PR DESCRIPTION
The gridsquare from the QSL will now update the log if the gridsquare
was not previously populated, or if the LotW gridsquare is more
specific than what previously existed.  Previously the gridsquare was
not being used from the LotW QSL record.

This will enable the map above the logbook to more accurately display
where the QSL was with instead of default values.

 - Add 'qsl_gridquare' to the logbook_model.php:lotw_update
   implementation.
 - Refactor code in lotw_update to remove duplicate code.
 - Add gridsquare into the LotW output table on what is imported.