### PR TITLE
Update update_cloudlog.sh

### DIFF
--- a/update_cloudlog.sh
+++ b/update_cloudlog.sh
@@ -10,7 +10,7 @@
 # The user and group that own the CLOUDLOG_SUBDIR directories. Passed to 'chown' as-is.
 DIR_OWNERSHIP="root:www-data"
 # The list of directories that need to have ownership restored after a git pull
-declare -a CLOUDLOG_SUBDIRS=("application/config" "assets/qslcard" "backup" "updates" "uploads")
+declare -a CLOUDLOG_SUBDIRS=("application/config" "assets" "backup" "updates" "uploads")
 # The name of the Git remote to fetch/pull from
 GIT_REMOTE="origin"
 # If true, pull from the HEAD of the configured origin, otherwise the latest tag


### PR DESCRIPTION
Change to asset directory permission check rather than just QSL

Assets directory as a whole should be permission updated rather than just the qslcard folder, otherwise  https://urlhere/index.php/update/update_dok fails with  

`file_put_contents(./assets/json/dok.txt): failed to open stream: Permission denied`

This is an edge case if the cron script runs as a different user to the www user.

May fix #1110  too ?