### PR TITLE
[QSO Entry] Maritime Mobile identification fix

### DIFF
--- a/application/models/Cq.php
+++ b/application/models/Cq.php
@@ -239,7 +239,7 @@ class CQ extends CI_Model{
     function getSummaryByBand($band, $station_id) {
         $sql = "SELECT count(distinct thcv.col_cqz) as count FROM " . $this->config->item('table_name') . " thcv";
 
-        $sql .= " where station_id = " . $station_id;
+        $sql .= " where station_id = " . $station_id . ' and col_cqz > 0';
 
         if ($band == 'SAT') {
             $sql .= " and thcv.col_prop_mode ='" . $band . "'";
@@ -258,7 +258,7 @@ class CQ extends CI_Model{
     function getSummaryByBandConfirmed($band, $station_id){
         $sql = "SELECT count(distinct thcv.col_cqz) as count FROM " . $this->config->item('table_name') . " thcv";
 
-        $sql .= " where station_id = " . $station_id;
+        $sql .= " where station_id = " . $station_id . ' and col_cqz > 0';
 
         if ($band == 'SAT') {
             $sql .= " and thcv.col_prop_mode ='" . $band . "'";

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2082,7 +2082,14 @@ class Logbook_model extends CI_Model {
 
 		if (preg_match('/(^KG4)[A-Z09]{3,}/', $call)) { 	// KG4/ and KG4 5 char calls are Guantanamo Bay. If 6 char, it is USA
 			$call = "K";
-		}
+		} elseif (preg_match_all('/^((\d|[A-Z])+\/)?((\d|[A-Z]){3,})(\/(\d|[A-Z])+)?(\/(\d|[A-Z])+)?$/', $call, $matches)) {
+			if ($matches[5][0] == '/MM') {
+				$row['adif'] = 0;
+				$row['entity'] = 'None';
+				$row['cqz'] = 0;
+				return array($row['adif'], $row['entity'], $row['cqz']);
+			}
+    	}
 
 		$len = strlen($call);
 
@@ -2127,7 +2134,16 @@ class Logbook_model extends CI_Model {
 
 				if (preg_match('/(^KG4)[A-Z09]{3,}/', $call)) { 	// KG4/ and KG4 5 char calls are Guantanamo Bay. If 6 char, it is USA
 					$call = "K";
-				}
+				} elseif (preg_match_all('/^((\d|[A-Z])+\/)?((\d|[A-Z]){3,})(\/(\d|[A-Z])+)?(\/(\d|[A-Z])+)?$/', $call, $matches)) {
+					if ($matches[5][0] == '/MM') {
+						$row['adif'] = 0;
+						$row['entity'] = 'None';
+						$row['cqz'] = 0;
+						$row['long'] = '0';
+						$row['lat'] = '0';
+						return $row;
+					}
+    			}
 
 				$len = strlen($call);
 

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -258,7 +258,7 @@
                   <label for="cqz"><?php echo $this->lang->line('gen_hamradio_cq_zone'); ?></label>
                   <select class="custom-select" id="cqz" name="cqz" required>
                       <?php
-                      for ($i = 1; $i<=40; $i++) {
+                      for ($i = 0; $i<=40; $i++) {
                           echo '<option value="'. $i . '">'. $i .'</option>';
                       }
                       ?>


### PR DESCRIPTION
This should fix #1090 by identifying /MM QSOs.

I am not sure if this fixes all use cases regarding /MM. I've fixed the two functions identifying a DXCC.
The REGEX is based on a DXCC Lookup DJ1YFK made: https://git.fkurz.net/dj1yfk/dxcc. I've converted this to PHP, but I'm not sure if we need this complexity in Cloudlog. I ripped out the part for identifying /MM QSOs instead.

Since we have no CQ Zone, I return this as 0. By doing this, I needed to add 0 to dropdown in the QSO Entry.
I also needed to fix the summary in the CQ Zone award to look for values > 0.

Long and lat is returned as 0 values. This would give an error QSO Data popup if these values were not set.

@magicbug please give this a test. I am unsure if every part using dxcc_lookup in loogbook_model has everything it needs to work correctly.