### PR TITLE
Input shortcuts for date/time in post QSO section

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -459,7 +459,7 @@ if ($('#frequency').val() == "")
 	});
 }
 
-/* format time input shortcut */
+/* time input shortcut */
 $('#start_time').change(function() {
 	var raw_time = $(this).val();
 	if(raw_time.match(/^\d\[0-6]d$/)) {
@@ -468,6 +468,15 @@ $('#start_time').change(function() {
 	if(raw_time.match(/^[012]\d[0-5]\d$/)) {
 		raw_time = raw_time.substring(0,2)+":"+raw_time.substring(2,4);
 		$('#start_time').val(raw_time);
+	}
+});
+
+/* date input shortcut */
+$('#start_date').change(function() {
+	 raw_date = $(this).val();
+	if(raw_date.match(/^[12]\d\d\d[01]\d[0123]\d$/)) {
+		raw_date = raw_date.substring(0,4)+"-"+raw_date.substring(4,6)+"-"+raw_date.substring(6,8);
+		$('#start_date').val(raw_date);
 	}
 });
 

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -459,6 +459,18 @@ if ($('#frequency').val() == "")
 	});
 }
 
+/* format time input shortcut */
+$('#start_time').change(function() {
+	var raw_time = $(this).val();
+	if(raw_time.match(/^\d\[0-6]d$/)) {
+		raw_time = "0"+raw_time;
+	}
+	if(raw_time.match(/^[012]\d[0-5]\d$/)) {
+		raw_time = raw_time.substring(0,2)+":"+raw_time.substring(2,4);
+		$('#start_time').val(raw_time);
+	}
+});
+
 /* on mode change */
 $('.mode').change(function() {
 	$.get('qso/band_to_freq/' + $('#band').val() + '/' + $('.mode').val(), function(result) {


### PR DESCRIPTION
Would like to copy a smart idea from CQRlog: This allows you to input date and time in the post QSO section without delimiters and automatically gets reformatted. So you can just write "20210829" and it would be re-formatted to "2021-08-29". Same goes for time: "1723" -> "17:23" and even allows for omitting the leading zero: "723" -> "07:23".