### PR TITLE
Use UTC timestamps for CAT control

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -455,14 +455,18 @@ class API extends CI_Controller {
 	}
 
 
-	/* ENDPOINT for Rig Control */
+	/*
+	* ENDPOINT for Rig Control
+	*
+	* Note: timestamp should always be in UTC
+	*/
 
 	function radio() {
 		header('Content-type: application/json');
 
 		$this->load->model('api_model');
 
-		//$json = '{"radio":"FT-950","frequency":14075,"mode":"SSB","timestamp":"2012/04/07 16:47"}';
+		//$json = '{"radio":"FT-950","frequency":14075,"mode":"SSB","timestamp":"2012/04/07 16:47:31"}';
 
 		$this->load->model('cat');
 
@@ -477,7 +481,7 @@ class API extends CI_Controller {
 		}
 
 		if(!isset($obj['timestamp'])) {
-			$obj['timestamp'] = gmdate('Y/m/d H:i:s');
+			$obj['timestamp'] = gmdate('Y/m/d H:i:s'); // in UTC
 		}
 
 		// Store Result to Database

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -476,6 +476,10 @@ class API extends CI_Controller {
 		   die();
 		}
 
+		if(!isset($obj['timestamp'])) {
+			$obj['timestamp'] = gmdate('Y/m/d H:i:s');
+		}
+
 		// Store Result to Database
 		$this->cat->update($obj);
 

--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -120,8 +120,9 @@
 				}
 
 				// Calculate how old the data is in minutes 
-				$datetime1 = new DateTime(); // Today's Date/Time
-				$datetime2 = new DateTime($row->newtime);
+				$timezone = new DateTimeZone("UTC");
+				$datetime1 = new DateTime("now", $timezone);
+				$datetime2 = new DateTime($row->timestamp, $timezone);
 				$interval = $datetime1->diff($datetime2);
 
 				$minutes = $interval->days * 24 * 60;

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -102,7 +102,7 @@
 
 		function radio_status($id) {
 
-			return $this->db->query('SELECT *, CONVERT_TZ(`timestamp`, @@session.time_zone, \'+00:00\' ) as newtime FROM `cat` WHERE id = '.$id.' ');
+			return $this->db->query('SELECT * FROM `cat` WHERE id = '.$id.' ');
 
 		}
 


### PR DESCRIPTION
I'm experiencing a bug because my computer is in one time zone and my server is in another, neither of which are UTC/GMT. This PR fixes that by making the `cat.timestamp` column and data inserted into it UTC.

This goes hand-in-hand with magicbug/CloudlogCAT#6.