### PR TITLE
eQSL request changed from GET to POST

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -144,19 +144,17 @@ class eqsl extends CI_Controller {
 			$active_station_info = $station_profile->row();
 			// Query the logbook to determine when the last LoTW confirmation was
 			$eqsl_last_qsl_date = $this->logbook_model->eqsl_last_qsl_rcvd_date();
-			
-			// Build URL for eQSL inbox file
-			$eqsl_url .= "?";
-			$eqsl_url .= "UserName=" . $data['user_eqsl_name'];
-			$eqsl_url .= "&Password=" . urlencode($data['user_eqsl_password']);
-			
-			$eqsl_url .= "&RcvdSince=" . $eqsl_last_qsl_date;
-			$eqsl_url .= "&QTHNickname=" . urlencode($active_station_info->eqslqthnickname);
-			
-			// Pull back only confirmations
-			$eqsl_url .= "&ConfirmedOnly=1";
 
-			//echo "<br><br>".$eqsl_url."<br><br>";
+			// Build parameters for eQSL inbox file
+			$eqsl_params = http_build_query(array(
+				'UserName' => $data['user_eqsl_name'],
+				'Password' => $data['user_eqsl_password'],
+				'RcvdSince' => $eqsl_last_qsl_date,
+				'QTHNickname' => $active_station_info->eqslqthnickname,
+				'ConfirmedOnly' => 1
+			));
+
+			//echo "<br><br>".$eqsl_url."<br>".$eqsl_params."<br><br>";
 			
  			// At this point, what we get isn't the ADI file we need, but rather
 			// an HTML page, which contains a link to the generated ADI file that we want.
@@ -170,8 +168,10 @@ class eqsl extends CI_Controller {
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
 			curl_setopt($ch, CURLOPT_HEADER, 1);
 			
-			// use the URL we built
+			// use the URL and params we built
 			curl_setopt($ch, CURLOPT_URL, $eqsl_url);
+			curl_setopt($ch, CURLOPT_POST, 1);
+			curl_setopt($ch, CURLOPT_POSTFIELDS, $eqsl_params);
 			
 			$input = curl_exec($ch);  
 			$chi = curl_getinfo($ch);


### PR DESCRIPTION
The request to eQSL should not be a GET request as in that case the password is transmitted in the query string. Therefore the password might become visible in plain text in logs (e.g. access log). POST just works as good and avoids this security issue.