### PR TITLE
[DOK Award] Updated code to support station logbooks

### DIFF
--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -27,7 +27,6 @@ class Awards extends CI_Controller {
 
 	public function dok ()
 	{
-		//echo "Needs Developed";
 		$this->load->model('dok');
 		$data['doks'] = $this->dok->show_stats();
 		$data['worked_bands'] = $this->dok->get_worked_bands();
@@ -226,7 +225,7 @@ class Awards extends CI_Controller {
 		$this->load->view('interface_assets/footer');
 	}
 
-	public function cq(){
+	public function cq() {
 		$CI =& get_instance();
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));


### PR DESCRIPTION
@magicbug The award itself is fixed now, but I have not fixed the displaying of the contacts when clicking on the DOK in the award. The reason is that this uses the api_model and the logbook_model to generate the query and execute it. They do not use station_id at all, so this needs a rewrite, but will not attempt is, as changing things here might affect things other places.

One workaround might be to append something like "and station_id in (1,2,3)" to the query in awards-controller before calling logbook_model to execute the query.