### PR TITLE
Fix to retrieval of eqsl images

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -589,11 +589,24 @@ class eqsl extends CI_Controller {
 		$this->load->view('interface_assets/footer');
 	}
 
-	function image($id, $callsign, $mode, $band, $hour, $minute, $day, $month, $year) {
+	function image($id) {
 		$this->load->library('electronicqsl');
 		$this->load->model('Eqsl_images');
 
 		if($this->Eqsl_images->get_image($id) == "No Image") {
+			$this->load->model('logbook_model');
+			$qso_query = $this->logbook_model->get_qso($id);
+			$qso = $qso_query->row();
+			$qso_timestamp = strtotime($qso->COL_TIME_ON);
+			$callsign = $qso->COL_CALL;
+			$band = $qso->COL_BAND;
+			$mode = $qso->COL_MODE;
+			$year = date('Y', $qso_timestamp);
+			$month = date('m', $qso_timestamp);
+			$day = date('d', $qso_timestamp);
+			$hour = date('H', $qso_timestamp);
+			$minute = date('i', $qso_timestamp);
+
 			$query = $this->user_model->get_by_id($this->session->userdata('user_id'));
 			$q = $query->row();
 			$username = $q->user_eqsl_name;
@@ -613,14 +626,14 @@ class eqsl extends CI_Controller {
 			}
 
 			foreach ($images as $image) 
-			{ 
-			 header('Content-Type: image/jpg');
-			 readfile ("https://www.eqsl.cc".$image->getAttribute('src')); 
-			 $content = file_get_contents("https://www.eqsl.cc".$image->getAttribute('src'));
-			 $filename = uniqid().'.jpg';
-			 file_put_contents('images/eqsl_card_images/' . '/'.$filename, $content);
+			{
+				header('Content-Type: image/jpg');
+				readfile ("https://www.eqsl.cc".$image->getAttribute('src')); 
+				$content = file_get_contents("https://www.eqsl.cc".$image->getAttribute('src'));
+				$filename = uniqid().'.jpg';
+				file_put_contents('images/eqsl_card_images/' . '/'.$filename, $content);
 
-			 $this->Eqsl_images->save_image($id, $filename);
+				$this->Eqsl_images->save_image($id, $filename);
 			}
 		} else {
 			header('Content-Type: image/jpg');

--- a/application/views/view_log/partial/log.php
+++ b/application/views/view_log/partial/log.php
@@ -97,7 +97,7 @@
 			    <span class="eqsl-<?php echo ($row->COL_EQSL_QSL_SENT=='Y')?'green':'red'?>">&#9650;</span>
 			    <span class="eqsl-<?php echo ($row->COL_EQSL_QSL_RCVD=='Y')?'green':'red'?>">
 			    	<?php if($row->COL_EQSL_QSL_RCVD =='Y') { ?>
-			    	<a style="color: green" href="<?php echo site_url("eqsl/image/".$row->COL_PRIMARY_KEY."/".$row->COL_CALL."/".$row->COL_MODE."/".$row->COL_BAND."/".date('H', $timestamp)."/".date('i', $timestamp)."/".date('d', $timestamp)."/".date('m', $timestamp)."/".date('Y', $timestamp)); ?>" data-fancybox="images" data-width="528" data-height="336">&#9660;</a>
+			    	<a style="color: green" href="<?php echo site_url("eqsl/image/".$row->COL_PRIMARY_KEY); ?>" data-fancybox="images" data-width="528" data-height="336">&#9660;</a>
 			    	<?php } else { ?>
 			    		&#9660;
 			    	<?php } ?>

--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -205,7 +205,7 @@
                         <span class="eqsl-<?php echo ($row->COL_EQSL_QSL_SENT=='Y')?'green':'red'?>">&#9650;</span>
                         <span class="eqsl-<?php echo ($row->COL_EQSL_QSL_RCVD=='Y')?'green':'red'?>">
 			    	<?php if($row->COL_EQSL_QSL_RCVD =='Y') { ?>
-                        <a style="color: green" href="<?php echo site_url("eqsl/image/".$row->COL_PRIMARY_KEY."/".$row->COL_CALL."/".$row->COL_MODE."/".$row->COL_BAND."/".date('H', $timestamp)."/".date('i', $timestamp)."/".date('d', $timestamp)."/".date('m', $timestamp)."/".date('Y', $timestamp)); ?>" data-fancybox="images" data-width="528" data-height="336">&#9660;</a>
+                        <a style="color: green" href="<?php echo site_url("eqsl/image/".$row->COL_PRIMARY_KEY); ?>" data-fancybox="images" data-width="528" data-height="336">&#9660;</a>
                     <?php } else { ?>
                         &#9660;
                     <?php } ?>


### PR DESCRIPTION
Callsign can contain / (e.g. /P) which leads to an invalid URL. Changed retrieval of eQSL image to just get/need QSO id.