### PR TITLE
[FIX] Solved a SQL syntax problem while using the latest MariaDB version.

### DIFF
--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -362,7 +362,7 @@ class User_Model extends CI_Model {
 	// FUNCTION: array timezones()
 	// Returns a list of timezones
 	function timezones() {
-		$r = $this->db->query('SELECT id, name FROM timezones ORDER BY offset');
+		$r = $this->db->query('SELECT id, name FROM timezones ORDER BY `offset`');
 		$ts = array();
 		foreach ($r->result_array() as $t) {
 			$ts[$t['id']] = $t['name'];


### PR DESCRIPTION
It seems that the previous version of this query was misunderstood by the SQL engine.  
The key `offset` was read as a SQL keyword instead of a name of a column.

This solve this problem.