### PR TITLE
"Mark QSL Card Not Required" sets status to Ignore but sets red arrow

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1239,7 +1239,7 @@ $(document).ready(function(){
                 },
                 success: function(data) {
                     if (data.message == 'OK') {
-                        $("#qso_" + id).find("td:eq(8)").find("span:eq(0)").attr('class', 'qsl-red'); // Paints arrow green
+                        $("#qso_" + id).find("td:eq(8)").find("span:eq(0)").attr('class', 'qsl-grey'); // Paints arrow grey
                     }
                     else {
                         $(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');


### PR DESCRIPTION
... which reflects status No. Changed color to grey.

If you use the feature "Mark QSL Card Not Required" the arrow is set to red color after the ajax call is finished. Anyway the status is set to Ignore and as soon as you reload the list the arrow is grey. Changed it to be consistent (Ignore = grey after ajax call).