### PR TITLE
PHP8 fix and folder not found fix

### DIFF
--- a/application/views/user/add.php
+++ b/application/views/user/add.php
@@ -30,10 +30,16 @@
 		    <select class="custom-select" name="user_type">
 			<?php
 				$levels = $this->config->item('auth_level');
-				while (list($key, $val) = each($levels)) {
-			?>
-					<option value="<?php echo $key; ?>" <?php if(isset($user_type)) { if($user_type == $key) { echo "selected=\"selected\""; } } ?>><?php echo $val; ?></option>
-				<?php } ?>
+				foreach ($levels as $key => $value) {
+					echo '<option value="'. $key . '"';
+					if(isset($user_type)) { 
+						if($user_type == $key) { 
+							echo "selected=\"selected\""; 
+						} 
+					} 
+					echo '>' . $value . '</option>';
+				} 
+				?>
 			</select>
 		  </div>
 

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -71,10 +71,14 @@
 						<select class="custom-select" name="user_type">
 						<?php
 							$levels = $this->config->item('auth_level');
-							while (list($key, $val) = each($levels)) {
-						?>
-							<option value="<?php echo $key; ?>" <?php if($user_type == $key) { echo "selected=\"selected\""; } ?>><?php echo $val; ?></option>
-							<?php } ?>
+							foreach ($levels as $key => $value) {
+								echo '<option value="'. $key . '"';
+									if($user_type == $key) { 
+										echo "selected=\"selected\""; 
+									} 
+								echo '>' . $value . '</option>';
+							} 
+							?>
 						</select>
 						<?php } else {
 							$l = $this->config->item('auth_level');

--- a/install/includes/core_class.php
+++ b/install/includes/core_class.php
@@ -26,7 +26,7 @@ class Core {
 		}
 
 		if($data['directory'] != "") {
-			if (file_exists("../".$data['directory'])) {
+			if (file_exists($_SERVER['DOCUMENT_ROOT'].$data['directory'])) {
 				//pass folders real
 				$counter++;
 			} else {
@@ -56,7 +56,7 @@ class Core {
 
 		// Config path
 		$template_path 	= 'config/database.php';
-		$output_path 	= '../application/config/database.php';
+		$output_path 	= $_SERVER['DOCUMENT_ROOT'].$data['directory'].'/application/config/database.php';
 
 		// Open the file
 		$database_file = file_get_contents($template_path);
@@ -92,7 +92,7 @@ class Core {
 
 		// Config path
 		$template_path 	= 'config/config.php';
-		$output_path 	= '../application/config/config.php';
+		$output_path 	= $_SERVER['DOCUMENT_ROOT'].$data['directory'].'/application/config/config.php';
 
 		// Open the file
 		$database_file = file_get_contents($template_path);


### PR DESCRIPTION
EACH is deprecated in PHP8.

I also kept having trouble with folder not found when installing Cloudlog.

@magicbug take a look and see if you agree. It works well here, but would be nice if you could test as well.