### PR TITLE
Dxcc lookup exceptions fix

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2216,8 +2216,8 @@ class Logbook_model extends CI_Model {
 		$dxcc_exceptions = $this->db->select('`entity`, `adif`, `cqz`')
 				->where('call', $call)
 				->where('(start <= CURDATE()')
-				->or_where('start is null', NULL, false)
-				->where('end >= CURDATE()')
+				->or_where('start is null)', NULL, false)
+				->where('(end >= CURDATE()')
 				->or_where('end is null)', NULL, false)
 				->get('dxcc_exceptions');
 


### PR DESCRIPTION
misplaced parens in query of dxcc_exceptions in dxcc_lookup was returning exceptions outside of the targeted date.

MariaDB [cloudlog]> SELECT * FROM dxcc_exceptions WHERE `call` = 'K7TAB' AND (start <= CURDATE() OR start is null AND end >= CURDATE() OR end is null);
+--------+-------+--------+------+-----+------+--------+------+------------+------------+
| record | call  | entity | adif | cqz | cont | long   | lat  | start      | end        |
+--------+-------+--------+------+-----+------+--------+------+------------+------------+
|  17527 | K7TAB | HAWAII |  110 |  31 | OC   | -157.9 | 21.3 | 2012-08-10 | 2012-11-24 |
+--------+-------+--------+------+-----+------+--------+------+------------+------------+
1 row in set (1.098 sec)

-- correct placement of parens
MariaDB [cloudlog]> SELECT * FROM dxcc_exceptions WHERE `call` = 'K7TAB' AND (start <= CURDATE() OR start is null) AND (end >= CURDATE() OR end is null);
Empty set (0.485 sec)
