### PR TITLE
fixes for station log

### DIFF
--- a/application/controllers/Logbooks.php
+++ b/application/controllers/Logbooks.php
@@ -85,9 +85,6 @@ class Logbooks extends CI_Controller {
 				if($this->logbooks_model->relationship_exists($this->input->post('station_logbook_id'), $this->input->post('SelectedStationLocation')) != TRUE) {
 					// If no link exisits create
 					$this->logbooks_model->create_logbook_location_link($this->input->post('station_logbook_id'), $this->input->post('SelectedStationLocation'));
-					echo "linked";
-				} else {
-					echo "Already Linked";
 				}
 			} else {
 				$this->logbooks_model->edit();

--- a/application/views/logbooks/edit.php
+++ b/application/views/logbooks/edit.php
@@ -75,17 +75,25 @@
 			<table class="table table-hover">
 				<thead class="thead-light">
 					<tr>
-				 		<th scope="col">Location Name</th>
+						<th scope="col">Location Name</th>
 						<th scope="col"></th>
-				    </tr>
+					</tr>
 				</thead>
-				 
-
 				<tbody>
-					<?php foreach ($station_locations_linked->result() as $row) { ?>
+					<?php
+						if ($station_locations_linked) {
+							foreach ($station_locations_linked->result() as $row) {
+					?>
 					<tr>
 						<td><?php echo $row->station_profile_name;?> (Callsign: <?php echo $row->station_callsign;?> DXCC: <?php echo $row->station_country;?>)</td>
 						<td><a href="<?php echo site_url('logbooks/delete_relationship/'); ?><?php echo $station_logbook_details->logbook_id; ?>/<?php echo $row->station_id;?>" class="btn btn-danger"><i class="fas fa-trash-alt"></i></a></td>
+					</tr>
+					<?php
+							}
+						} else {
+					?>
+					<tr>
+						<td colspan="2">No linked locations</td>
 					</tr>
 					<?php } ?>
 				</tbody>


### PR DESCRIPTION
added check for empty result from list_logbooks_linked (otherwise an error occurs when editing a logbook without stations (e.g. newly created one))
removed "echo" outputs as then the following redirect is not possible (causing an error after linking a station)