### PR TITLE
sort logbook and station list by name

### DIFF
--- a/application/models/Logbooks_model.php
+++ b/application/models/Logbooks_model.php
@@ -11,6 +11,7 @@ class Logbooks_model extends CI_Model {
 
     function show_all() {
         $this->db->where('user_id', $this->session->userdata('user_id'));
+        $this->db->order_by('logbook_name');
 		return $this->db->get('station_logbooks');
 	}
 

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -15,7 +15,8 @@ class Stations extends CI_Model {
         $this->db->join($this->config->item('table_name'),'station_profile.station_id = '.$this->config->item('table_name').'.station_id','left');
        	$this->db->group_by('station_profile.station_id');
 		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
-		$this->db->or_where('station_profile.user_id =', NULL); 
+		$this->db->or_where('station_profile.user_id =', NULL);
+		$this->db->order_by('station_profile.station_profile_name');
         return $this->db->get();
 	}
 


### PR DESCRIPTION
I have quite a few stations and find it a bit strange to have them sorted by ID. Changed that to sort by name (also for logbooks). I think that's easier to navigate.