### PR TITLE
improvements to multi user support of stations/logbooks

### DIFF
--- a/application/controllers/Logbooks.php
+++ b/application/controllers/Logbooks.php
@@ -53,7 +53,7 @@ class Logbooks extends CI_Controller {
 	{
 		$this->load->library('form_validation');
 
-        $this->load->model('logbooks_model');
+		$this->load->model('logbooks_model');
 		$this->load->model('stations');
 
 		$station_logbook_id = $this->security->xss_clean($id);
@@ -62,7 +62,7 @@ class Logbooks extends CI_Controller {
 		$data['station_locations_array'] = $this->logbooks_model->list_logbook_relationships($station_logbook_id);
 
 		$data['station_logbook_details'] = $station_logbook_details_query->row();
-		$data['station_locations_list'] = $this->stations->all();
+		$data['station_locations_list'] = $this->stations->all_of_user();
 
 		$data['station_locations_linked'] = $this->logbooks_model->list_logbooks_linked($station_logbook_id);
 		

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -30,7 +30,7 @@ class QSO extends CI_Controller {
 
 		$data['active_station_profile'] = $this->stations->find_active();
 		$data['notice'] = false;
-		$data['stations'] = $this->stations->all();
+		$data['stations'] = $this->stations->all_of_user();
 		$data['radios'] = $this->cat->radios();
 		$data['query'] = $this->logbook_model->last_custom('5');
 		$data['dxcc'] = $this->logbook_model->fetchDxcc();

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -459,6 +459,7 @@ class Logbook_model extends CI_Model {
   /* Edit QSO */
   function edit() {
     $entity = $this->get_entity($this->input->post('dxcc_id'));
+    $stationId = $this->input->post('station_profile');
     $country = $entity['name'];
 
     $mode = $this->get_main_mode_if_submode($this->input->post('mode'));
@@ -539,7 +540,7 @@ class Logbook_model extends CI_Model {
 		   'COL_SRX' => $srx_string,
 		   'COL_CONTEST_ID' => $this->input->post('contest_name'),
        'COL_QSL_VIA' => $this->input->post('qsl_via_callsign'),
-       'station_id' => $this->input->post('station_profile'),
+       'station_id' => $stationId,
        'COL_OPERATOR' => $this->input->post('operator_callsign'),
        'COL_STATE' =>$this->input->post('usa_state'),
        'COL_CNTY' => $uscounty

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -462,6 +462,13 @@ class Logbook_model extends CI_Model {
     $stationId = $this->input->post('station_profile');
     $country = $entity['name'];
 
+    // be sure that station belongs to user
+    $CI =& get_instance();
+    $CI->load->model('Stations');
+    if (!$CI->Stations->check_station_is_accessible($stationId)) {
+        return;
+    }
+
     $mode = $this->get_main_mode_if_submode($this->input->post('mode'));
     if ($mode == null) {
         $mode = $this->input->post('mode');

--- a/application/models/Logbooks_model.php
+++ b/application/models/Logbooks_model.php
@@ -51,10 +51,7 @@ class Logbooks_model extends CI_Model {
 		$cleanId = xss_clean($id);
 
 		// be sure that logbook belongs to user
-		$this->db->where('user_id', $this->session->userdata('user_id'));
-		$this->db->where('logbook_id', $cleanId);
-		$query = $this->db->get('station_logbooks');
-		if ($query->num_rows() != 1) {
+		if (!$this->check_logbook_is_accessible($cleanId)) {
 			return;
 		}
 
@@ -83,18 +80,14 @@ class Logbooks_model extends CI_Model {
 		$clean_location_id = $this->security->xss_clean($location_id);
 
 		// be sure that logbook belongs to user
-		$this->db->where('user_id', $this->session->userdata('user_id'));
-		$this->db->where('logbook_id', $clean_logbook_id);
-		$query = $this->db->get('station_logbooks');
-		if ($query->num_rows() != 1) {
+		if (!$this->check_logbook_is_accessible($clean_logbook_id)) {
 			return;
 		}
 
 		// be sure that station belongs to user
-		$this->db->where('user_id', $this->session->userdata('user_id'));
-		$this->db->where('station_id', $clean_location_id);
-		$query = $this->db->get('station_profile');
-		if ($query->num_rows() != 1) {
+		$CI =& get_instance();
+		$CI->load->model('Stations');
+		if (!$CI->Stations->check_station_is_accessible($clean_location_id)) {
 			return;
 		}
 
@@ -171,25 +164,32 @@ class Logbooks_model extends CI_Model {
 		$clean_station_id = $this->security->xss_clean($station_id);
 
 		// be sure that logbook belongs to user
-		$this->db->where('user_id', $this->session->userdata('user_id'));
-		$this->db->where('logbook_id', $clean_logbook_id);
-		$query = $this->db->get('station_logbooks');
-		if ($query->num_rows() != 1) {
+		if (!$this->check_logbook_is_accessible($clean_logbook_id)) {
 			return;
 		}
 
 		// be sure that station belongs to user
-		$this->db->where('user_id', $this->session->userdata('user_id'));
-		$this->db->where('station_id', $clean_station_id);
-		$query = $this->db->get('station_profile');
-		if ($query->num_rows() != 1) {
+		$CI =& get_instance();
+		$CI->load->model('Stations');
+		if (!$CI->Stations->check_station_is_accessible($clean_station_id)) {
 			return;
 		}
 
-		// Delete QSOs
+		// Delete relationship
 		$this->db->where('station_logbook_id', $clean_logbook_id);
 		$this->db->where('station_location_id', $clean_station_id);
 		$this->db->delete('station_logbooks_relationship'); 
+	}
+
+	public function check_logbook_is_accessible($id) {
+		// check if logbook belongs to user
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('logbook_id', $id);
+		$query = $this->db->get('station_logbooks');
+		if ($query->num_rows() == 1) {
+			return true;
+		}
+		return false;
 	}
 }
 ?>

--- a/application/models/Logbooks_model.php
+++ b/application/models/Logbooks_model.php
@@ -26,40 +26,51 @@ class Logbooks_model extends CI_Model {
 		$this->db->insert('station_logbooks', $data); 
 	}
 
-    function delete($id) {
+	function delete($id) {
 		// Clean ID
 		$clean_id = $this->security->xss_clean($id);
 
 		// Delete QSOs
-        $this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('user_id', $this->session->userdata('user_id'));
 		$this->db->where('logbook_id', $id);
 		$this->db->delete('station_logbooks'); 
 	}
 
-    function edit() {
+	function edit() {
 		$data = array(
 			'logbook_name' => xss_clean($this->input->post('station_logbook_name', true)),
 		);
 
-        $this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('user_id', $this->session->userdata('user_id'));
 		$this->db->where('logbook_id', xss_clean($this->input->post('logbook_id', true)));
 		$this->db->update('station_logbooks', $data); 
 	}
 
 	function set_logbook_active($id) {
+		// Clean input
+		$cleanId = xss_clean($id);
+
+		// be sure that logbook belongs to user
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('logbook_id', $cleanId);
+		$query = $this->db->get('station_logbooks');
+		if ($query->num_rows() != 1) {
+			return;
+		}
+
 		$data = array(
-			'active_station_logbook' => xss_clean($id),
+			'active_station_logbook' => $cleanId,
 		);
 
-        $this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('user_id', $this->session->userdata('user_id'));
 		$this->db->update('users', $data); 
 	}
 
-    function logbook($id) {
+	function logbook($id) {
 		// Clean ID
 		$clean_id = $this->security->xss_clean($id);
 
-        $this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('user_id', $this->session->userdata('user_id'));
 		$this->db->where('logbook_id', $clean_id);
 		return $this->db->get('station_logbooks');
 	}
@@ -67,10 +78,30 @@ class Logbooks_model extends CI_Model {
 
 	// Creates relationship between a logbook and a station location
 	function create_logbook_location_link($logbook_id, $location_id) {
+		// Clean ID
+		$clean_logbook_id = $this->security->xss_clean($logbook_id);
+		$clean_location_id = $this->security->xss_clean($location_id);
+
+		// be sure that logbook belongs to user
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('logbook_id', $clean_logbook_id);
+		$query = $this->db->get('station_logbooks');
+		if ($query->num_rows() != 1) {
+			return;
+		}
+
+		// be sure that station belongs to user
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('station_id', $clean_location_id);
+		$query = $this->db->get('station_profile');
+		if ($query->num_rows() != 1) {
+			return;
+		}
+
 		// Create data array with field values
 		$data = array(
-			'station_logbook_id' => $logbook_id,
-			'station_location_id' =>  $location_id,
+			'station_logbook_id' => $clean_logbook_id,
+			'station_location_id' =>  $clean_location_id,
 		);
 
 		// Insert Record
@@ -138,6 +169,22 @@ class Logbooks_model extends CI_Model {
 		// Clean ID
 		$clean_logbook_id = $this->security->xss_clean($logbook_id);
 		$clean_station_id = $this->security->xss_clean($station_id);
+
+		// be sure that logbook belongs to user
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('logbook_id', $clean_logbook_id);
+		$query = $this->db->get('station_logbooks');
+		if ($query->num_rows() != 1) {
+			return;
+		}
+
+		// be sure that station belongs to user
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('station_id', $clean_station_id);
+		$query = $this->db->get('station_profile');
+		if ($query->num_rows() != 1) {
+			return;
+		}
 
 		// Delete QSOs
 		$this->db->where('station_logbook_id', $clean_logbook_id);

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -26,6 +26,11 @@ class Stations extends CI_Model {
 		return $this->db->get('station_profile');
 	}
 
+	function all_of_user() {
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		return $this->db->get('station_profile');
+	}
+
 	function profile($id) {
 		// Clean ID
 		$clean_id = $this->security->xss_clean($id);
@@ -129,54 +134,67 @@ class Stations extends CI_Model {
 	}
 
 	function set_active($current, $new) {
-
 		// Clean inputs
-
 		$clean_current = $this->security->xss_clean($current);
 		$clean_new = $this->security->xss_clean($new);
 
-        // Deselect current default
+		// be sure that stations belong to user
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where_in('station_id', array($clean_current, $clean_new));
+		$query = $this->db->get('station_profile');
+		if ($clean_current == 0 && $query->num_rows() != 1) {
+			return;
+		}
+		if ($clean_current != 0 && $query->num_rows() != 2) {
+			return;
+		}
+
+		// Deselect current default
 		$current_default = array(
-				'station_active' => null,
+			'station_active' => null,
 		);
+		$this->db->where('user_id', $this->session->userdata('user_id'));
 		$this->db->where('station_id', $clean_current);
 		$this->db->update('station_profile', $current_default);
-		
+
 		// Deselect current default	
 		$newdefault = array(
 			'station_active' => 1,
 		);
+		$this->db->where('user_id', $this->session->userdata('user_id'));
 		$this->db->where('station_id', $clean_new);
 		$this->db->update('station_profile', $newdefault);
-    }
+	}
 
-    public function find_active() {
-        $this->db->where('station_active', 1);
-       	$query = $this->db->get('station_profile');
-        
-        if($query->num_rows() >= 1) {
-        	foreach ($query->result() as $row)
+	public function find_active() {
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('station_active', 1);
+		$query = $this->db->get('station_profile');
+
+		if($query->num_rows() >= 1) {
+			foreach ($query->result() as $row)
 			{
 				return $row->station_id;
 			}
-       	} else {
+		} else {
 			return "0";
 		}
 	}
 	
 	public function find_gridsquare() {
-        $this->db->where('station_active', 1);
-       	$query = $this->db->get('station_profile');
-        
-        if($query->num_rows() >= 1) {
-        	foreach ($query->result() as $row)
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('station_active', 1);
+		$query = $this->db->get('station_profile');
+
+		if($query->num_rows() >= 1) {
+			foreach ($query->result() as $row)
 			{
 				return $row->station_gridsquare;
 			}
-       	} else {
+		} else {
 			return "0";
 		}
-    }
+	}
 
     public function reassign($id) {
 		// Clean ID

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -102,6 +102,7 @@ class Stations extends CI_Model {
             'qrzrealtime' => xss_clean($this->input->post('qrzrealtime', true)),
 		);
 
+		$this->db->where('user_id', $this->session->userdata('user_id'));
 		$this->db->where('station_id', xss_clean($this->input->post('station_id', true)));
 		$this->db->update('station_profile', $data); 
 	}
@@ -139,13 +140,12 @@ class Stations extends CI_Model {
 		$clean_new = $this->security->xss_clean($new);
 
 		// be sure that stations belong to user
-		$this->db->where('user_id', $this->session->userdata('user_id'));
-		$this->db->where_in('station_id', array($clean_current, $clean_new));
-		$query = $this->db->get('station_profile');
-		if ($clean_current == 0 && $query->num_rows() != 1) {
-			return;
+		if ($clean_current != 0) {
+			if (!$this->check_station_is_accessible($clean_current)) {
+				return;
+			}
 		}
-		if ($clean_current != 0 && $query->num_rows() != 2) {
+		if (!$this->check_station_is_accessible($clean_new)) {
 			return;
 		}
 
@@ -294,6 +294,16 @@ class Stations extends CI_Model {
 		return $query->num_rows();
     }
 
+	public function check_station_is_accessible($id) {
+		// check if station belongs to user
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('station_id', $id);
+		$query = $this->db->get('station_profile');
+		if ($query->num_rows() == 1) {
+			return true;
+		}
+		return false;
+	}
 }
 
 ?>


### PR DESCRIPTION
- Set active logbooks checks if logbook belongs to user
- Link station to logbook checks that station and logbook belong to user
- Unlink station from logbook checks that station and logbook belong to user
- Edit of logbook only shows stations of user
- Set active station checks if station belongs to user
- find_active and find_gridsquare of Stations model check user
- QSO create/edit check that station belongs to user
- QSO form only shows stations of user