### PR TITLE
map on dashboard now shows the same QSOs as the list below

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -99,13 +99,7 @@ class Dashboard extends CI_Controller {
 		
 		$this->load->library('qra');
 
-		//echo date('Y-m-d')
-		$raw = strtotime('Monday last week');
-		
-		$mon = date('Y-m-d', $raw);
-		$sun = date('Y-m-d', strtotime('Monday next week'));
-
-		$qsos = $this->logbook_model->map_week_qsos($mon, $sun);
+		$qsos = $this->logbook_model->get_last_qsos('11');
 
 		echo "{\"markers\": [";
 		$count = 1;


### PR DESCRIPTION
the dashboard list shows the last 11 QSOs whereas the map shows the QSOs from the last week. I find that a bit confusing so I changed it to be the last 11 QSOs in both cases. Still it might not be the same number of QSOs as the map only shows QSOs with a gridsquare.