### PR TITLE
version 2 hide satellites

### DIFF
--- a/application/controllers/Gridsquares.php
+++ b/application/controllers/Gridsquares.php
@@ -17,7 +17,15 @@ class Gridsquares extends CI_Controller {
 
 
 	public function index() {
-		$data['page_title'] = "Satellite Gridsquare Map";
+		// if there are no satelite QSOs redirect to band selection directly
+		$this->load->model('logbook_model');
+		$total_sat = $this->logbook_model->total_sat();
+		if ($total_sat->num_rows() == 0) {
+			redirect('gridsquares/band/2m');
+			return;
+		}
+
+		$data['page_title'] = "Gridsquare Map";
 
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('gridsquares/main.php');

--- a/application/controllers/Gridsquares.php
+++ b/application/controllers/Gridsquares.php
@@ -17,7 +17,7 @@ class Gridsquares extends CI_Controller {
 
 
 	public function index() {
-		// if there are no satelite QSOs redirect to band selection directly
+		// if there are no satellite QSOs redirect to band selection directly
 		$this->load->model('logbook_model');
 		$total_sat = $this->logbook_model->total_sat();
 		if ($total_sat->num_rows() == 0) {

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1279,7 +1279,8 @@ class Logbook_model extends CI_Model {
 
       $this->db->select('COL_SAT_NAME, COUNT( * ) as count', FALSE);
       $this->db->where_in('station_id', $logbooks_locations_array);
-      $this->db->where('COL_SAT_NAME !=', 'null');
+      $this->db->where('COL_SAT_NAME is not null');
+      $this->db->where('COL_SAT_NAME !=', '');
       $this->db->group_by('COL_SAT_NAME');
       $query = $this->db->get($this->config->item('table_name'));
 

--- a/application/views/distances/index.php
+++ b/application/views/distances/index.php
@@ -8,18 +8,24 @@
         <form class="form-inline">
             <label class="my-1 mr-2" for="distplot_bands">Band Selection</label>
             <select class="custom-select my-1 mr-sm-2"  id="distplot_bands">
-                <option value="sat">SAT</option>
+                <?php if (count($sats_available) != 0) { ?>
+                    <option value="sat">SAT</option>
+                <?php } ?>
                 <?php foreach($bands_available as $band) {
                     echo '<option value="' . $band . '"' . '>' . $band . '</option>'."\n";
                 } ?>
             </select>
-            <label class="my-1 mr-2" for="distplot_sats">Satellite</label>
-            <select class="custom-select my-1 mr-sm-2"  id="distplot_sats">
-                <option value="All">All</option>
-                <?php foreach($sats_available as $sat) {
-                    echo '<option value="' . $sat . '"' . '>' . $sat . '</option>'."\n";
-                } ?>
-            </select>
+            <?php if (count($sats_available) != 0) { ?>
+                <label class="my-1 mr-2" for="distplot_sats">Satellite</label>
+                <select class="custom-select my-1 mr-sm-2"  id="distplot_sats">
+                    <option value="All">All</option>
+                    <?php foreach($sats_available as $sat) {
+                        echo '<option value="' . $sat . '"' . '>' . $sat . '</option>'."\n";
+                    } ?>
+                </select>
+            <?php } else { ?>
+                <input id="distplot_sats" type="hidden" value="All"></input>
+            <?php } ?>
             <button id="plot" type="button" name="plot" class="btn btn-primary" onclick="distPlot(this.form)">Plot</button>
         </form>
     </div>

--- a/application/views/statistics/index.php
+++ b/application/views/statistics/index.php
@@ -13,7 +13,7 @@
 		google.setOnLoadCallback(drawBandChart);
 	<?php } ?>
 
-	<?php if ($total_sat) { ?>
+	<?php if ($total_sat && $total_sat->num_rows() != 0) { ?>
 		google.setOnLoadCallback(drawSatChart);
 	<?php } ?>
 
@@ -208,14 +208,16 @@
 
 	<br>
 
-	<ul class="nav nav-tabs" id="myTab" role="tablist">
-		<li class="nav-item">
-			<a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true">General</a>
-		</li>
-		<li class="nav-item">
-			<a class="nav-link" id="satellite-tab" data-toggle="tab" href="#satellite" role="tab" aria-controls="satellite" aria-selected="false">Satellites</a>
-		</li>
-	</ul>
+	<?php if ($total_sat && $total_sat->num_rows() != 0) { ?>
+		<ul class="nav nav-tabs" id="myTab" role="tablist">
+			<li class="nav-item">
+				<a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true">General</a>
+			</li>
+			<li class="nav-item">
+				<a class="nav-link" id="satellite-tab" data-toggle="tab" href="#satellite" role="tab" aria-controls="satellite" aria-selected="false">Satellites</a>
+			</li>
+		</ul>
+	<?php } ?>
 
 	<div class="tab-content" id="myTabContent">
 		<div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">


### PR DESCRIPTION
hide satellites selection if there are not satellite QSOs in
* statistics (task from version 2)
* distances worked (added to be consistent)
* gridsquares (added to be consistent)

Not sure if it is good as I did it for gridsquares but as in that case the statistic uses different controller actions simply hiding the field was not enough. Therefore I used a redirect if there are not sat QSOs.