### PR TITLE
[LoTW] Fix MFSK mode mapping

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -927,17 +927,20 @@ class Lotw extends CI_Controller {
 				if ($submode == "FT4") {
 					return "FT4";
 					break;
-				} elseif ($submode == "JS8") {
-						return "JS8";
-						break;
 				} elseif ($submode == "FST4") {
-						return "FST4";
-						break;
+					return "FST4";
+					break;
+				} elseif ($submode == "MFSK16") {
+					return "MFSK16";
+					break;
+				} elseif ($submode == "MFSK8") {
+					return "MFSK8";
+					break;
 				} elseif ($submode == "Q65") {
-						return "Q65";
-						break;
+					return "Q65";
+					break;
 				} else {
-					return "MFSK";
+					return "DATA";
 					break;
 				}
 			default:


### PR DESCRIPTION
Fixed https://github.com/magicbug/Cloudlog/issues/1248

According to the TQSL mapping rules, all MFSK besides `FT4/FST4/MFSK16/MFSK8/Q65` need to be mapped to `DATA` mode

```
<adifmode adif-mode="MFSK" adif-submode="FSQCALL" mode="DATA">FSQCALL</adifmode>
<adifmode adif-mode="MFSK" adif-submode="FST4" mode="FST4">FST4</adifmode>
<adifmode adif-mode="MFSK" adif-submode="FT4" mode="FT4">FT4</adifmode>
<adifmode adif-mode="MFSK" adif-submode="JS8" mode="DATA">JS8</adifmode>
<adifmode adif-mode="MFSK" adif-submode="MFSK11" mode="DATA">MFSK11</adifmode>
<adifmode adif-mode="MFSK" adif-submode="MFSK128" mode="DATA">MFSK128</adifmode>
<adifmode adif-mode="MFSK" adif-submode="MFSK16" mode="MFSK16">MFSK16</adifmode>
<adifmode adif-mode="MFSK" adif-submode="MFSK22" mode="DATA">MFSK22</adifmode>
<adifmode adif-mode="MFSK" adif-submode="MFSK31" mode="DATA">MFSK31</adifmode>
<adifmode adif-mode="MFSK" adif-submode="MFSK32" mode="DATA">MFSK32</adifmode>
<adifmode adif-mode="MFSK" adif-submode="MFSK4" mode="DATA">MFSK4</adifmode>
<adifmode adif-mode="MFSK" adif-submode="MFSK64" mode="DATA">MFSK64</adifmode>
<adifmode adif-mode="MFSK" adif-submode="MFSK8" mode="MFSK8">MFSK8</adifmode>
<adifmode adif-mode="MFSK" adif-submode="Q65" mode="Q65">Q65</adifmode>
<adifmode adif-mode="MFSK" mode="DATA">MFSK</adifmode>
```

This commit https://github.com/magicbug/Cloudlog/commit/c34f80f5e9036f2299af27d9b4accf80b6aab0b4 doesn't work at all

```
2021-11-20 11:52:07 LOTW_QSO: Error in record 3: MODE: Invalid value in field (JS8)
```