### PR TITLE
Small fixes for installator

### DIFF
--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -9,7 +9,12 @@
 		}
 
 		function update($result) {
-		
+			if ($result['timestamp'] != "") {
+				$timestamp = $result['timestamp'];
+			} else {
+				$timestamp = date("Y-m-d H:i:s");
+			}
+
 			$this->db->where('radio', $result['radio']); 
 			$query = $this->db->get('cat');
 			
@@ -41,7 +46,7 @@
 						$data = array(
 						'frequency' => $result['frequency'],
 						'mode' => $result['mode'],
-						'timestamp' => $result['timestamp'],
+						'timestamp' => $timestamp,
 						);
 
 						$this->db->where('id', $radio_id);
@@ -67,7 +72,7 @@
 						'radio' => $result['radio'],
 						'frequency' => $result['frequency'],
 						'mode' => $result['mode'],
-						'timestamp' => $result['timestamp'],
+						'timestamp' => $timestamp,
 					);
 				}
 

--- a/install/index.php
+++ b/install/index.php
@@ -5,8 +5,20 @@ $db_config_path = '../application/config/';
 
 $db_file_path = $db_config_path."database.php";
 
+function delDir($dir) {
+	$files = glob( $dir . '*', GLOB_MARK );
+    foreach( $files as $file ){
+        if( substr( $file, -1 ) == '/' )
+            delDir( $file );
+        else
+            unlink( $file );
+    }
+    rmdir( $dir );
+}
+
 if (file_exists($db_file_path)) {
-    echo "Cloudlog is already installed, please delete the /install folder.";
+	delDir(getcwd());
+	header("../");
 	exit;
 }
 
@@ -40,11 +52,23 @@ if($_POST) {
 
 		// If no errors, redirect to registration page
 		if(!isset($message)) {
+			sleep(1);
+			$ch = curl_init();
+			$protocol=((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443) ? "https" : "http";
+			list($realHost,)=explode(':',$_SERVER['HTTP_HOST']);
+			$cloudlog_url=$protocol."://".$realHost.":".$_SERVER['SERVER_PORT'];
+			curl_setopt($ch, CURLOPT_URL,$cloudlog_url);
+			curl_setopt($ch, CURLOPT_VERBOSE, 0);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			$result = curl_exec($ch);
+			curl_setopt($ch, CURLOPT_URL,$cloudlog_url."/index.php/update/dxcc");
+			$result = curl_exec($ch);
+			delDir(getcwd());
+			header('Location: '.$protocol."://".$_SERVER['HTTP_HOST'].$_POST['directory']);
 			echo "<h1>Install successful</h1>";
 			echo "<p>Please delete the install folder";
 			exit;
 		}
-
 	}
 	else {
 		$message = $core->show_message('error','Not all fields have been filled in correctly. The host, username, password, and database name are required.');
@@ -139,4 +163,3 @@ if($_POST) {
 
 	</body>
 </html>
-

--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -256,8 +256,9 @@ if ( ! function_exists('get_config'))
 			}
 			elseif ( ! $found)
 			{
-				set_status_header(503);
-				echo 'The configuration file does not exist.';
+				// set_status_header(301);
+				header('Location: install/');
+				// echo 'The configuration file does not exist.';
 				exit(3); // EXIT_CONFIG
 			}
 


### PR DESCRIPTION
If config.php doesn't exist then user we'll be redirect to install page. Installator, after sucessful install will open main site with curl (to load extra sql files to DB), update dxcc (also with curl) and then remove install dir for security reason automaticlly.