### PR TITLE
Change how comments in CL show on eQSL.

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -451,6 +451,15 @@ class eqsl extends CI_Controller {
                     $adif .= "%20";
 				}
 
+                 if ($qsl['COL_COMMENT'] != ''){
+                    $adif .= "%3C";
+                    $adif .= "QSLMSG";
+                    $adif .= "%3A";
+                    $adif .= strlen($qsl['COL_COMMENT']);
+                    $adif .= "%3E";
+                    $adif .= $qsl['COL_COMMENT'];
+                    $adif .= "%20";
+                                }
 
 				# Tie a bow on it!
 				$adif .= "%3C";


### PR DESCRIPTION
Adding the ability to send comments in Cloudlog to show on eQSL.

They use QSLMSG, and if you send anything in the COMMENT section, like signal reports from WSJT-X, it will be ignored by eQSL. 

So this edit adds reading the comments section and will upload it as QSLMSG.