### PR TITLE
Also add QSL/contest tooltips to advanced search results

### DIFF
--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -12,6 +12,12 @@ class Search extends CI_Controller {
             $this->load->model('user_model');
             if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
         }
+
+        // Load language files
+        $this->lang->load(array(
+          'lotw',
+          'eqsl',
+        ));
     }
 
 	public function index()

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -360,6 +360,7 @@ function load_was_map() {
                     if (isDarkModeTheme()) {
                         $(".buttons-csv").css("color", "white");
                     }
+                    $('[data-toggle="tooltip"]').tooltip();
                     $(".searchbutton").removeClass('running');
                     $(".searchbutton").prop('disabled', false);
                     $("#btn-save").show();
@@ -395,6 +396,7 @@ function load_was_map() {
         //$log.info(e.value);
     });
 </script>
+
 <?php } ?>
 
 <script>

--- a/application/views/search/search_result_ajax.php
+++ b/application/views/search/search_result_ajax.php
@@ -119,8 +119,8 @@
 
 			switch($this->session->userdata('user_column1')==""?'Mode':$this->session->userdata('user_column1')) {
 				case 'Mode':    echo '<td>'; echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE; break;
-				case 'RSTS':    echo '<td>' . $row->COL_RST_SENT; if ($row->COL_STX) { echo '<span class="badge badge-light">'; printf("%03d", $row->COL_STX); echo '</span>';} if ($row->COL_STX_STRING) { echo '<span class="badge badge-light">' . $row->COL_STX_STRING . '</span>';}; break;
-				case 'RSTR':    echo '<td>' . $row->COL_RST_RCVD; if ($row->COL_SRX) { echo '<span class="badge badge-light">'; printf("%03d", $row->COL_SRX); echo '</span>';} if ($row->COL_SRX_STRING) { echo '<span class="badge badge-light">' . $row->COL_SRX_STRING . '</span>';}; break;
+				case 'RSTS':    echo '<td>' . $row->COL_RST_SENT; if ($row->COL_STX) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">'; printf("%03d", $row->COL_STX); echo '</span>';} if ($row->COL_STX_STRING) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">' . $row->COL_STX_STRING . '</span>';} echo '</td>'; break;
+				case 'RSTR': echo '<td>' . $row->COL_RST_RCVD; if ($row->COL_SRX) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">'; printf("%03d", $row->COL_SRX); echo '</span>';} if ($row->COL_SRX_STRING) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">' . $row->COL_SRX_STRING . '</span>';} echo '</td>'; break;
 				case 'Country': echo '<td>' . ucwords(strtolower(($row->COL_COUNTRY)));; break;
 				case 'IOTA':    echo '<td>' . ($row->COL_IOTA); break;
 				case 'SOTA':    echo '<td>' . ($row->COL_SOTA_REF); break;
@@ -132,8 +132,8 @@
 			echo '</td>';
 			switch($this->session->userdata('user_column2')==""?'RSTS':$this->session->userdata('user_column2')) {
 				case 'Mode':    echo '<td>'; echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE; break;
-				case 'RSTS':    echo '<td>' . $row->COL_RST_SENT; if ($row->COL_STX) { echo '<span class="badge badge-light">'; printf("%03d", $row->COL_STX); echo '</span>';} if ($row->COL_STX_STRING) { echo '<span class="badge badge-light">' . $row->COL_STX_STRING . '</span>';}; break;
-				case 'RSTR':    echo '<td>' . $row->COL_RST_RCVD; if ($row->COL_SRX) { echo '<span class="badge badge-light">'; printf("%03d", $row->COL_SRX); echo '</span>';} if ($row->COL_SRX_STRING) { echo '<span class="badge badge-light">' . $row->COL_SRX_STRING . '</span>';}; break;
+				case 'RSTS':    echo '<td>' . $row->COL_RST_SENT; if ($row->COL_STX) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">'; printf("%03d", $row->COL_STX); echo '</span>';} if ($row->COL_STX_STRING) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">' . $row->COL_STX_STRING . '</span>';} echo '</td>'; break;
+				case 'RSTR': echo '<td>' . $row->COL_RST_RCVD; if ($row->COL_SRX) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">'; printf("%03d", $row->COL_SRX); echo '</span>';} if ($row->COL_SRX_STRING) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">' . $row->COL_SRX_STRING . '</span>';} echo '</td>'; break;
 				case 'Country': echo '<td>' . ucwords(strtolower(($row->COL_COUNTRY)));; break;
 				case 'IOTA':    echo '<td>' . ($row->COL_IOTA); break;
 				case 'SOTA':    echo '<td>' . ($row->COL_SOTA_REF); break;
@@ -146,8 +146,8 @@
 
 			switch($this->session->userdata('user_column3')==""?'RSTR':$this->session->userdata('user_column3')) {
 				case 'Mode':    echo '<td>'; echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE; break;
-				case 'RSTS':    echo '<td>' . $row->COL_RST_SENT; if ($row->COL_STX) { echo '<span class="badge badge-light">'; printf("%03d", $row->COL_STX); echo '</span>';} if ($row->COL_STX_STRING) { echo '<span class="badge badge-light">' . $row->COL_STX_STRING . '</span>';}; break;
-				case 'RSTR':    echo '<td>' . $row->COL_RST_RCVD; if ($row->COL_SRX) { echo '<span class="badge badge-light">'; printf("%03d", $row->COL_SRX); echo '</span>';} if ($row->COL_SRX_STRING) { echo '<span class="badge badge-light">' . $row->COL_SRX_STRING . '</span>';}; break;
+				case 'RSTS':    echo '<td>' . $row->COL_RST_SENT; if ($row->COL_STX) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">'; printf("%03d", $row->COL_STX); echo '</span>';} if ($row->COL_STX_STRING) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">' . $row->COL_STX_STRING . '</span>';} echo '</td>'; break;
+				case 'RSTR': echo '<td>' . $row->COL_RST_RCVD; if ($row->COL_SRX) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">'; printf("%03d", $row->COL_SRX); echo '</span>';} if ($row->COL_SRX_STRING) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">' . $row->COL_SRX_STRING . '</span>';} echo '</td>'; break;
 				case 'Country': echo '<td>' . ucwords(strtolower(($row->COL_COUNTRY)));; break;
 				case 'IOTA':    echo '<td>' . ($row->COL_IOTA); break;
 				case 'SOTA':    echo '<td>' . ($row->COL_SOTA_REF); break;
@@ -159,8 +159,8 @@
 			echo '</td>';
 			switch($this->session->userdata('user_column4')==""?'Band':$this->session->userdata('user_column4')) {
 				case 'Mode':    echo '<td>'; echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE; break;
-				case 'RSTS':    echo '<td>' . $row->COL_RST_SENT; if ($row->COL_STX) { echo '<span class="badge badge-light">'; printf("%03d", $row->COL_STX); echo '</span>';} if ($row->COL_STX_STRING) { echo '<span class="badge badge-light">' . $row->COL_STX_STRING . '</span>';}; break;
-				case 'RSTR':    echo '<td>' . $row->COL_RST_RCVD; if ($row->COL_SRX) { echo '<span class="badge badge-light">'; printf("%03d", $row->COL_SRX); echo '</span>';} if ($row->COL_SRX_STRING) { echo '<span class="badge badge-light">' . $row->COL_SRX_STRING . '</span>';}; break;
+				case 'RSTS':    echo '<td>' . $row->COL_RST_SENT; if ($row->COL_STX) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">'; printf("%03d", $row->COL_STX); echo '</span>';} if ($row->COL_STX_STRING) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">' . $row->COL_STX_STRING . '</span>';} echo '</td>'; break;
+				case 'RSTR': echo '<td>' . $row->COL_RST_RCVD; if ($row->COL_SRX) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">'; printf("%03d", $row->COL_SRX); echo '</span>';} if ($row->COL_SRX_STRING) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">' . $row->COL_SRX_STRING . '</span>';} echo '</td>'; break;
 				case 'Country': echo '<td>' . ucwords(strtolower(($row->COL_COUNTRY)));; break;
 				case 'IOTA':    echo '<td>' . ($row->COL_IOTA); break;
 				case 'SOTA':    echo '<td>' . ($row->COL_SOTA_REF); break;
@@ -172,8 +172,8 @@
 			echo '</td>';
 			switch($this->session->userdata('user_column5')==""?'Country':$this->session->userdata('user_column5')) {
 				case 'Mode':    echo '<td>'; echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE; break;
-				case 'RSTS':    echo '<td>' . $row->COL_RST_SENT; if ($row->COL_STX) { echo '<span class="badge badge-light">'; printf("%03d", $row->COL_STX); echo '</span>';} if ($row->COL_STX_STRING) { echo '<span class="badge badge-light">' . $row->COL_STX_STRING . '</span>';}; break;
-				case 'RSTR':    echo '<td>' . $row->COL_RST_RCVD; if ($row->COL_SRX) { echo '<span class="badge badge-light">'; printf("%03d", $row->COL_SRX); echo '</span>';} if ($row->COL_SRX_STRING) { echo '<span class="badge badge-light">' . $row->COL_SRX_STRING . '</span>';}; break;
+				case 'RSTS':    echo '<td>' . $row->COL_RST_SENT; if ($row->COL_STX) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">'; printf("%03d", $row->COL_STX); echo '</span>';} if ($row->COL_STX_STRING) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">' . $row->COL_STX_STRING . '</span>';} echo '</td>'; break;
+				case 'RSTR': echo '<td>' . $row->COL_RST_RCVD; if ($row->COL_SRX) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">'; printf("%03d", $row->COL_SRX); echo '</span>';} if ($row->COL_SRX_STRING) { echo '<span data-toggle="tooltip" data-original-title="'.($row->COL_CONTEST_ID!=""?$row->COL_CONTEST_ID:"n/a").'" class="badge badge-light">' . $row->COL_SRX_STRING . '</span>';} echo '</td>'; break;
 				case 'Country': echo '<td>' . ucwords(strtolower(($row->COL_COUNTRY)));; break;
 				case 'IOTA':    echo '<td>' . ($row->COL_IOTA); break;
 				case 'SOTA':    echo '<td>' . ($row->COL_SOTA_REF); break;
@@ -184,66 +184,137 @@
 			}
 			echo '</td>';
 				if(($this->config->item('use_auth')) && ($this->session->userdata('user_type') >= 2)) { ?>
-                <td class="qsl">
-				<span class="qsl-<?php
-                switch ($row->COL_QSL_SENT) {
-                    case "Y":
-                        echo "green";
+
+                <?php
+                  echo '<td style=\'text-align: center\' class="qsl">';
+                  echo '<span ';
+                  if ($row->COL_QSL_SENT != "N") {
+                     $timestamp = strtotime($row->COL_QSLSDATE);
+                     switch ($row->COL_QSL_SENT) {
+                     case "Y":
+                        echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_sent')." ".date($custom_date_format,$timestamp);
                         break;
-                    case "Q":
-                        echo "yellow";
+                     case "Q":
+                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued')." ".date($custom_date_format,$timestamp);
                         break;
-                    case "R":
-                        echo "yellow";
+                     case "R":
+                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested')." ".date($custom_date_format,$timestamp);
                         break;
-                    case "I":
-                        echo "grey";
+                     case "I":
+                        echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore')." ".date($custom_date_format,$timestamp);
                         break;
-                    default:
-                        echo "red";
+                     default:
+                        echo "class=\"qsl-red";
+                        break;
+                     }
+                  } else { echo "class=\"qsl-red"; }
+                  if ($row->COL_QSL_SENT_VIA != "") {
+                     switch ($row->COL_QSL_SENT_VIA) {
+                     case "B":
+                        echo " (".$this->lang->line('general_word_qslcard_bureau').")";
+                        break;
+                     case "D":
+                        echo " (".$this->lang->line('general_word_qslcard_direct').")";
+                        break;
+                     case "M":
+                        echo " (".$this->lang->line('general_word_qslcard_via').": ".($row->COL_QSL_VIA!="" ? $row->COL_QSL_VIA:"n/a").")";
+                        break;
+                     case "E":
+                        echo " (".$this->lang->line('general_word_qslcard_electronic').")";
+                        break;
+                     }
+                  }
+                  echo '">&#9650;</span>';
+                  echo '<span ';
+                  if ($row->COL_QSL_RCVD != "N") {
+                     $timestamp = strtotime($row->COL_QSLRDATE);
+                     switch ($row->COL_QSL_RCVD) {
+                     case "Y":
+                        echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_received')." ".date($custom_date_format,$timestamp);
+                        break;
+                     case "Q":
+                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued')." ".date($custom_date_format,$timestamp);
+                        break;
+                     case "R":
+                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested')." ".date($custom_date_format,$timestamp);
+                        break;
+                     case "I":
+                        echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore')." ".date($custom_date_format,$timestamp);
+                        break;
+                     default:
+                        echo "class=\"qsl-red";
+                        break;
+                     }
+                  } else { echo "class=\"qsl-red"; }
+                  if ($row->COL_QSL_RCVD_VIA != "") {
+                     switch ($row->COL_QSL_RCVD_VIA) {
+                     case "B":
+                        echo " (".$this->lang->line('general_word_qslcard_bureau').")";
+                        break;
+                     case "D":
+                        echo " (".$this->lang->line('general_word_qslcard_direct').")";
+                        break;
+                     case "M":
+                        echo " (Manager)";
+                        break;
+                     case "E":
+                        echo " (".$this->lang->line('general_word_qslcard_electronic').")";
+                        break;
+                     }
+                  }
+                  echo '">&#9660;</span>';
+                ?>
+                <?php if ($this->session->userdata('user_eqsl_name') != ""){
+                  echo '<td style=\'text-align: center\' class="eqsl">';
+                  echo '<span ';
+                  if ($row->COL_EQSL_QSL_SENT == "Y") {
+                     $timestamp = strtotime($row->COL_EQSL_QSLSDATE);
+                     echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_sent')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+                  }
+                  echo ' class="eqsl-';
+                  echo ($row->COL_EQSL_QSL_SENT=='Y')?'green':'red';
+                  echo '">&#9650;</span>';
+
+                  echo '<span ';
+                  if ($row->COL_EQSL_QSL_RCVD == "Y") {
+                     $timestamp = strtotime($row->COL_EQSL_QSLRDATE);
+                     echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_received')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+                  }
+                  echo ' class="eqsl-';
+                  echo ($row->COL_EQSL_QSL_RCVD=='Y')?'green':'red';
+                  echo '">';
+                  if($row->COL_EQSL_QSL_RCVD =='Y') {
+                     echo '<a style="color: green" href="';
+                     echo site_url("eqsl/image/".$row->COL_PRIMARY_KEY);
+                     echo '" data-fancybox="images" data-width="528" data-height="336">&#9660;</a>';
+                  } else {
+                     echo '&#9660;';
+                  }
+                  echo '</span>';
+                  echo '</td>';
+                } ?>
+
+                <?php if($this->session->userdata('user_lotw_name') != "") {
+                echo '<td style=\'text-align: center\' class="lotw">';
+                echo '<span ';
+                if ($row->COL_LOTW_QSL_SENT == "Y") {
+                   $timestamp = strtotime($row->COL_LOTW_QSLSDATE);
+                   echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_sent')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
                 }
-                ?>">&#9650;</span>
-                    <span class="qsl-<?php
-                    switch ($row->COL_QSL_RCVD) {
-                        case "Y":
-                            echo "green";
-                            break;
-                        case "Q":
-                            echo "yellow";
-                            break;
-                        case "R":
-                            echo "yellow";
-                            break;
-                        case "I":
-                            echo "grey";
-                            break;
-                        default:
-                            echo "red";
-                    }
-                    ?>">&#9660;</span>
-                </td>
+                echo ' class="lotw-';
+                echo ($row->COL_LOTW_QSL_SENT=='Y')?'green':'red';
+                echo '">&#9650;</span>';
 
-                <?php if ($this->session->userdata('user_eqsl_name') != ""){ ?>
-                    <td class="eqsl">
-                        <span class="eqsl-<?php echo ($row->COL_EQSL_QSL_SENT=='Y')?'green':'red'?>">&#9650;</span>
-                        <span class="eqsl-<?php echo ($row->COL_EQSL_QSL_RCVD=='Y')?'green':'red'?>">
-			    	<?php if($row->COL_EQSL_QSL_RCVD =='Y') { ?>
-                        <a style="color: green" href="<?php echo site_url("eqsl/image/".$row->COL_PRIMARY_KEY); ?>" data-fancybox="images" data-width="528" data-height="336">&#9660;</a>
-                    <?php } else { ?>
-                        &#9660;
-                    <?php } ?>
-			    </span>
-                    </td>
-                <?php } ?>
-
-                <?php if($this->session->userdata('user_lotw_name') != "") { ?>
-                    <td class="lotw">
-                        <?php if ($row->COL_LOTW_QSL_SENT != ''){ ?>
-                            <span class="lotw-<?php echo ($row->COL_LOTW_QSL_SENT=='Y')?'green':'red'?>">&#9650;</span>
-                            <span class="lotw-<?php echo ($row->COL_LOTW_QSL_RCVD=='Y')?'green':'red'?>">&#9660;</span>
-                        <?php } ?>
-                    </td>
-                <?php } ?>
+                echo '<span ';
+                if ($row->COL_LOTW_QSL_RCVD == "Y") {
+                   $timestamp = strtotime($row->COL_LOTW_QSLRDATE);
+                   echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_received')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+                }
+                echo ' class="lotw-';
+                echo ($row->COL_LOTW_QSL_RCVD=='Y')?'green':'red';
+                echo '">&#9660;</span>';
+                echo '</td>';
+                } ?>
 
             <?php } ?>
 


### PR DESCRIPTION
This ports the tooltips for contest and QSL info to the advanced search results section in Cloudlog.

![Screenshot from 2022-02-13 23-05-39](https://user-images.githubusercontent.com/7112907/153777232-aeff89d1-96f1-49bf-b3cf-5e07cc909062.png)
