### PR TITLE
added missing join (otherwise error in view)

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -365,6 +365,8 @@ class Logbook_model extends CI_Model {
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
+		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+
         if ($band != 'All') {
             if ($band == 'SAT') {
                 $this->db->where('col_prop_mode', $band);
@@ -378,7 +380,7 @@ class Logbook_model extends CI_Model {
             $this->db->where('col_mode', $mode);
         }
 
-        $this->db->where_in('station_id', $logbooks_locations_array);
+        $this->db->where_in('station_profile.station_id', $logbooks_locations_array);
 
         switch($type) {
             case 'dxcc': $this->db->where('COL_DXCC', $querystring); break;


### PR DESCRIPTION
Without this join there is an error when doing

- Open "Analytics > Timeline"
- Click on "Show" in "Show QSOs" column
=> Error in log_ajax.php

Reason is that the timeline details use the same view as the logbook partial but were not having the join so far.