### PR TITLE
Add table for (VUCC) gridsquare activators top list

### DIFF
--- a/application/controllers/Activators.php
+++ b/application/controllers/Activators.php
@@ -1,0 +1,75 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Activators extends CI_Controller {
+
+    function __construct()
+    {
+        parent::__construct();
+
+        $this->load->model('user_model');
+        if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+    }
+
+    public function index()
+    {
+        // Render Page
+        $data['page_title'] = "Gridsquare Activators";
+
+        $this->load->model('Activators_model');
+
+        if ($this->input->post('band') != NULL) {   // Band is not set when page first loads.
+            $band = $this->input->post('band');
+        }
+        else {
+            $band = 'All';
+        }
+
+        $this->load->model('bands');
+
+        $data['worked_bands'] = $this->bands->get_worked_bands();
+        $data['maxactivatedgrids'] = $this->Activators_model->get_max_activated_grids();
+        $data['activators_array'] = $this->Activators_model->get_activators($band, $this->input->post('mincount'), $this->input->post('leogeo'));
+        $data['activators_vucc_array'] = $this->Activators_model->get_activators_vucc($band, $this->input->post('leogeo'));
+        $data['bandselect'] = $band;
+
+        $this->load->view('interface_assets/header', $data);
+        $this->load->view('activators/index');
+        $this->load->view('interface_assets/footer');
+    }
+
+    public function details() {
+        $this->load->model('logbook_model');
+
+        $call = str_replace('"', "", $this->input->post("Callsign"));
+        $band = str_replace('"', "", $this->input->post("Band"));
+        $leogeo = str_replace('"', "", $this->input->post("LeoGeo"));
+        $data['results'] = $this->logbook_model->activator_details($call, $band, $leogeo);
+        $data['filter'] = "Call ".$call;
+        switch($band) {
+        case 'All':     $data['page_title'] = "Log View All Bands";
+                        $data['filter'] .= " and Band All";
+                        break;
+        case 'SAT':     $data['page_title'] = "Log View SAT";
+                        $data['filter'] .= " and Band SAT";
+                        break;
+        default:        $data['page_title'] = "Log View Band";
+                        $data['filter'] .= " and Band ".$band;
+                        break;
+        }
+        if ($band == "SAT") {
+            switch($leogeo) {
+            case 'both':    $data['filter'] .= " and GEO/LEO";
+                            break;
+            case 'leo':     $data['filter'] .= " and LEO";
+                            break;
+            case 'geo':     $data['filter'] .= " and GEO";
+                            break;
+            }
+        }
+
+
+        $this->load->view('activators/details', $data);
+    }
+
+}

--- a/application/models/Activators_model.php
+++ b/application/models/Activators_model.php
@@ -1,0 +1,117 @@
+<?php
+if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+class Activators_model extends CI_Model
+{
+    function get_activators($band, $mincount, $leogeo)  {
+		$CI =& get_instance();
+		$CI->load->model('logbooks_model');
+		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+
+      if ($mincount == '' || $mincount == 0 || ! is_numeric($mincount)) {
+         $mincount = 2;
+      }
+
+        if (!$logbooks_locations_array) {
+            return null;
+        }
+
+		$location_list = "'".implode("','",$logbooks_locations_array)."'";
+
+		$sql = "select COL_CALL as `call`, COUNT(DISTINCT(SUBSTR(COL_GRIDSQUARE,1,4))) AS `count`, GROUP_CONCAT(DISTINCT SUBSTR(`COL_GRIDSQUARE`,1,4) ORDER BY `COL_GRIDSQUARE` SEPARATOR ', ') AS `grids` from ".$this->config->item('table_name')." WHERE station_id in (" . $location_list . ")";
+        if ($band != 'All') {
+            if ($band == 'SAT') {
+               switch ($leogeo) {
+               case 'both' :
+                  $sql .= " and col_prop_mode ='" . $band . "'";
+                  break;
+               case 'leo' :
+                  $sql .= " and col_prop_mode = '" . $band . "'";
+                  $sql .= " and col_sat_name != 'QO-100'";
+                  break;
+               case 'geo' :
+                  $sql .= " and col_prop_mode = '" . $band . "'";
+                  $sql .= " and col_sat_name = 'QO-100'";
+                  break;
+               default :
+                  $sql .= " and col_prop_mode ='" . $band . "'";
+                  break;
+               }
+            }
+            else {
+                $sql .= " and col_prop_mode !='SAT'";
+                $sql .= " and COL_BAND ='" . $band . "'";
+            }
+        }
+		$sql .= " AND `COL_GRIDSQUARE` != '' GROUP BY `COL_CALL` HAVING `count` >= ".$mincount." ORDER BY `count` DESC;";
+
+        $query = $this->db->query($sql);
+
+        return $query->result();
+    }
+
+    function get_activators_vucc($band, $leogeo)  {
+		$CI =& get_instance();
+		$CI->load->model('logbooks_model');
+		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+
+        if (!$logbooks_locations_array) {
+            return null;
+        }
+
+		$location_list = "'".implode("','",$logbooks_locations_array)."'";
+
+      $sql = "SELECT DISTINCT COL_CALL AS `call`, GROUP_CONCAT(REGEXP_REPLACE(COL_VUCC_GRIDS, '([A-Z]{2}[0-9]{2})[A-Z]{2}', '$1')) AS `vucc_grids` FROM ".$this->config->item('table_name')." WHERE station_id in (" . $location_list . ")";
+        if ($band != 'All') {
+            if ($band == 'SAT') {
+               switch ($leogeo) {
+               case 'both' :
+                  $sql .= " and col_prop_mode ='" . $band . "'";
+                  break;
+               case 'leo' :
+                  $sql .= " and col_prop_mode = '" . $band . "'";
+                  $sql .= " and col_sat_name != 'QO-100'";
+                  break;
+               case 'geo' :
+                  $sql .= " and col_prop_mode = '" . $band . "'";
+                  $sql .= " and col_sat_name = 'QO-100'";
+                  break;
+               default :
+                  $sql .= " and col_prop_mode ='" . $band . "'";
+                  break;
+               }
+            }
+            else {
+                $sql .= " and col_prop_mode !='SAT'";
+                $sql .= " and COL_BAND ='" . $band . "'";
+            }
+        }
+      $sql .= " AND COL_VUCC_GRIDS != '' GROUP BY COL_CALL;";
+
+        $query = $this->db->query($sql);
+
+        return $query->result();
+    }
+	function get_max_activated_grids() {
+		$CI =& get_instance();
+		$CI->load->model('logbooks_model');
+		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+
+		if (!$logbooks_locations_array) {
+			return array();
+		}
+
+		$location_list = "'".implode("','",$logbooks_locations_array)."'";
+
+		// Get max no of activated grids of single operator
+		$data = $this->db->query(
+			"select COUNT(DISTINCT(SUBSTR(COL_GRIDSQUARE,1,4))) AS `count` from TABLE_HRD_CONTACTS_V01 WHERE station_id in (" . $location_list . ") AND `COL_GRIDSQUARE` != '' GROUP BY `COL_CALL` ORDER BY `count` DESC LIMIT 1"
+		);
+		foreach($data->result() as $row){
+			$max =  $row->count;
+		}
+
+		return $max;
+	}
+
+}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -392,6 +392,32 @@ class Logbook_model extends CI_Model {
         return $this->db->get($this->config->item('table_name'));
     }
 
+    public function activator_details($call, $band, $leogeo){
+		$CI =& get_instance();
+		$CI->load->model('logbooks_model');
+		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+
+        $this->db->where('COL_CALL', $call);
+        if ($band != 'All') {
+            if ($band == 'SAT') {
+                $this->db->where('col_prop_mode', $band);
+                switch ($leogeo) {
+                case 'leo' :  $this->db->where('COL_SAT_NAME !=', 'QO-100');
+                              break;
+                case 'geo':   $this->db->where('COL_SAT_NAME', 'QO-100');
+                              break;
+                }
+            } else {
+                $this->db->where('COL_PROP_MODE !=', 'SAT');
+                $this->db->where('col_band', $band);
+            }
+        }
+
+        $this->db->where_in('station_id', $logbooks_locations_array);
+
+        return $this->db->get($this->config->item('table_name'));
+    }
+
   public function get_callsigns($callsign){
     $this->db->select('COL_CALL');
     $this->db->distinct();

--- a/application/views/activators/details.php
+++ b/application/views/activators/details.php
@@ -1,0 +1,4 @@
+<div class="container">
+    <h5>Filtering on <?php echo $filter ?></h5>
+
+    <?php $this->load->view('view_log/partial/log_ajax') ?>

--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -1,0 +1,130 @@
+<div class="container">
+    <h1><?php echo $page_title; ?></h1>
+
+    <form class="form" action="<?php echo site_url('activators'); ?>" method="post" enctype="multipart/form-data">
+        <!-- Select Basic -->
+                <div class="form-group row">
+                    <label class="col-md-1 control-label" for="band">Band</label>
+                    <div class="col-md-3">
+                        <select id="band" name="band" class="form-control custom-select">
+                            <option value="All" <?php if ($this->input->post('band') == "All" || $this->input->method() !== 'post') echo ' selected'; ?> >All</option>
+                            <?php foreach($worked_bands as $band) {
+                                echo '<option value="' . $band . '"';
+                                if ($this->input->post('band') == $band) echo ' selected';
+                                echo '>' . $band . '</option>'."\n";
+                            } ?>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group row" id="leogeo">
+                    <label class="col-md-1 control-label" for="leogeo">LEO/GEO</label>
+                    <div class="col-md-3">
+                        <select id="leogeo" name="leogeo" class="form-control custom-select">
+                            <option value="both" <?php if ($this->input->post('leogeo') == "both" || $this->input->method() !== 'post') echo ' selected'; ?> >Both</option>
+                            <option value="leo" <?php if ($this->input->post('leogeo') == "leo") echo ' selected'; ?>>LEO</option>
+                            <option value="geo" <?php if ($this->input->post('leogeo') == "geo") echo ' selected'; ?>>GEO</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <label class="col-md-1 control-label" for="mincount">Minimum Count</label>
+                    <div class="col-md-3">
+                        <select id="mincount" name="mincount" class="form-control custom-select">
+                            <?php
+                                $i = 1;
+                                do {
+                                   echo '<option value="'.$i.'"';
+                                   if ($this->input->post('mincount') == $i || ($this->input->method() !== 'post' && $i == 2)) echo ' selected';
+                                   echo '>'.$i.'</option>'."\n";
+                                   $i++;
+                                } while ($i <= $maxactivatedgrids);
+                            ?>
+                        </select>
+                    </div>
+
+                </div>
+
+            <div class="form-group row">
+                <label class="col-md-1 control-label" for="button1id"></label>
+                <div class="col-md-10">
+                    <button id="button1id" type="submit" name="button1id" class="btn btn-primary">Show</button>
+                </div>
+            </div>
+
+    </form>
+
+    <?php 
+    // Get Date format
+    if($this->session->userdata('user_date_format')) {
+        // If Logged in and session exists
+        $custom_date_format = $this->session->userdata('user_date_format');
+    } else {
+        // Get Default date format from /config/cloudlog.php
+        $custom_date_format = $this->config->item('qso_date_format');
+    }
+    ?>
+    <?php 
+    $vucc_grids = array();
+    if ($activators_vucc_array) {
+       foreach ($activators_vucc_array as $line) {
+          $vucc_grids[$line->call] = $line->vucc_grids;
+       }
+    }
+    if ($activators_array) {
+
+        $result = write_activators($activators_array, $vucc_grids, $custom_date_format, $this->input->post('band'), $this->input->post('leogeo'));
+    }
+    else {
+        echo '<div class="alert alert-danger" role="alert"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Nothing found!</div>';
+    }
+    ?>
+
+</div>
+
+<?php
+
+function write_activators($activators_array, $vucc_grids, $custom_date_format, $band, $leogeo) {
+    if ($band == '') {
+       $band = 'All';
+    }
+    if ($leogeo == '') {
+       $leogeo = 'both';
+    }
+    $i = 1;
+    echo '<table style="width:100%" class="table table-sm activatorstable table-bordered table-hover table-striped table-condensed text-center">
+              <thead>
+                    <tr>
+                        <td>#</td>
+                        <td>Callsign</td>
+                        <td>Count</td>
+                        <td>Gridsquares</td>
+                        <td>Show QSOs</td>
+                    </tr>
+                </thead>
+                <tbody>';
+
+    $activators = array();
+    foreach ($activators_array as $line) {
+        $call = $line->call;
+        $grids = $line->grids;
+        $count = $line->count;
+        if (array_key_exists($line->call, $vucc_grids)) {
+           $grids .= ','.$vucc_grids[$line->call];
+           $grid_array = explode(',', $grids);
+           array_unique($grid_array, SORT_STRING);
+           $count = count($grid_array);
+        }
+        array_push($activators, array($count, $call, $grids));
+    }
+    arsort($activators);
+    foreach ($activators as $line) {
+        echo '<tr>
+                <td>' . $i++ . '</td>
+                <td>'.$line[1].'</td>
+                <td>'.$line[0].'</td>
+                <td style="text-align: left; font-family: monospace;">'.$line[2].'</td>
+                <td><a href=javascript:displayActivatorsContacts("'.$line[1].'","'.$band.'","'.$leogeo.'")>Show</a></td>
+               </tr>';
+    }
+    echo '</tfoot></table></div>';
+}

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -405,7 +405,8 @@ function load_was_map() {
 $(document).ready(function() {
 	$('#create_station_profile #country').val($("#dxcc_select option:selected").text());
 	$("#create_station_profile #dxcc_select" ).change(function() {
-	  $('#country').val($("#dxcc_select option:selected").text());
+	$('#country').val($("#dxcc_select option:selected").text());
+
 	});
 });
 </script>
@@ -2006,6 +2007,72 @@ $(document).ready(function(){
                         'Band': band,
                         'Mode': mode,
                         'Type': type
+                    },
+                    success: function(html) {
+                        BootstrapDialog.show({
+                            title: 'QSO Data',
+                            size: BootstrapDialog.SIZE_WIDE,
+                            cssClass: 'qso-was-dialog',
+                            nl2br: false,
+                            message: html,
+                            onshown: function(dialog) {
+                               $('[data-toggle="tooltip"]').tooltip();
+                            },
+                            buttons: [{
+                                label: 'Close',
+                                action: function (dialogItself) {
+                                    dialogItself.close();
+                                }
+                            }]
+                        });
+                    }
+                });
+            }
+        </script>
+        <?php } ?>
+    <?php if ($this->uri->segment(1) == "activators") { ?>
+        <script>
+            $('.activatorstable').DataTable({
+                "pageLength": 25,
+                responsive: false,
+                ordering: false,
+                "scrollY":        "500px",
+                "scrollCollapse": true,
+                "paging":         false,
+                "scrollX": true,
+                dom: 'Bfrtip',
+                buttons: [
+                    'csv'
+                ]
+            });
+
+            // change color of csv-button if dark mode is chosen
+            if (isDarkModeTheme()) {
+                $(".buttons-csv").css("color", "white");
+            }
+
+      $(document).ready(function(){
+         $('#band').change(function()
+         {
+            if($(this).val() == "SAT")
+            {
+               $('#leogeo').show();
+            } else {
+               $('#leogeo').hide();
+            }
+         });
+         <?php if ($this->input->post('band') != "SAT") { ?>
+         $('#leogeo').hide();
+         <?php } ?>
+      });
+            function displayActivatorsContacts(call, band, leogeo) {
+                var baseURL= "<?php echo base_url();?>";
+                $.ajax({
+                    url: baseURL + 'index.php/activators/details',
+                    type: 'post',
+                    data: {'Callsign': call,
+                        'Band': band,
+                        'LeoGeo': leogeo
                     },
                     success: function(html) {
                         BootstrapDialog.show({

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -88,6 +88,8 @@
                     <div class="dropdown-divider"></div>
                     <a class="dropdown-item" href="<?php echo site_url('activated_grids');?>" title="Activated Gridsquares">Activated Gridsquares</a>
                     <div class="dropdown-divider"></div>
+                    <a class="dropdown-item" href="<?php echo site_url('activators');?>" title="Gridsquare Activators">Gridsquare Activators</a>
+                    <div class="dropdown-divider"></div>
                     <a class="dropdown-item" href="<?php echo site_url('distances');?>" title="Distances">Distances Worked</a>
                     <div class="dropdown-divider"></div>
                     <a class="dropdown-item" href="<?php echo site_url('dayswithqso');?>" title="Days with QSOs">Days with QSOs</a>


### PR DESCRIPTION
Added a new menu item under Analytics that shows a table of (top) gridsquare activators. It takes GRIDSQUARE as well as VUCC_GRIDS into acount and lists the activators in decending order.

![Screenshot from 2022-03-22 17-43-12](https://user-images.githubusercontent.com/7112907/159531137-51f3fde8-b30c-4230-bac3-57f82f628e4d.png)


Squashed commit of the following:

commit 1091c0321e49b37f29d2997ff28051f137efc53f
Author: phl0 <florian@florian-wolters.de>
Date:   Tue Mar 22 17:31:08 2022 +0100

    Also take VUCC_GRIDS into account

commit c396e87c78e659c98c86ebf96ce21ba9a34203d0
Author: phl0 <florian@florian-wolters.de>
Date:   Thu Jan 27 23:19:39 2022 +0100

    Add ShowQSO function for detailed view

commit 52d3ef9b60de6a82c9239e6be387aa35050db203
Author: phl0 <florian@florian-wolters.de>
Date:   Thu Jan 27 20:59:58 2022 +0100

    Distinguish between LEO and GEO in SAT selection

commit 019d1d71bf3f06abbd38c65b0278c52c785bf407
Author: phl0 <florian@florian-wolters.de>
Date:   Thu Jan 27 19:57:48 2022 +0100

    Make sure mincount is numeric

commit 3802f9269d7e6bae7891e814909bd364afbfdf73
Author: phl0 <florian@florian-wolters.de>
Date:   Thu Jan 27 00:37:35 2022 +0100

    Implement optional minimin grid count

commit d206f2429d2bbaab1336c2266e7036e2ea77718d
Author: phl0 <florian@florian-wolters.de>
Date:   Wed Jan 26 23:21:55 2022 +0100

    Add table showing gridsquare activators