### PR TITLE
Fix options lib to return values not named 'options_*'

### DIFF
--- a/application/libraries/OptionsLib.php
+++ b/application/libraries/OptionsLib.php
@@ -56,15 +56,10 @@ class OptionsLib {
     
                 // return option_value as a string
                 return $options_result;
-            } else {
-                return $CI->config->item($option_name);
             }
-        } else {
-
-                return $CI->config->item($option_name);
         }
 
-        if(!$CI->config->item('option_'.$option_name)) {
+        else if(!$CI->config->item('option_'.$option_name)) {
             //Load the options model
             $CI->load->model('options_model');
             

--- a/application/libraries/OptionsLib.php
+++ b/application/libraries/OptionsLib.php
@@ -113,7 +113,12 @@ class OptionsLib {
         // If session data for stylesheet is set return choice
         if($CI->session->userdata('user_stylesheet')) {
             return $CI->session->userdata('user_stylesheet');
-        } else {
+        }
+        else if ($CI->options_model->item('theme')) {
+            // Return the globally stored theme from database.
+            return $CI->options_model->item('theme');
+        }
+        else {
             // Return the global choice.
             return $CI->config->item('option_theme');
         }


### PR DESCRIPTION
Switching themes for global appearance options does switch values in database but will not correctly display them on the config page and always show "Blue' as (default because first item in the list) theme.

Reason:
The options library would not return configuration items not having 'options_' as prefix in their name. Instead it would return config items from the config file. If the file does not contain that item (e.g. theme) nothing is returned. In this case the options lib is queried for "theme" but as that does not have the "options_" prefix it looks for "theme" in the config file and as that also fails the return result is simply empty.

I think @AndreasK79 was meant to have an if - else if - else structure in the lib when he changed that. Could you please confirm?