### PR TITLE
search function for Qrz.com now has a default for $use_fullname

### DIFF
--- a/application/libraries/Qrz.php
+++ b/application/libraries/Qrz.php
@@ -54,7 +54,7 @@ class Qrz {
 	}
 
 
-	public function search($callsign, $key, $use_fullname)
+	public function search($callsign, $key, $use_fullname=true)
 	{
         $data = null;
         try {

--- a/application/libraries/Qrz.php
+++ b/application/libraries/Qrz.php
@@ -54,7 +54,7 @@ class Qrz {
 	}
 
 
-	public function search($callsign, $key, $use_fullname=true)
+	public function search($callsign, $key, $use_fullname = false)
 	{
         $data = null;
         try {


### PR DESCRIPTION
the call to
[index.php/update/check_missing_grid](https://cloudlog.mydomain.com/index.php/update/check_missing_grid)
threw an error because of the missing 3rd parameter - this PR fixes this as it sets the 3rd parameter ($use_fullname) optional with true as the default