### PR TITLE
Show profile pic of QSO partner upon logging

### DIFF
--- a/application/config/cloudlog.php
+++ b/application/config/cloudlog.php
@@ -139,3 +139,18 @@ $config['map_6digit_grids'] = FALSE;
 */
 
 $config['qso_auto_qth'] = FALSE;
+
+/*
+|--------------------------------------------------------------------------
+| Pull qrz.com image on logging
+|--------------------------------------------------------------------------
+|
+| Setting this to TRUE allows Cloudlog to pull and show
+| the profile picture of the qrz.com profile of your QSO
+| partner upon QSO logging.
+|
+| Default is: FALSE
+|
+*/
+
+$config['show_qrz_image'] = FALSE;

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -126,10 +126,13 @@ class Logbook extends CI_Controller {
 			"bearing" 		=> "",
 			"workedBefore" => false,
 			"lotw_member" => $lotw_member,
+			"image" => "",
 		];
 
 		$return['dxcc'] = $this->dxcheck($callsign);
 		$return['partial'] = $this->partial($callsign);
+
+		$callbook = $this->logbook_model->loadCallBook($callsign, $this->config->item('use_fullname'));
 
 		// Do we have local data for the Callsign?
 		if($this->logbook_model->call_name($callsign) != null)
@@ -148,6 +151,15 @@ class Logbook extends CI_Controller {
 			$return['callsign_state'] = $this->logbook_model->call_state($callsign);
 			$return['bearing'] = $this->bearing($return['callsign_qra'], $measurement_base, $station_id);
 			$return['workedBefore'] = $this->worked_grid_before($return['callsign_qra'], $type, $band, $mode);
+			if (isset($callbook)) {
+				if ($callbook['image'] == "") {
+					$return['image'] = "n/a";
+				} else {
+					$return['image'] = $callbook['image'];
+				}
+			} else {
+				$return['image'] = "n/a";
+			}
 
 			if ($return['callsign_qra'] != "") {
 				$return['latlng'] = $this->qralatlng($return['callsign_qra']);
@@ -157,7 +169,7 @@ class Logbook extends CI_Controller {
 			return;
 		}
 
-		$callbook = $this->logbook_model->loadCallBook($callsign, $this->config->item('use_fullname'));
+		//$callbook = $this->logbook_model->loadCallBook($callsign, $this->config->item('use_fullname'));
 
 		if (isset($callbook))
 		{
@@ -167,6 +179,11 @@ class Logbook extends CI_Controller {
 			$return['callsign_iota'] = $callbook['iota'];
 			$return['callsign_state'] = $callbook['state'];
 			$return['callsign_us_county'] = $callbook['us_county'];
+			if ($callbook['image'] == "") {
+				$return['image'] = "n/a";
+			} else {
+				$return['image'] = $callbook['image'];
+			}
 
 			if(isset($callbook['qslmgr'])) {
 				$return['qsl_manager'] = $callbook['qslmgr'];

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -151,14 +151,16 @@ class Logbook extends CI_Controller {
 			$return['callsign_state'] = $this->logbook_model->call_state($callsign);
 			$return['bearing'] = $this->bearing($return['callsign_qra'], $measurement_base, $station_id);
 			$return['workedBefore'] = $this->worked_grid_before($return['callsign_qra'], $type, $band, $mode);
-			if (isset($callbook)) {
-				if ($callbook['image'] == "") {
-					$return['image'] = "n/a";
+			if ($this->config->item('show_qrz_image')) {
+				if (isset($callbook)) {
+					if ($callbook['image'] == "") {
+						$return['image'] = "n/a";
+					} else {
+						$return['image'] = $callbook['image'];
+					}
 				} else {
-					$return['image'] = $callbook['image'];
+					$return['image'] = "n/a";
 				}
-			} else {
-				$return['image'] = "n/a";
 			}
 
 			if ($return['callsign_qra'] != "") {
@@ -169,8 +171,6 @@ class Logbook extends CI_Controller {
 			return;
 		}
 
-		//$callbook = $this->logbook_model->loadCallBook($callsign, $this->config->item('use_fullname'));
-
 		if (isset($callbook))
 		{
 			$return['callsign_name'] = $callbook['name'];
@@ -179,10 +179,12 @@ class Logbook extends CI_Controller {
 			$return['callsign_iota'] = $callbook['iota'];
 			$return['callsign_state'] = $callbook['state'];
 			$return['callsign_us_county'] = $callbook['us_county'];
-			if ($callbook['image'] == "") {
-				$return['image'] = "n/a";
-			} else {
-				$return['image'] = $callbook['image'];
+			if ($this->config->item('show_qrz_image')) {
+				if ($callbook['image'] == "") {
+					$return['image'] = "n/a";
+				} else {
+					$return['image'] = $callbook['image'];
+				}
 			}
 
 			if(isset($callbook['qslmgr'])) {

--- a/application/language/english/qso_lang.php
+++ b/application/language/english/qso_lang.php
@@ -6,6 +6,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['qso_title_qso_map'] = 'QSO Map';
 $lang['qso_title_suggestions'] = 'Suggestions';
 $lang['qso_title_pervious_contacts'] = 'Previous Contacts';
+$lang['qso_title_image'] = 'Image';
 
 // Input Help Text on the /QSO Display
 $lang['qso_transmit_power_helptext'] = 'Give power value in Watts. Include only numbers in the input.';

--- a/application/language/german/qso_lang.php
+++ b/application/language/german/qso_lang.php
@@ -6,6 +6,7 @@ defined('BASEPATH') OR exit('Direkter Zugriff auf Skripte ist nicht erlaubt');
 $lang['qso_title_qso_map'] = 'QSO-Karte';
 $lang['qso_title_suggestions'] = 'Vorschläge';
 $lang['qso_title_pervious_contacts'] = 'Vorherige Kontakte';
+$lang['qso_title_image'] = 'Bild';
 
 // Input Help Text on the /QSO Display
 $lang['qso_transmit_power_helptext'] = 'Gib die Ausgangsleistung in Watt an. Erfasse nur Zahlen bei der Eingabe.';

--- a/application/libraries/Qrz.php
+++ b/application/libraries/Qrz.php
@@ -88,6 +88,7 @@ class Qrz {
             $data['long'] = (string)$xml->Callsign->lon;
             $data['iota'] = (string)$xml->Callsign->iota;
             $data['qslmgr'] = (string)$xml->Callsign->qslmgr;
+            $data['image'] = (string)$xml->Callsign->image;
 
             if ($xml->Callsign->country == "United States") {
                 $data['state'] = (string)$xml->Callsign->state;

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -521,6 +521,15 @@
         <div class="card-body callsign-suggestions"></div>
     </div>
 
+    <div class="card callsign-image" id="callsign-image" style="display: none;">
+        <div class="card-header"><h4 style="font-size: 16px; font-weight: bold;" class="card-title"><?php echo $this->lang->line('qso_title_image'); ?></h4></div>
+
+        <div class="card-body callsign-image">
+            <div class="callsign-image-content" id="callsign-image-content">
+            </div>
+        </div>
+    </div>
+
     <div class="card previous-qsos">
       <div class="card-header"><h4 class="card-title" style="font-size: 16px; font-weight: bold;"><?php echo $this->lang->line('qso_title_pervious_contacts'); ?></h4></div>
 

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -521,6 +521,7 @@
         <div class="card-body callsign-suggestions"></div>
     </div>
 
+    <?php if ($this->config->item('show_qrz_image')) { ?>
     <div class="card callsign-image" id="callsign-image" style="display: none;">
         <div class="card-header"><h4 style="font-size: 16px; font-weight: bold;" class="card-title"><?php echo $this->lang->line('qso_title_image'); ?></h4></div>
 
@@ -529,6 +530,7 @@
             </div>
         </div>
     </div>
+    <?php } ?>
 
     <div class="card previous-qsos">
       <div class="card-header"><h4 class="card-title" style="font-size: 16px; font-weight: bold;"><?php echo $this->lang->line('qso_title_pervious_contacts'); ?></h4></div>

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -145,6 +145,25 @@ TD.lotw{
     margin-bottom: 0px;
 }
 
+.callsign-image .card-title {
+    margin-bottom: 0px;
+}
+
+.callsign-image {
+    margin-bottom: 10px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.callsign-image-content {
+    display: block;
+    max-height: 300px;
+}
+
+.callsign-image-pic {
+    max-height: 250px;
+}
+
 .qso-map .card-title {
     margin-bottom: 0px;
 }

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -279,6 +279,8 @@ function reset_fields() {
 	$('#callsign_info').removeClass("badge-secondary");
 	$('#callsign_info').removeClass("badge-success");
 	$('#callsign_info').removeClass("badge-danger");
+	$('#callsign-image').attr('style', 'display: none;');
+	$('#callsign-image-content').text("");
 	$('#qsl_via').val("");
 	$('#callsign_info').text("");
 	$('#input_usa_state').val("");
@@ -439,6 +441,12 @@ $("#callsign").focusout(function() {
 
 				if($('#qth').val() == "") {
 					$('#qth').val(result.callsign_qth);
+				}
+
+				/* Find link to qrz.com picture */
+				if (result.image != "n/a") {
+					$('#callsign-image-content').html('<img class="callsign-image-pic" src="'+result.image+'">');
+					$('#callsign-image').attr('style', 'display: true;');
 				}
 
 				/*


### PR DESCRIPTION
Adding some lines of code to pull profile pic of QSO partner upon logging the QSO.
As this might be prone to qrz.com not answering (in time) it was put into a config option which is disabled by default. 
To enable set show_qrz_image in application/config/cloudlog.php to TRUE.

![Screenshot from 2022-04-03 10-16-15](https://user-images.githubusercontent.com/7112907/161427411-fa9c2751-0aeb-4203-b333-9aedc04f5b86.png)
