### PR TITLE
CAT support other prop modes

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 88;
+$config['migration_version'] = 90;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -87,11 +87,13 @@
 			{
 
 
-				if($row->sat_name != "") {
+				if($row->prop_mode == "SAT") {
 					$uplink_freq = $row->uplink_freq;
 					$downlink_freq = $row->downlink_freq;
 
 					$power = $row->power;
+
+					$prop_mode = $row->prop_mode;
 
 					// Check Mode
 					if(strtoupper($row->uplink_mode) == "FMN"){
@@ -118,10 +120,11 @@
 					}
 
 				} else {
-					$uplink_freq = $row->frequency;
-					$downlink_freq = "";
+					$frequency = $row->frequency;
 
 					$power = $row->power;
+
+					$prop_mode = $row->prop_mode;
 
 					// Check Mode
 					if(strtoupper($row->mode) == "FMN"){
@@ -146,15 +149,26 @@
 				$updated_at = $minutes;
 
 				// Return Json data
-				echo json_encode(array(
-					"uplink_freq" => $uplink_freq,
-					"downlink_freq" => $downlink_freq,
-					"mode" => $mode,
-					"satmode" => $sat_mode,
-					"satname" => $sat_name,
-					"power" => $power,
-					"updated_minutes_ago" => $updated_at,
-				), JSON_PRETTY_PRINT);
+				if ($prop_mode == "SAT") {
+					echo json_encode(array(
+						"uplink_freq" => $uplink_freq,
+						"downlink_freq" => $downlink_freq,
+						"mode" => $mode,
+						"satmode" => $sat_mode,
+						"satname" => $sat_name,
+						"power" => $power,
+						"prop_mode" => $prop_mode,
+						"updated_minutes_ago" => $updated_at,
+					), JSON_PRETTY_PRINT);
+				} else {
+					echo json_encode(array(
+						"frequency" => $frequency,
+						"mode" => $mode,
+						"power" => $power,
+						"prop_mode" => $prop_mode,
+						"updated_minutes_ago" => $updated_at,
+					), JSON_PRETTY_PRINT);
+				}
 			}
 		}
 

--- a/application/migrations/089_add_propmode_to_cat.php
+++ b/application/migrations/089_add_propmode_to_cat.php
@@ -1,0 +1,28 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Class Migration_add_propmode_to_cat
+ *
+ * Creates a varchar column in CAT table that holds value of propagation mode
+ * 
+ */
+
+class Migration_add_propmode_to_cat extends CI_Migration {
+
+        public function up()
+        {
+                if (!$this->db->field_exists('prop_mode', 'cat')) {
+                        $fields = array(
+                                'prop_mode VARCHAR(10) DEFAULT NULL',
+                        );
+                        $this->dbforge->add_column('cat', $fields, 'sat_name');
+                }
+        }
+
+        public function down()
+        {
+                $this->dbforge->drop_column('cat', 'propmode');
+        }
+}

--- a/application/migrations/090_make_mode_frequency_null.php
+++ b/application/migrations/090_make_mode_frequency_null.php
@@ -5,7 +5,8 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 /**
  * Class Migration_make_mode_frequency_null
  *
- * Creates a varchar column in CAT table that holds value of propagation mode
+ * Modify frequency and mode column so that NULL is allowed
+ * Basically for propmode != SAT
  * 
  */
 

--- a/application/migrations/090_make_mode_frequency_null.php
+++ b/application/migrations/090_make_mode_frequency_null.php
@@ -1,0 +1,53 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Class Migration_make_mode_frequency_null
+ *
+ * Creates a varchar column in CAT table that holds value of propagation mode
+ * 
+ */
+
+class Migration_make_mode_frequency_null extends CI_Migration {
+
+        public function up()
+        {
+                if ($this->db->field_exists('frequency', 'cat')) {
+                        $fields = array(
+                           'frequency' => array(
+                              'type' => 'VARCHAR(10) NULL',
+                           ),
+                        );
+                        $this->dbforge->modify_column('cat', $fields);
+                }
+                if ($this->db->field_exists('mode', 'cat')) {
+                        $fields = array(
+                           'mode' => array(
+                              'type' => 'VARCHAR(10) NULL',
+                           ),
+                        );
+                        $this->dbforge->modify_column('cat', $fields);
+                }
+        }
+
+        public function down()
+        {
+                if ($this->db->field_exists('frequency', 'cat')) {
+                        $fields = array(
+                           'frequency' => array(
+                              'type' => 'VARCHAR(10) NOT NULL',
+                           ),
+                        );
+                        $this->dbforge->modify_column('cat', $fields);
+                }
+                if ($this->db->field_exists('mode', 'cat')) {
+                        $fields = array(
+                           'mode' => array(
+                              'type' => 'VARCHAR(10) NOT NULL',
+                           ),
+                        );
+                        $this->dbforge->modify_column('cat', $fields);
+                }
+        }
+}

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -40,15 +40,33 @@
 					{
 						$radio_id = $row->id;
 
-						$data = array(
-							'sat_name' => $result['sat_name'],
-							'downlink_freq' => $result['downlink_freq'],
-							'uplink_freq' => $result['uplink_freq'],
-							'downlink_mode' => $result['downlink_mode'],
-							'uplink_mode' => $result['uplink_mode'],
-						);
-						if (isset($result['power'])) {
-							$data['power'] = $result['power'];
+						if ($result['prop_mode'] == "SAT") {
+							$data = array(
+								'sat_name' => $result['sat_name'],
+								'prop_mode' => $result['prop_mode'],
+								'mode' => NULL,
+								'frequency' => NULL,
+								'downlink_freq' => $result['downlink_freq'],
+								'uplink_freq' => $result['uplink_freq'],
+								'downlink_mode' => $result['downlink_mode'],
+								'uplink_mode' => $result['uplink_mode'],
+							);
+							if (isset($result['power'])) {
+								$data['power'] = $result['power'];
+							}
+						} else {
+							$data = array(
+								'prop_mode' => $result['prop_mode'],
+								'mode' => $result['mode'],
+								'frequency' => $result['frequency'],
+								'downlink_freq' => NULL,
+								'downlink_mode' => NULL,
+								'uplink_freq' => NULL,
+								'uplink_mode' => NULL,
+							);
+							if (isset($result['power'])) {
+								$data['power'] = $result['power'];
+							}
 						}
 
 						$this->db->where('id', $radio_id);
@@ -88,19 +106,37 @@
 						'user_id' => $user_id,
 					);
 				} else if($result['radio'] == "CloudLogCATQt") {
-					$data = array(
-						'radio' => $result['radio'],
-						'frequency' => $result['frequency'],
-						'mode' => $result['mode'],
-						'sat_name' => $result['sat_name'],
-						'downlink_freq' => $result['downlink_freq'],
-						'uplink_freq' => $result['uplink_freq'],
-						'downlink_mode' => $result['downlink_mode'],
-						'uplink_mode' => $result['uplink_mode'],
-						'user_id' => $user_id,
-					);
-					if (isset($result['power'])) {
-						$data['power'] = $result['power'];
+					if ($result['prop_mode'] == "SAT") {
+						$data = array(
+							'radio' => $result['radio'],
+							'sat_name' => $result['sat_name'],
+							'prop_mode' => $result['prop_mode'],
+							'mode' => NULL,
+							'frequency' => NULL,
+							'downlink_freq' => $result['downlink_freq'],
+							'uplink_freq' => $result['uplink_freq'],
+							'downlink_mode' => $result['downlink_mode'],
+							'uplink_mode' => $result['uplink_mode'],
+							'user_id' => $user_id,
+						);
+						if (isset($result['power'])) {
+							$data['power'] = $result['power'];
+						}
+					} else {
+						$data = array(
+							'radio' => $result['radio'],
+							'prop_mode' => $result['prop_mode'],
+							'mode' => $result['mode'],
+							'frequency' => $result['frequency'],
+							'downlink_freq' => NULL,
+							'downlink_mode' => NULL,
+							'uplink_freq' => NULL,
+							'uplink_mode' => NULL,
+							'user_id' => $user_id,
+						);
+						if (isset($result['power'])) {
+							$data['power'] = $result['power'];
+						}
 					}
 				} else {
 					$data = array(

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1104,7 +1104,7 @@ $(document).on('keypress',function(e) {
           $("#sat_name").val(data.satname);
           $("#sat_mode").val(data.satmode);
           if(data.power != 0) {
-            $("#power").val(data.power);
+            $("#transmit_power").val(data.power);
           }
           $("#selectPropagation").val(data.prop_mode);
 

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1073,11 +1073,16 @@ $(document).on('keypress',function(e) {
               "satmode": "",
               "satname": "ES'HAIL-2"
               "power": "20"
+              "prop_mode": "SAT"
           }  */
-          if (data.uplink_freq != "")
+          if (data.prop_mode == "SAT")
+          //if (data.uplink_freq != "")
           {
             $('#frequency').val(data.uplink_freq);
             $("#band").val(frequencyToBand(data.uplink_freq));
+          } else {
+            $('#frequency').val(data.frequency);
+            $("#band").val(frequencyToBand(data.frequency));
           }
           if (data.downlink_freq != "")
           {
@@ -1101,6 +1106,7 @@ $(document).on('keypress',function(e) {
           if(data.power != 0) {
             $("#power").val(data.power);
           }
+          $("#selectPropagation").val(data.prop_mode);
 
           // Display CAT Timeout warnng based on the figure given in the config file
             var minutes = Math.floor(<?php echo $this->config->item('cat_timeout_interval'); ?> / 60);


### PR DESCRIPTION
This allows Cloudlog's CAT/API interface for CloudLogCATQt to also allow for other prop modes than SAT.
CloudLogCATQt is also patched separately. New interface would look like this

![Screenshot from 2022-04-08 21-51-24](https://user-images.githubusercontent.com/7112907/162518589-0e72b06f-83a1-497f-b8e1-97cd92ba00c2.png)
