### PR TITLE
Prefill DOK field from previous QSO

### DIFF
--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -112,4 +112,20 @@ class Lookup extends CI_Controller {
 
 	}
 
+	public function dok($call) {
+
+		if($call) {
+			$uppercase_callsign = strtoupper($call);
+		}
+
+		// DOK results from logbook
+		$this->load->model('logbook_model');
+
+		$query = $this->logbook_model->get_dok($uppercase_callsign);
+
+		if ($query->row()) {
+			echo $query->row()->COL_DARC_DOK;
+		}
+	}
+
 }

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -429,6 +429,16 @@ class Logbook_model extends CI_Model {
 
   }
 
+  public function get_dok($callsign){
+    $this->db->select('COL_DARC_DOK');
+    $this->db->where('COL_CALL', $callsign);
+    $this->db->order_by("COL_TIME_ON", "desc");
+    $this->db->limit(1);
+
+    return $this->db->get($this->config->item('table_name'));
+
+  }
+
   function add_qso($data, $skipexport = false) {
 
     if ($data['COL_DXCC'] == "Not Found"){

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -383,8 +383,12 @@ $("#callsign").focusout(function() {
 				var $select = $('#darc_dok').selectize();
 				var selectize = $select[0].selectize;
 				if (result.dxcc.adif == '230') {
-					selectize.addOption({name:'N18'});
-					selectize.setValue('N18', false);
+					$.get('lookup/dok/' + $('#callsign').val().toUpperCase(), function(result) {
+						if (result) {
+							selectize.addOption({name: result});
+							selectize.setValue(result, false);
+						}
+					});
 				} else {
 					selectize.clear();
 				}

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -286,6 +286,9 @@ function reset_fields() {
 	$('#input_usa_state').val("");
 	$('#qso-last-table').show();
 	$('#partial_view').hide();
+	var $select = $('#darc_dok').selectize();
+	var selectize = $select[0].selectize;
+	selectize.clear();
 
 	mymap.setView(pos, 12);
 	mymap.removeLayer(markers);
@@ -376,6 +379,15 @@ $("#callsign").focusout(function() {
 				$('#qrz_info').attr('title', 'Lookup '+find_callsign+' info on qrz.com');
 				$('#hamqth_info').html('<a target="_blank" href="https://www.hamqth.com/'+find_callsign+'"><img width="32" height="32" src="'+base_url+'images/icons/hamqth.com.png"></a>'); 
 				$('#hamqth_info').attr('title', 'Lookup '+find_callsign+' info on hamqth.com');
+
+				var $select = $('#darc_dok').selectize();
+				var selectize = $select[0].selectize;
+				if (result.dxcc.adif == '230') {
+					selectize.addOption({name:'N18'});
+					selectize.setValue('N18', false);
+				} else {
+					selectize.clear();
+				}
 
 				$('#dxcc_id').val(result.dxcc.adif);
 				$('#cqz').val(result.dxcc.cqz);


### PR DESCRIPTION
This adds a lookup function for German callsigns so that the DOK field is automagically prefilled with the DOK from the previous QSO. Saves some time to not enter it again and again. If last QSO did not contain a DOK value it is left empty (i.e. DB lookup does not disregard emtpy fields), so that if someone leaves the club the field is not filled with the former DOK.