### PR TITLE
add station profile name to qso detail

### DIFF
--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -302,6 +302,10 @@
                         <td><?php echo $row->station_callsign; ?></td>
                     </tr>
                     <tr>
+                        <td>Station Name</td>
+                        <td><?php echo $row->station_profile_name; ?></td>
+                    </tr>
+                    <tr>
                         <td>Station Gridsquare</td>
                         <td><?php echo $row->station_gridsquare; ?></td>
                     </tr>


### PR DESCRIPTION
I think it makes sense to add the station profile name in addition to the station callsign. Personally I have a lot of stations with the same callsign but different names. Only the callsign is therefore not distinguishable for me.