### PR TITLE
added possibility to sort locations by id

### DIFF
--- a/application/models/Logbooks_model.php
+++ b/application/models/Logbooks_model.php
@@ -4,7 +4,6 @@ class Logbooks_model extends CI_Model {
 
     function show_all() {
         $this->db->where('user_id', $this->session->userdata('user_id'));
-        $this->db->order_by('logbook_name');
 		return $this->db->get('station_logbooks');
 	}
 

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -10,7 +10,6 @@ class Stations extends CI_Model {
        	$this->db->group_by('station_profile.station_id');
 		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
 		$this->db->or_where('station_profile.user_id =', NULL);
-		$this->db->order_by('station_profile.station_profile_name');
         return $this->db->get();
 	}
 

--- a/application/views/station_profile/index.php
+++ b/application/views/station_profile/index.php
@@ -60,7 +60,7 @@
 					<td><?php echo $row->station_callsign;?></td>
 					<td><?php echo $row->station_country;?></td>
 					<td><?php echo $row->station_gridsquare;?></td>
-					<td style="text-align: center">
+					<td style="text-align: center" data-order="<?php echo $row->station_id;?>">
 						<?php if($row->station_active != 1) { ?>
 							<a href="<?php echo site_url('station/set_active/').$current_active."/".$row->station_id; ?>" class="btn btn-outline-secondary btn-sm" onclick="return confirm('Are you sure you want to make station <?php echo $row->station_profile_name; ?> the active station?');">Set Active</a>
 						<?php } else { ?>


### PR DESCRIPTION
In the pull request #1243 I changed the server side sort of the logbooks and stations list to be in alphabetical order instead of creation (ID). During the last months I came to the conclusion that this might have been an "error". Elsewhere the list is not sorted alphabetical (e.g. when assigning a location to a logbook or in the dropdown to select the location when creating a QSO). Therefore it is inconsistent with the rest of the system.

Coming to that conclusion I wanted to create a pull request to revert the sort back to its original form. While doing that I noticed that the server side sort doesn't even matter anymore because in the meantime there was a client side sort added.

In order to have both possibilities I added that sorting by the 4th column (contains the ID among other stuff) is sorting by the ID of the location. By doing that it basically sorts by creation. Sorting by the first column (which is the default) is sorting by name.

What do you think?