### PR TITLE
Sort QSL images by last added to be on top

### DIFF
--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -9,6 +9,7 @@ class Qsl_model extends CI_Model {
         $this->db->from($this->config->item('table_name'));
         $this->db->join('qsl_images', 'qsl_images.qsoid = ' . $this->config->item('table_name') . '.col_primary_key');
         $this->db->where_in('station_id', $logbooks_locations_array);
+        $this->db->order_by("id", "desc");
 
         return $this->db->get();
     }

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2146,7 +2146,7 @@ $(document).ready(function(){
         $('.qsltable').DataTable({
             "pageLength": 25,
             responsive: false,
-            ordering: false,
+            ordering: true,
             "scrollY":        "500px",
             "scrollCollapse": true,
             "paging":         false,

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2141,8 +2141,33 @@ $(document).ready(function(){
 	<script src="<?php echo base_url(); ?>assets/js/sections/timeplot.js"></script>
 <?php } ?>
 
-<?php if ($this->uri->segment(1) == "qsl") { ?>
+<?php if ($this->uri->segment(1) == "qsl") { 
+    	// Get Date format
+	if($this->session->userdata('user_date_format')) {
+		// If Logged in and session exists
+		$custom_date_format = $this->session->userdata('user_date_format');
+	} else {
+		// Get Default date format from /config/cloudlog.php
+		$custom_date_format = $this->config->item('qso_date_format');
+	}
+
+    switch ($custom_date_format) {
+        case 'd/m/y': $usethisformat = 'D/MM/YY';break;
+        case 'd/m/Y': $usethisformat = 'D/MM/YYYY';break;
+        case 'm/d/y': $usethisformat = 'MM/D/YY';break;
+        case 'm/d/Y': $usethisformat = 'MM/D/YYYY';break;
+        case 'd.m.Y': $usethisformat = 'D.MM.YYYY';break;
+        case 'y/m/d': $usethisformat = 'YY/MM/D';break;
+        case 'Y-m-d': $usethisformat = 'YYYY-MM-D';break;
+        case 'M d, Y': $usethisformat = 'MMM D, YYYY';break;
+        case 'M d, y': $usethisformat = 'MMM D, YY';break;
+    }
+    
+    ?>
+    <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/moment.min.js"></script>
+    <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/datetime-moment.js"></script>
     <script>
+        $.fn.dataTable.moment('<? echo $usethisformat ?>');
         $('.qsltable').DataTable({
             "pageLength": 25,
             responsive: false,
@@ -2150,8 +2175,11 @@ $(document).ready(function(){
             "scrollY":        "500px",
             "scrollCollapse": true,
             "paging":         false,
-            "scrollX": true
+            "scrollX": true,
+            "order": [ 2, 'desc' ],
         });
+        
+        
     </script>
 <?php } ?>
 

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2167,7 +2167,7 @@ $(document).ready(function(){
     <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/moment.min.js"></script>
     <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/datetime-moment.js"></script>
     <script>
-        $.fn.dataTable.moment('<? echo $usethisformat ?>');
+        $.fn.dataTable.moment('<?php echo $usethisformat ?>');
         $('.qsltable').DataTable({
             "pageLength": 25,
             responsive: false,

--- a/assets/js/datetime-moment.js
+++ b/assets/js/datetime-moment.js
@@ -1,0 +1,70 @@
+/**
+ * This plug-in for DataTables represents the ultimate option in extensibility
+ * for sorting date / time strings correctly. It uses
+ * [Moment.js](http://momentjs.com) to create automatic type detection and
+ * sorting plug-ins for DataTables based on a given format. This way, DataTables
+ * will automatically detect your temporal information and sort it correctly.
+ *
+ * For usage instructions, please see the DataTables blog
+ * post that [introduces it](//datatables.net/blog/2014-12-18).
+ *
+ * @name Ultimate Date / Time sorting
+ * @summary Sort date and time in any format using Moment.js
+ * @author [Allan Jardine](//datatables.net)
+ * @depends DataTables 1.10+, Moment.js 1.7+
+ *
+ * @example
+ *    $.fn.dataTable.moment( 'HH:mm MMM D, YY' );
+ *    $.fn.dataTable.moment( 'dddd, MMMM Do, YYYY' );
+ *
+ *    $('#example').DataTable();
+ */
+
+(function (factory) {
+	if (typeof define === "function" && define.amd) {
+		define(["jquery", "moment", "datatables.net"], factory);
+	} else {
+		factory(jQuery, moment);
+	}
+}(function ($, moment) {
+
+function strip (d) {
+	if ( typeof d === 'string' ) {
+		// Strip HTML tags and newline characters if possible
+		d = d.replace(/(<.*?>)|(\r?\n|\r)/g, '');
+
+		// Strip out surrounding white space
+		d = d.trim();
+	}
+
+	return d;
+}
+
+$.fn.dataTable.moment = function ( format, locale, reverseEmpties ) {
+	var types = $.fn.dataTable.ext.type;
+
+	// Add type detection
+	types.detect.unshift( function ( d ) {
+		d = strip(d);
+
+		// Null and empty values are acceptable
+		if ( d === '' || d === null ) {
+			return 'moment-'+format;
+		}
+
+		return moment( d, format, locale, true ).isValid() ?
+			'moment-'+format :
+			null;
+	} );
+
+	// Add sorting method - use an integer for the sorting
+	types.order[ 'moment-'+format+'-pre' ] = function ( d ) {
+		d = strip(d);
+		
+		return !moment(d, format, locale, true).isValid() ?
+			(reverseEmpties ? -Infinity : Infinity) :
+			parseInt( moment( d, format, locale, true ).format( 'x' ), 10 );
+	};
+};
+
+}));


### PR DESCRIPTION
I think it would be nice to have the latest images at the top of the QSL images table rather than at the bottom.
Also thought using qsoid but that is not necessarily ordering by QSO date.
