### PR TITLE
Replace REGEXP_LIKE in DOK stats

### DIFF
--- a/application/models/Dok.php
+++ b/application/models/Dok.php
@@ -16,9 +16,9 @@ class DOK extends CI_Model {
 		$location_list = "'".implode("','",$logbooks_locations_array)."'";
 		$sql = "select upper(COL_DARC_DOK) as COL_DARC_DOK, COL_MODE, lcase(COL_BAND) as COL_BAND, count(COL_DARC_DOK) as cnt from ".$this->config->item('table_name')." WHERE station_id in (" . $location_list . ") AND COL_DARC_DOK IS NOT NULL AND COL_DARC_DOK != '' AND COL_DXCC = 230";
 		if ($postdata['doks'] == 'dok') {
-			$sql .= " AND REGEXP_LIKE (COL_DARC_DOK, '^[A-Z][0-9]{2}$')";
+			$sql .= " AND COL_DARC_DOK REGEXP '^[A-Z][0-9]{2}$'";
 		} else if ($postdata['doks'] == 'sdok') {
-			$sql .= " AND NOT REGEXP_LIKE (COL_DARC_DOK, '^[A-Z][0-9]{2}$')";
+			$sql .= " AND COL_DARC_DOK NOT REGEXP '^[A-Z][0-9]{2}$'";
 		}
 		$sql .= " group by COL_DARC_DOK, COL_MODE, COL_BAND";
 		$sql .= " order by COL_DARC_DOK asc";


### PR DESCRIPTION
As @dg9vh reported there is an issue with REGEXP_LIKE not being supported in older mySQL versions I replaced the code with backwards compatible stuff. Fix was tested with positive result by @dg9vh.