### PR TITLE
DXCC vs. Country

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -558,7 +558,7 @@ class Logbook_model extends CI_Model {
 
     $entity = $this->get_entity($this->input->post('dxcc_id'));
     $stationId = $this->input->post('station_profile');
-    $country = $entity['name'];
+    $country = ucwords(strtolower($entity['name']));
 
     // be sure that station belongs to user
     $CI =& get_instance();
@@ -2228,12 +2228,11 @@ class Logbook_model extends CI_Model {
       }
 
         // Store or find country name
-        if(isset($record['country'])) {
+        // dxcc has higher priority to be consistent with qso create and edit
+        if (isset($dxcc[1])) {
+            $country = ucwords(strtolower($dxcc[1]));
+        } else if (isset($record['country'])) {
             $country = $record['country'];
-        } else {
-            if (isset($dxcc[1])) {
-                $country = ucwords(strtolower($dxcc[1]));
-            }
         }
 
         // RST recevied


### PR DESCRIPTION
While playing around with `cloudLogOffline` I noticed that the country field is handled differently during ADIF import compared to QSO edit/create.

When doing an ADIF import the country is used from the ADIF data and from DXCC as a fallback. For QSO create/edit it is the other way around. That means when creating a german QSO via `cloudLogOffline` the country is set to `Germany` (which is what most german OMs have in their QRZ profile). If afterwards the QSO is edited in `Cloudlog` the country is changed to `Federal Republic Of Germany` which is the country name of the DXCC. I find that inconsistent and and unexpected change. Therefore I changed the ADIF import to give higher priority to DXCC country and use ADIF country as a fallback.

Furthermore I added `ucwords(strtolower(...))` to QSO edit also to be consistent to QSO create and ADIF import.

What do you think?