### PR TITLE
adapted visible conditions for lotw arrows to be consistent to eqsl

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2415,16 +2415,16 @@ class Logbook_model extends CI_Model {
         if (isset($record['lotw_qsl_rcvd'])){
             $input_lotw_qsl_rcvd = mb_strimwidth($record['lotw_qsl_rcvd'], 0, 1);
         } else {
-            $input_lotw_qsl_rcvd = "";
+            $input_lotw_qsl_rcvd = NULL;
         }
 
         if (isset($record['lotw_qsl_sent'])){
-          $input_lotw_qsl_sent = mb_strimwidth($record['lotw_qsl_sent'], 0, 1);
-      } else if ($markLotw != NULL) {
-          $input_lotw_qsl_sent = "Y";
-      } else {
-          $input_lotw_qsl_sent = "";
-      }
+            $input_lotw_qsl_sent = mb_strimwidth($record['lotw_qsl_sent'], 0, 1);
+        } else if ($markLotw != NULL) {
+            $input_lotw_qsl_sent = "Y";
+        } else {
+            $input_lotw_qsl_sent = NULL;
+        }
 
         if (isset($record['lotw_qslrdate'])){
             if(validateADIFDate($record['lotw_qslrdate']) == true){

--- a/application/views/search/result_search.php
+++ b/application/views/search/result_search.php
@@ -57,10 +57,8 @@
 
 			<?php if($this->session->userdata('user_lotw_name') != "") { ?>
 			<td class="lotw">
-				<?php if ($row->COL_LOTW_QSL_SENT != ''){ ?>
 			    <span class="lotw-<?php echo ($row->COL_LOTW_QSL_SENT=='Y')?'green':'red'?>">&#9650;</span>
 			    <span class="lotw-<?php echo ($row->COL_LOTW_QSL_RCVD=='Y')?'green':'red'?>">&#9660;</span>
-			    <?php } ?>
 			</td>
 			<?php } ?>
 

--- a/application/views/view_log/partial/log.php
+++ b/application/views/view_log/partial/log.php
@@ -107,10 +107,8 @@
 
 			<?php if($this->session->userdata('user_lotw_name') != "") { ?>
 			<td class="lotw">
-				<?php if ($row->COL_LOTW_QSL_SENT != ''){ ?>
 			    <span class="lotw-<?php echo ($row->COL_LOTW_QSL_SENT=='Y')?'green':'red'?>">&#9650;</span>
 			    <span class="lotw-<?php echo ($row->COL_LOTW_QSL_RCVD=='Y')?'green':'red'?>">&#9660;</span>
-			    <?php } ?>
 			</td>
 			<?php } ?>
 

--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -188,10 +188,8 @@ function echoQrbCalcLink($mygrid, $grid, $vucc) {
 
                 <?php if($this->session->userdata('user_lotw_name') != "") { ?>
                     <td class="lotw">
-                        <?php if ($row->COL_LOTW_QSL_SENT != ''){ ?>
-                            <span <?php if ($row->COL_LOTW_QSL_SENT == "Y") { $timestamp = strtotime($row->COL_LOTW_QSLSDATE); echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_sent')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\""; } ?> class="lotw-<?php echo ($row->COL_LOTW_QSL_SENT=='Y')?'green':'red'?>">&#9650;</span>
-                            <span <?php if ($row->COL_LOTW_QSL_RCVD == "Y") { $timestamp = strtotime($row->COL_LOTW_QSLRDATE); echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_received')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\""; } ?> class="lotw-<?php echo ($row->COL_LOTW_QSL_RCVD=='Y')?'green':'red'?>">&#9660;</span>
-                        <?php } ?>
+                        <span <?php if ($row->COL_LOTW_QSL_SENT == "Y") { $timestamp = strtotime($row->COL_LOTW_QSLSDATE); echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_sent')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\""; } ?> class="lotw-<?php echo ($row->COL_LOTW_QSL_SENT=='Y')?'green':'red'?>">&#9650;</span>
+                        <span <?php if ($row->COL_LOTW_QSL_RCVD == "Y") { $timestamp = strtotime($row->COL_LOTW_QSLRDATE); echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_received')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\""; } ?> class="lotw-<?php echo ($row->COL_LOTW_QSL_RCVD=='Y')?'green':'red'?>">&#9660;</span>
                     </td>
                 <?php } ?>
 


### PR DESCRIPTION
Again something that I noticed while playing around with `cloudLogOffline`

I noticed that ADIF imported QSOs do not show the (red) arros in the LotW column (column is just empty) while the arrows in the eQSL column are shown. While researching I noticed that the eQSL database columns are set to `NULL` while the LotW columns are set to `''` in the ADIF import. So first I changed that to be consistent. Afterwards I noticed that the LotW arrows had in some views (but not all) an additional condition (`$row->COL_LOTW_QSL_SENT != ''`) to be shown while the eQSL arrows did not. So I adapted that as well.

That "solved" the behaviour for me but I'm not sure if that behaviour was intentional. I searched in the code but couldn't find a hint to that. So what do you think?