### PR TITLE
Fix Radio timeout

### DIFF
--- a/application/config/cloudlog.php
+++ b/application/config/cloudlog.php
@@ -49,19 +49,6 @@ $config['map_gridsquares'] = FALSE;
 
 /*
 |--------------------------------------------------------------------------
-| CAT Timeout Warning Inverval
-|--------------------------------------------------------------------------
-| 
-| The external CAT applications can obviously stop working for various reasons 
-| this interval is used for displaying a warning on the QSO Panel
-|
-| Default is: 1800 seconds (30 minutes)
-|
-*/
-$config['cat_timeout_interval'] = 1800;
-
-/*
-|--------------------------------------------------------------------------
 | Public Search
 |--------------------------------------------------------------------------
 | 

--- a/application/controllers/Options.php
+++ b/application/controllers/Options.php
@@ -137,7 +137,7 @@ class Options extends CI_Controller {
 		else
 		{
 			// Update theme choice within the options system
-			$radioTimeout_update = $this->optionslib->update('cat_timeout_interval', $this->input->post('radioTimeout'));
+			$radioTimeout_update = $this->optionslib->update('cat_timeout_interval', $this->input->post('radioTimeout'), 'yes');
 
 			// If theme update is complete set a flashsession with a success note
 			if($radioTimeout_update == TRUE) {

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1126,7 +1126,7 @@ $(document).on('keypress',function(e) {
           $("#selectPropagation").val(data.prop_mode);
 
           // Display CAT Timeout warnng based on the figure given in the config file
-            var minutes = Math.floor(<?php echo $this->config->item('cat_timeout_interval'); ?> / 60);
+            var minutes = Math.floor(<?php echo $this->optionslib->get_option('cat_timeout_interval'); ?> / 60);
 
             if(data.updated_minutes_ago > minutes) {
               if($('.radio_timeout_error').length == 0) {


### PR DESCRIPTION
As reported in https://github.com/magicbug/Cloudlog/issues/1506 the radio timeout is not used correctly. As the config item is present in the hard coded `application/config/cloudlog.php` config the value from database is not read (though stored there correctly). This fixes it by removing the hard-coded config item.
There is also a bugfix that the autoload value is set to 'no' if updated from the web interface. So a third argument 'yes' is given to the options->update call.