### PR TITLE
Bugfix for dxcc_lookup in logbook_model

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2245,7 +2245,7 @@ class Logbook_model extends CI_Model {
 
     public function dxcc_lookup($call, $date){
 
-		$dxcc_exceptions = $this->db->select('`entity`, `adif`, `cqz`')
+		$dxcc_exceptions = $this->db->select('*')
 				->where('call', $call)
 				->where('(start <= CURDATE()')
 				->or_where('start is null', NULL, false)


### PR DESCRIPTION
This fixes #1512. Since latitude and longitude were never fetched when call was found in dxcc_exception, it would not load maps correctly.