### PR TITLE
[QSO dialog] Map fix

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1035,9 +1035,8 @@ class Logbook_model extends CI_Model {
   }
 
   function get_qso($id) {
-    $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*');
     $this->db->from($this->config->item('table_name'));
-
+    $this->db->join('dxcc_entities', $this->config->item('table_name').'.col_dxcc = dxcc_entities.adif', 'left');
     $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
     $this->db->where('COL_PRIMARY_KEY', $id);
 

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -473,20 +473,19 @@
 		    $lng = $midpoint[1];
         }
 	} else {
+        if(isset($row->lat)) {
+			$lat = $row->lat;
+        } else {
+            $lat = 0;
+        }
 
-		$CI =& get_instance();
-		$CI->load->model('Logbook_model');
-
-		$result = $CI->Logbook_model->dxcc_lookup($row->COL_CALL, $row->COL_TIME_ON);
-
-        if(isset($result)) {
-			$lat = $result['lat'];
-			$lng = $result['long'];
+        if(isset($row->long)) {
+			$lng = $row->long;
+        } else {
+            $lng = 0;
         }
 	}
 ?>
-
-
 
 <script>
 var lat = <?php echo $lat; ?>;


### PR DESCRIPTION
This is one part of fixing map pins. This is for the QSO dialog when clicking on callsign.

Since we have stored the dxcc id in the database for the QSO, there is no need to figure out the dxcc again.
I left join dxcc_entities while fetching the qso (if dxcc set to none, we get the result with a left join). We get rid of one query (if no gridsquare is set), and use lat/long from the dxcc.

@magicbug I think this is a smarter way of doing things. Take a look and give me some feedback.