### PR TITLE
[Dashboard map] Fix lookup for dashboard QSOs plotted on the map

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -163,11 +163,9 @@ class Dashboard extends CI_Controller {
 					echo ",";
 				}
 
-				$result = $this->logbook_model->dxcc_lookup($row->COL_CALL, $row->COL_TIME_ON);
-		
-				if(isset($result)) {
-					$lat = $result['lat'];
-					$lng = $result['long'];
+				if(isset($row->lat) && isset($row->long)) {
+					$lat = $row->lat;
+					$lng = $row->long;
 				}
 				echo "{\"lat\":\"".$lat."\",\"lng\":\"".$lng."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
 				$count++;

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1102,9 +1102,9 @@ class Logbook_model extends CI_Model {
     }
 
     if ($logbooks_locations_array) {
-      //$this->db->select('COL_CALL, COL_BAND, COL_TIME_ON, COL_RST_RCVD, COL_RST_SENT, COL_MODE, COL_SUBMODE, COL_NAME, COL_COUNTRY, COL_PRIMARY_KEY, COL_SAT_NAME, COL_STX_STRING, COL_SRX_STRING, COL_IOTA, COL_STATE, COL_GRIDSQUARE');
       $this->db->where_in($this->config->item('table_name').'.station_id', $logbooks_locations_array);
       $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+      $this->db->join('dxcc_entities', $this->config->item('table_name').'.col_dxcc = dxcc_entities.adif', 'left');
       $this->db->order_by("COL_TIME_ON", "desc");
       $this->db->limit($num);
       $query = $this->db->get($this->config->item('table_name'));


### PR DESCRIPTION
Same map fix. Use the stored dxcc and get lat/long if gridsquare not available.