### PR TITLE
[Custom map] Using already logged dxcc to set position when gridsquare is not present

### DIFF
--- a/application/controllers/Map.php
+++ b/application/controllers/Map.php
@@ -174,12 +174,11 @@ class Map extends CI_Controller {
 						echo ",";
 					}
 	
-					$result = $this->logbook_model->dxcc_lookup($row->COL_CALL, $row->COL_TIME_ON);
-			
-					if(isset($result)) {
-						$lat = $result['lat'];
-						$lng = $result['long'];
+					if(isset($row->lat) && isset($row->long)) {
+						$lat = $row->lat;
+						$lng = $row->long;
 					}
+					
 					echo "{\"lat\":\"".$lat."\",\"lng\":\"".$lng."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
 					$count++;
 				}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1292,6 +1292,7 @@ class Logbook_model extends CI_Model {
       return null;
     }
 
+      $this->db->join('dxcc_entities', $this->config->item('table_name').'.col_dxcc = dxcc_entities.adif', 'left');
       $this->db->where("COL_TIME_ON BETWEEN '".$start."' AND '".$end."'");
       $this->db->where_in("station_id", $logbooks_locations_array);
 


### PR DESCRIPTION
Same map fix. Use the stored dxcc and get lat/long if gridsquare not available.