### PR TITLE
Also upload QSOs where QSL_SENT is NULL

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3107,7 +3107,10 @@ class Logbook_model extends CI_Model {
     $this->db->select('COL_PRIMARY_KEY,COL_CALL, COL_BAND, COL_BAND_RX, COL_TIME_ON, COL_RST_RCVD, COL_RST_SENT, COL_MODE, COL_SUBMODE, COL_FREQ, COL_FREQ_RX, COL_GRIDSQUARE, COL_SAT_NAME, COL_PROP_MODE, COL_LOTW_QSL_SENT, station_id');
 
     $this->db->where("station_id", $station_id);
-    $this->db->where('COL_LOTW_QSL_SENT !=', "Y");
+    $this->db->group_start();
+    $this->db->where('COL_LOTW_QSL_SENT', NULL);
+    $this->db->or_where('COL_LOTW_QSL_SENT !=', "Y");
+    $this->db->group_end();
     $this->db->where('COL_PROP_MODE !=', "INTERNET");
     $this->db->where('COL_TIME_ON >=', $start_date);
     $this->db->where('COL_TIME_ON <=', $end_date);


### PR DESCRIPTION
With PR https://github.com/magicbug/Cloudlog/pull/1493 by @Werzi2001 all QSO imported via API have COL_LOTW_QSL_SENT column set to NULL (where it was "", i.e. an empty string before). This breaks the LotW upload (via cronjobs).
The LotW upload function checks for not uploaded QSOs with SQL query "WHERE COL_LOTW_QSL_SENT != 'Y'" and this does not include rows where this column is NULL. So the selection has to be modified so that it checks for NULL values. 
For backwards compatibility the SQL statement is now "(WHERE COL_LOTW_QSL_SENT != 'Y' OR COL_LOTW_QSL_SENT IS NULL)".
Otherwise API QSO will never get uploaded to LotW anymore.