### PR TITLE
Fix issue where warning is displayed that CAT data from radio is out of date

### DIFF
--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -32,7 +32,7 @@
 			// user is not logged in
 			redirect('user/login');
 		}
-		
+
 		$this->load->model('cat');
 		$query = $this->cat->status();
 		if ($query->num_rows() > 0)
@@ -138,8 +138,8 @@
 				}
 
 				// Calculate how old the data is in minutes
-				$datetime1 = new DateTime(); // Today's Date/Time
-				$datetime2 = new DateTime($row->newtime);
+				$datetime1 = new DateTime("now", new DateTimeZone('UTC')); // Today's Date/Time
+				$datetime2 = new DateTime($row->timestamp, new DateTimeZone('UTC'));
 				$interval = $datetime1->diff($datetime2);
 
 				$minutes = $interval->days * 24 * 60;

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -189,7 +189,7 @@
 		}
 
 		function radio_status($id) {
-			$sql = 'SELECT *, CONVERT_TZ(`timestamp`, @@session.time_zone, \'+00:00\' ) as newtime FROM `cat` WHERE id = ' . $id . ' and user_id =' . $this->session->userdata('user_id');
+			$sql = 'SELECT * FROM `cat` WHERE id = ' . $id . ' and user_id =' . $this->session->userdata('user_id');
 			return $this->db->query($sql);
 		}
 


### PR DESCRIPTION
Hello,

I have observed an issue with the Radio/CAT Integration, where because the PHP System timezone was used the updated_minutes_ago was incorrect preventing this radio being used on the QSO screen.

Thanks,
Jordan