### PR TITLE
Fix rogue echos on json QSL status code

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -574,7 +574,7 @@ class Logbook extends CI_Controller {
 							$html .= "yellow";
 							break;
 						case "I":
-							echo "grey";
+							$html .= "grey";
 							break;
 						default:
 						   $html .= "red";
@@ -592,7 +592,7 @@ class Logbook extends CI_Controller {
 							$html .= "yellow";
 							break;
 						case "I":
-							echo "grey";
+							$html .= "grey";
 							break;
 						default:
 						   $html .= "red";


### PR DESCRIPTION
Two forgotten `echos` were outputting code to the browser during the "get qsos and qrz data" phase of the add QSO feature, thus breaking the json output.