### PR TITLE
First version of the "QSL Manager" that doesn't do anything useful yet.

### DIFF
--- a/application/controllers/Qslmanager.php
+++ b/application/controllers/Qslmanager.php
@@ -1,0 +1,138 @@
+<?php
+
+use Cloudlog\QSLManager\SearchCriteria;
+use Cloudlog\QSLManager\QSO;
+
+if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+
+/*
+	This controller will contain features for managing QSL cards
+*/
+
+class Qslmanager extends CI_Controller
+{
+	function __construct()
+	{
+		parent::__construct();
+		$this->load->helper(array('form', 'url', 'psr4_autoloader'));
+
+		$this->load->model('user_model');
+		if (!$this->user_model->authorize(2)) {
+			$this->session->set_flashdata('notice', 'You\'re not allowed to do that!');
+			redirect('dashboard');
+		}
+	}
+
+	public function index()
+	{
+		$this->load->model('stations');
+		$this->load->model('logbook_model');
+		$this->load->model('bands');
+
+		$stationIds = [];
+
+		$deOptions = [];
+		foreach ($this->stations->all_of_user()->result() as $station) {
+			$deOptions[$station->station_callsign] = 1;
+			$stationIds[] = $station->station_id;
+		}
+		ksort($deOptions);
+		$deOptions = array_keys($deOptions);
+
+		$modes = [];
+		if ($stationIds !== []) {
+			foreach ($this->logbook_model->get_worked_modes($stationIds) as $mode) {
+				$key = $mode['mode'];
+				if ($mode['submode'] !== null) {
+					$key .= "|" . $mode['submode'];
+				}
+				if ($mode['submode'] == null) {
+					$modes[$key] = $mode['mode'];
+				} else {
+					$modes[$key] = $mode['submode'];
+				}
+			}
+		}
+
+		$data = [];
+		$data['page_title'] = "QSL Manager";
+		$data['hasDatePicker'] = true;
+
+		$pageData = [];
+		$pageData['datePlaceholder'] = 'YYYY-MM-DD';
+		$pageData['deOptions'] = $deOptions;
+		$pageData['modes'] = $modes;
+		$pageData['bands'] = $this->bands->get_worked_bands_for_user($this->session->userdata('user_id'));
+
+		$footerData = [];
+		$footerData['scripts'] = [
+			'assets/js/moment.min.js',
+			'assets/js/tempusdominus-bootstrap-4.min.js',
+			'assets/js/qslmanager.js?' . filemtime(realpath(__DIR__ . "/../../assets/js/qslmanager.js"))
+		];
+
+		$this->load->view('interface_assets/header', $data);
+		$this->load->view('qslmanager/index', $pageData);
+		$this->load->view('interface_assets/footer', $footerData);
+	}
+
+	public function search()
+	{
+		$this->load->model('logbook_model');
+
+		$searchCriteria = new SearchCriteria(
+			(int)$this->session->userdata('user_id'),
+			xss_clean($this->input->post('dateFrom')),
+			xss_clean($this->input->post('dateTo')),
+			xss_clean($this->input->post('de')),
+			xss_clean($this->input->post('dx')),
+			xss_clean($this->input->post('mode')),
+			xss_clean($this->input->post('band')),
+			xss_clean($this->input->post('qslSent')),
+			xss_clean($this->input->post('qslReceived'))
+		);
+
+		$qsos = [];
+		foreach ($this->logbook_model->doSearchForQSLManager($searchCriteria) as $qso) {
+			$qsos[] = $qso->toArray();
+		}
+
+		header("Content-Type: application/json");
+		print json_encode($qsos);
+
+	}
+
+	public function test()
+	{
+		$this->load->model('logbook_model');
+		$callbook = $this->logbook_model->loadCallBook("CT7AUS", $this->config->item('use_fullname'));
+
+	}
+
+	public function updateFromCallbook()
+	{
+		$this->load->model('logbook_model');
+
+		$qsoID = xss_clean($this->input->post('qsoID'));
+		$qso = $this->logbook_model->qso_info($qsoID)->row_array();
+		if ($qso === null) {
+			header("Content-Type: application/json");
+			echo json_encode([]);
+			return;
+		}
+
+		$callbook = $this->logbook_model->loadCallBook($qso['COL_CALL'], $this->config->item('use_fullname'));
+
+		if ($callbook['callsign'] !== "") {
+			$qso['COL_NAME'] = trim($callbook['name']);
+			$qso['COL_QSL_VIA'] = trim($callbook['qslmgr']);
+		}
+
+		$qsoObj = new QSO($qso);
+
+		header("Content-Type: application/json");
+		echo json_encode($qsoObj->toArray());
+	}
+
+}

--- a/application/helpers/psr4_autoloader_helper.php
+++ b/application/helpers/psr4_autoloader_helper.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/*
+ * Extremely simple autoloader helper, has lots of shortcomings
+ */
+spl_autoload_register(function ($class) {
+	if (mb_substr($class, 0, 9) !== 'Cloudlog\\') {
+		return false;
+	}
+	$class=substr($class,9);
+	$file = str_replace('\\', DIRECTORY_SEPARATOR, $class).'.php';
+	$file = __DIR__ . "/../../src/" . $file;
+	if (file_exists($file)) {
+		require $file;
+		return true;
+	}
+	return false;
+});

--- a/application/models/Bands.php
+++ b/application/models/Bands.php
@@ -68,6 +68,24 @@ class Bands extends CI_Model {
 		return $results;
 	}
 
+	function get_worked_bands_for_user($userId) {
+
+		// get all worked slots from database
+		$sql = "
+				SELECT distinct LOWER(`COL_BAND`) as `COL_BAND`
+				FROM `" . $this->config->item('table_name') . "` qsos
+				INNER JOIN station_profile ON qsos.station_id=station_profile.station_id
+				WHERE station_profile.user_id =  ?
+			";
+
+		$data = $this->db->query($sql, $userId);
+		$results = [];
+		foreach ($data->result('array') as $row) {
+			$results[]=$row['COL_BAND'];
+		}
+		return $results;
+	}
+
 	function get_worked_bands_distances() {
 		$CI =& get_instance();
 		$CI->load->model('logbooks_model');

--- a/application/models/Modes.php
+++ b/application/models/Modes.php
@@ -7,7 +7,7 @@ class Modes extends CI_Model {
 		$this->db->order_by('submode', 'ASC');
 		return $this->db->get('adif_modes');
 	}
-	
+
 	function active() {
 		$this->db->where('active', 1);
 		$this->db->order_by('mode', 'ASC');
@@ -30,7 +30,7 @@ class Modes extends CI_Model {
 			$submode = null;
 		else
 			$submode = xss_clean($this->input->post('submode', true));
-		
+
 		$data = array(
 			'mode' => xss_clean($this->input->post('mode', true)),
 			'submode' => $submode,
@@ -38,7 +38,7 @@ class Modes extends CI_Model {
 			'active' =>  xss_clean($this->input->post('active', true)),
 		);
 
-		$this->db->insert('adif_modes', $data); 
+		$this->db->insert('adif_modes', $data);
 	}
 
 	function edit() {
@@ -46,7 +46,7 @@ class Modes extends CI_Model {
 			$submode = null;
 		else
 			$submode = xss_clean($this->input->post('submode', true));
-		
+
 		$data = array(
 			'mode' => xss_clean($this->input->post('mode', true)),
 			'submode' => $submode,
@@ -55,7 +55,7 @@ class Modes extends CI_Model {
 		);
 
 		$this->db->where('id', xss_clean($this->input->post('id', true)));
-		$this->db->update('adif_modes', $data); 
+		$this->db->update('adif_modes', $data);
 	}
 
 	function delete($id) {
@@ -63,7 +63,7 @@ class Modes extends CI_Model {
 		$clean_id = $this->security->xss_clean($id);
 
 		// Delete Mode
-		$this->db->delete('adif_modes', array('id' => $clean_id)); 
+		$this->db->delete('adif_modes', array('id' => $clean_id));
 	}
 
     function activate($id) {

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -15,7 +15,6 @@
 <script src="<?php echo base_url(); ?>assets/js/bootstrapdialog/js/bootstrap-dialog.min.js"></script>
 <script type="text/javascript" src="<?php echo base_url() ;?>assets/js/easyprint.js"></script>
 <script src="https://unpkg.com/htmx.org@1.6.1"></script>
-
 <script type="text/javascript">
   /*
   *
@@ -67,7 +66,7 @@ function load_was_map() {
             console.log("'clicked");
             if (navigator.geolocation) {
                 navigator.geolocation.getCurrentPosition(showPosition);
-            } else { 
+            } else {
                 console.log('Geolocation is not supported by this browser.');
             }
         }
@@ -283,7 +282,7 @@ function load_was_map() {
                             $(".bootstrap-dialog-message").prepend('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>The stored query has been deleted!</div>');
                             $("#query_" + id).remove(); // removes query from table in dialog
                             $("#querydropdown option[value='" + id + "']").remove(); // removes query from dropdown
-                            if ($("#querydropdown option").length == 0) { 
+                            if ($("#querydropdown option").length == 0) {
                                 $("#btn-edit").remove();
                                 $('.querydropdownform').remove();
                             };
@@ -520,13 +519,13 @@ function calculateQrb() {
             data: {'locator1': locator1,
                     'locator2': locator2},
             success: function (html) {
-                
+
                 var result = "<h5>Negative latitudes are south of the equator, negative longitudes are west of Greenwich. <br/>";
                 result += ' ' + locator1.toUpperCase() + ' Latitude = ' + html['latlng1'][0] + ' Longitude = ' + html['latlng1'][1] + '<br/>';
                 result += ' ' + locator2.toUpperCase() + ' Latitude = ' + html['latlng2'][0] + ' Longitude = ' + html['latlng2'][1] + '<br/>';
                 result += 'Distance between ' + locator1.toUpperCase() + ' and ' + locator2.toUpperCase() + ' is ' + html['distance'] + '.<br />';
                 result += 'The bearing is ' + html['bearing'] + '.</h5>';
-                
+
                 $(".qrbResult").html(result);
                 newpath(html['latlng1'], html['latlng2'], locator1, locator2);
             }
@@ -540,7 +539,7 @@ function validateLocator(locator) {
     if(locator.length < 4 && !(/^[a-rA-R]{2}[0-9]{2}[a-xA-X]{0,2}[0-9]{0,2}[a-xA-X]{0,2}$/.test(locator))) {
         return false;
     }
-    
+
     return true;
 }
 
@@ -558,7 +557,7 @@ function newpath(latlng1, latlng2, locator1, locator2) {
 
     var osmUrl='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
     var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
-    var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 9, attribution: osmAttrib}); 
+    var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 9, attribution: osmAttrib});
 
     var redIcon = L.icon({
 					iconUrl: icon_dot_url,
@@ -611,7 +610,7 @@ function showActivatorsMap(call, count, grids) {
 
     var osmUrl='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
     var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
-    var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 9, attribution: osmAttrib}); 
+    var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 9, attribution: osmAttrib});
 
     map.addLayer(osm);
 }
@@ -896,7 +895,7 @@ $(document).on('keypress',function(e) {
 <?php if ($this->uri->segment(1) == "qso") { ?>
 <script src="<?php echo base_url() ;?>assets/js/sections/qso.js"></script>
 
-<?php 
+<?php
 
     $this->load->model('stations');
     $active_station_id = $this->stations->find_active();
@@ -1611,7 +1610,7 @@ $(document).ready(function(){
 								attribution: '<?php echo $this->optionslib->get_option('option_map_tile_server_copyright');?>',
 							}).addTo(mymap);
 
-                            
+
                             var printer = L.easyPrint({
                                 tileLayer: tiles,
                                 sizeModes: ['Current'],
@@ -2234,7 +2233,7 @@ $(document).ready(function(){
 	<script src="<?php echo base_url(); ?>assets/js/sections/timeplot.js"></script>
 <?php } ?>
 
-<?php if ($this->uri->segment(1) == "qsl") { 
+<?php if ($this->uri->segment(1) == "qsl") {
     	// Get Date format
 	if($this->session->userdata('user_date_format')) {
 		// If Logged in and session exists
@@ -2255,7 +2254,7 @@ $(document).ready(function(){
         case 'M d, Y': $usethisformat = 'MMM D, YYYY';break;
         case 'M d, y': $usethisformat = 'MMM D, YY';break;
     }
-    
+
     ?>
     <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/moment.min.js"></script>
     <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/datetime-moment.js"></script>
@@ -2271,8 +2270,8 @@ $(document).ready(function(){
             "scrollX": true,
             "order": [ 2, 'desc' ],
         });
-        
-        
+
+
     </script>
 <?php } ?>
 
@@ -2873,5 +2872,13 @@ function deleteQsl(id) {
 		});
 	</script>
 <?php } ?>
+<?php
+if (isset($scripts) && is_array($scripts)){
+	foreach($scripts as $script){
+		?><script type="text/javascript" src="<?php echo base_url() . $script ;?>"></script>
+		<?php
+	}
+}
+?>
   </body>
 </html>

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -36,10 +36,10 @@
 
   	<link rel="stylesheet" type="text/css" href="<?php echo base_url(); ?>assets/css/datatables.min.css"/>
 
- 	<?php if ($this->uri->segment(1) == "adif") { ?>
+ 	<?php if ($this->uri->segment(1) == "adif" || (isset($hasDatePicker) && $hasDatePicker)) { ?>
   	<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/datepicker.css" />
   	<?php } ?>
-	 
+
 	<?php if (file_exists(APPPATH.'../assets/css/custom.css')) { echo '<link rel="stylesheet" href="'.base_url().'assets/css/custom.css">'; } ?>
 
     <link rel="icon" href="<?php echo base_url(); ?>favicon.ico">
@@ -74,6 +74,8 @@
 							<a class="dropdown-item" href="<?php echo site_url('contesting?manual=1');?>" title="Post contest QSOs">Post Contest Logging</a>
 							<div class="dropdown-divider"></div>
 							<a class="dropdown-item" href="<?php echo site_url('qsl');?>" title="QSL"> View QSL</a>
+							<div class="dropdown-divider"></div>
+							<a class="dropdown-item" href="<?php echo site_url('qslmanager');?>" title="QSL Manager"> QSL Manager</a>
 						</div>
         	</li>
 
@@ -201,7 +203,7 @@
 				<a class="dropdown-item" href="<?php echo site_url('user/edit')."/".$this->session->userdata('user_id'); ?>" title="Account"><i class="fas fa-user"></i> Account</a>
 
 				<a class="dropdown-item" href="<?php echo site_url('logbooks');?>" title="Manage station logbooks"><i class="fas fa-home"></i> Station Logbooks</a>
-				
+
 				<a class="dropdown-item" href="<?php echo site_url('station');?>" title="Manage station locations"><i class="fas fa-home"></i> Station Locations</a>
 
 				<div class="dropdown-divider"></div>

--- a/application/views/qslmanager/index.php
+++ b/application/views/qslmanager/index.php
@@ -1,0 +1,221 @@
+<div class="container-fluid qso_manager pt-3 pl-4 pr-4">
+	<?php if ($this->session->flashdata('message')) { ?>
+		<!-- Display Message -->
+		<div class="alert-message error">
+			<p><?php echo $this->session->flashdata('message'); ?></p>
+		</div>
+	<?php } ?>
+
+	<h2>QSL Manager</h2>
+
+	<form id="searchForm" name="searchForm" action="<?php echo base_url()."qslmanager/search";?>" method="post">
+		<div class="form-row">
+			<div class="form-group col-1">
+				<label for="dateFrom">From</label>
+				<div class="input-group date" id="dateFrom" data-target-input="nearest">
+					<input name="dateFrom" type="text" placeholder="<?php echo $datePlaceholder;?>" class="form-control" data-target="#dateFrom"/>
+					<div class="input-group-append"  data-target="#dateFrom" data-toggle="datetimepicker">
+						<div class="input-group-text"><i class="fa fa-calendar"></i></div>
+					</div>
+				</div>
+			</div>
+			<div class="form-group col-1">
+				<label for="dateTo">To</label>
+				<div class="input-group date" id="dateTo" data-target-input="nearest">
+					<input name="dateTo" type="text" placeholder="<?php echo $datePlaceholder;?>" class="form-control" data-target="#dateTo"/>
+					<div class="input-group-append"  data-target="#dateTo" data-toggle="datetimepicker">
+						<div class="input-group-text"><i class="fa fa-calendar"></i></div>
+					</div>
+				</div>
+			</div>
+			<div class="form-group col-1">
+				<label for="de">De</label>
+				<select id="de" name="de" class="form-control">
+					<option value="">All</option>
+					<?php
+					foreach($deOptions as $deOption){
+						?><option value="<?php echo htmlentities($deOption);?>"><?php echo htmlspecialchars($deOption);?></option><?php
+					}
+					?>
+				</select>
+			</div>
+			<div class="form-group col-1">
+				<label for="dx">Dx</label>
+				<input type="text" name="dx" id="dx" class="form-control" value="">
+			</div>
+			<div class="form-group col-1">
+				<label for="mode">Mode</label>
+				<select id="mode" name="mode" class="form-control">
+					<option value="">All</option>
+					<?php
+					foreach($modes as $modeId => $mode){
+						?><option value="<?php echo htmlentities($modeId);?>"><?php echo htmlspecialchars($mode);?></option><?php
+					}
+					?>
+				</select>
+			</div>
+			<div class="form-group col-1">
+				<label for="band">Band</label>
+				<select id="band" name="band" class="form-control">
+					<option value="">All</option>
+					<?php
+					foreach($bands as $band){
+						?><option value="<?php echo htmlentities($band);?>"><?php echo htmlspecialchars($band);?></option><?php
+					}
+					?>
+				</select>
+			</div>
+			<div class="form-group col-1">
+				<label for="qslSent">QSL Sent</label>
+				<select id="qslSent" name="qslSent" class="form-control">
+					<option value="">All</option>
+					<option value="Y">Yes</option>
+					<option value="N">No</option>
+					<option value="R">Requested</option>
+					<option value="Q">Queued</option>
+					<option value="I">Ignore/Invalid</option>
+				</select>
+			</div>
+			<div class="form-group col-1">
+				<label for="qslReceived">QSL Received</label>
+				<select id="qslReceived" name="qslReceived" class="form-control">
+					<option value="">All</option>
+					<option value="Y">Yes</option>
+					<option value="N">No</option>
+					<option value="R">Requested</option>
+					<option value="I">Ignore/Invalid</option>
+					<option value="V">Verified</option>
+				</select>
+			</div>
+			<div class="form-group col-2">
+				<label>&nbsp;</label><br>
+				<button type="submit" class="btn btn-primary" id="searchButton">Search</button>
+				<button type="reset" class="btn btn-danger" id="resetButton">Reset</button>
+			</div>
+		</div>
+	</form>
+	<hr class="mt-0 mb-3">
+	<div class="mb-2">
+		<span class="h6">With selected :</span>
+		<button type="button" class="btn btn-sm btn-primary" id="btnUpdateFromCallbook">Update from Callbook</button>
+		<button type="button" class="btn btn-sm btn-primary">Copy refs to QSL Msg</button>
+		<button type="button" class="btn btn-sm btn-primary">Queue Bureau</button>
+		<button type="button" class="btn btn-sm btn-primary">Queue Direct</button>
+		<button type="button" class="btn btn-sm btn-success">Sent Bureau</button>
+		<button type="button" class="btn btn-sm btn-success">Sent Direct</button>
+		<button type="button" class="btn btn-sm btn-warning">Don't Send</button>
+		<button type="button" class="btn btn-sm btn-info">Create ADIF</button>
+		<span id="infoBox"></span>
+	</div>
+	<table class="table" id="qsoList">
+		<thead>
+			<tr>
+				<th><div class="form-check" style="margin-top: -1.5em"><input class="form-check-input" type="checkbox" id="checkBoxAll" /></div></th>
+				<th>Date/Time</th>
+				<th>De</th>
+				<th>Dx</th>
+				<th>Mode</th>
+				<th>RST (S)</th>
+				<th>RST (R)</th>
+				<th>Band</th>
+				<th>My Refs</th>
+				<th>Refs</th>
+				<th>Name</th>
+				<th>QSL Via</th>
+				<th>QSL Sent</th>
+				<th>QSL Received</th>
+				<th>QSL Msg</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="model d-none">
+				<td>
+					<div class="form-check">
+						<input class="form-check-input" type="checkbox" />
+					</div>
+				</td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+			</tr>
+			<?php /*
+			<tr>
+				<td>
+					<div class="form-check">
+						<input class="form-check-input" type="checkbox" value="" id="defaultCheck1">
+						<label class="form-check-label d-none" for="defaultCheck1">Select QSO ID 999</label>
+					</div>
+				</td>
+				<td>2022-01-02 03:04</td>
+				<td>CT7AOV/P</td>
+				<td>DF2ET/P</td>
+				<td>SSB</td>
+				<td>59</td>
+				<td>59</td>
+				<td>20m</td>
+				<td>CT/ES-004</td>
+				<td>DLFF-1234</td>
+				<td>Buro, Direct, LOTW</td>
+				<td></td>
+				<td></td>
+				<td></td>
+			</tr>
+			<tr>
+				<td>
+					<div class="form-check">
+						<input class="form-check-input" type="checkbox" value="" id="defaultCheck1">
+						<label class="form-check-label d-none" for="defaultCheck1">Select QSO ID 999</label>
+					</div>
+				</td>
+				<td>2022-01-02 03:04</td>
+				<td>CT7AOV/P</td>
+				<td>DF2ET/P</td>
+				<td>SSB</td>
+				<td>59</td>
+				<td>59</td>
+				<td>20m</td>
+				<td>CT/HCE-123</td>
+				<td>DLFF-1234</td>
+				<td>Buro, Direct, LOTW</td>
+				<td>Queued Direct</td>
+				<td></td>
+				<td>CT/HCE-123</td>
+			</tr>
+			<tr>
+				<td>
+					<div class="form-check">
+						<input class="form-check-input" type="checkbox" value="" id="defaultCheck1">
+						<label class="form-check-label d-none" for="defaultCheck1">Select QSO ID 999</label>
+					</div>
+				</td>
+				<td>2022-01-02 03:04</td>
+				<td>DL/CT7AOV/P</td>
+				<td>DF2ET/P</td>
+				<td>SSB</td>
+				<td>59</td>
+				<td>59</td>
+				<td>20m</td>
+				<td>DLFF-1234</td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+			</tr>
+ 			*/ ?>
+		</tbody>
+	</table>
+
+
+</div>

--- a/assets/js/qslmanager.js
+++ b/assets/js/qslmanager.js
@@ -1,0 +1,190 @@
+var callBookProcessingDialog = null;
+var inCallbookProcessing = false;
+var inCallbookItemProcessing = false;
+
+function updateRow(qso) {
+	let row = $('#qsoID-' + qso.qsoID);
+	let cells = row.find('td');
+	let c = 1;
+	cells.eq(c++).text(qso.qsoDateTime);
+	cells.eq(c++).text(qso.de);
+	cells.eq(c++).text(qso.dx);
+	cells.eq(c++).text(qso.mode);
+	cells.eq(c++).text(qso.rstS);
+	cells.eq(c++).text(qso.rstR);
+	cells.eq(c++).text(qso.band);
+	cells.eq(c++).text(qso.deRefs);
+	cells.eq(c++).text(qso.dxRefs);
+	cells.eq(c++).text(qso.name);
+	cells.eq(c++).text(qso.qslVia);
+	cells.eq(c++).text(qso.qslSent);
+	cells.eq(c++).text(qso.qslReceived);
+	cells.eq(c++).text(qso.qslMsg);
+	return row;
+}
+
+function loadQSOTable(rows) {
+	let table = $("#qsoList");
+	table.find('tbody').children('tr').not('.model').remove();
+	for (i = 0; i < rows.length; i++) {
+		let qso = rows[i];
+		let row = table.find('tbody tr.model').clone();
+		row.attr('id', 'qsoID-' + qso.qsoID)
+		row.data('qsoID', qso.qsoID);
+		table.find('tbody').append(row);
+		updateRow(qso);
+		row.removeClass('d-none');
+		row.removeClass('model');
+
+	}
+}
+
+function selectQsoID(qsoID) {
+	var element = $("#qsoID-" + qsoID);
+	element.find("input[type=checkbox]").prop("checked", true);
+	element.addClass('alert-success')
+}
+
+
+function unselectQsoID(qsoID) {
+	var element = $("#qsoID-" + qsoID);
+	element.find("input[type=checkbox]").prop("checked", false);
+	element.removeClass('alert-success')
+}
+
+function processNextCallbookItem() {
+	if (!inCallbookProcessing) return;
+
+	var elements = $('#qsoList tbody input:checked');
+	var nElements = elements.length;
+	if (nElements == 0) {
+		inCallbookProcessing = false;
+		callBookProcessingDialog.close();
+		return;
+	}
+
+	callBookProcessingDialog.setMessage("Retrieving callbook data : " + nElements + " remaining");
+
+	unselectQsoID(elements.first().closest('tr').data('qsoID'));
+
+	$.ajax({
+		url: site_url + '/qslmanager/updateFromCallbook',
+		type: 'post',
+		data: {
+			qsoID: elements.first().closest('tr').data('qsoID')
+		},
+		dataType: 'json',
+		success: function (data) {
+			if (data !== []) {
+				updateRow(data);
+			}
+			setTimeout("processNextCallbookItem()", 50);
+		},
+		error: function (data) {
+			setTimeout("processNextCallbookItem()", 50);
+		},
+	});
+}
+
+$(document).ready(function () {
+	$('#dateFrom').datetimepicker({
+		format: 'YYYY-MM-DD',
+	});
+	$('#dateTo').datetimepicker({
+		format: 'YYYY-MM-DD',
+	});
+
+	$('#searchForm').submit(function (e) {
+		$('#searchButton').prop("disabled", true);
+
+		$.ajax({
+			url: this.action,
+			type: 'post',
+			data: {
+				dateFrom: this.dateFrom.value,
+				dateTo: this.dateTo.value,
+				de: this.de.value,
+				dx: this.dx.value,
+				mode: this.mode.value,
+				band: this.band.value,
+				qslSent: this.qslSent.value,
+				qslReceived: this.qslReceived.value
+			},
+			dataType: 'json',
+			success: function (data) {
+				$('#searchButton').prop("disabled", false);
+				loadQSOTable(data);
+			},
+			error: function (data) {
+				$('#searchButton').prop("disabled", false);
+				BootstrapDialog.alert({
+					title: 'ERROR',
+					message: 'An error ocurred while making the request',
+					type: BootstrapDialog.TYPE_DANGER,
+					closable: false,
+					draggable: false,
+					callback: function (result) {
+						//document.location=document.location;
+					}
+				});
+			},
+		});
+		return false;
+	});
+
+	$("#qsoList tbody").on('click', 'tr', function (event) {
+		var qsoID = $(event.currentTarget).data('qsoID');
+		let checkBox;
+		if (event.target.tagName === 'INPUT') {
+			checkBox = $(this);
+		} else {
+			checkBox = $(this).find('input[type=checkbox]');
+		}
+		if (checkBox.prop("checked")) {
+			unselectQsoID(qsoID);
+		} else {
+			selectQsoID(qsoID);
+		}
+	});
+
+	$('#btnUpdateFromCallbook').click(function (event) {
+
+		var elements = $('#qsoList tbody input:checked');
+		var nElements = elements.length;
+		if (nElements == 0) {
+			return;
+		}
+		inCallbookProcessing = true;
+
+		callBookProcessingDialog = BootstrapDialog.show({
+			title: "Retrieving callbook data for " + nElements + " QSOs",
+			message: "Retrieving callbook data for " + nElements + " QSOs",
+			type: BootstrapDialog.TYPE_DANGER,
+			closable: false,
+			draggable: false,
+			buttons: [{
+				label: 'Cancel',
+				action: function(dialog) {
+					inCallbookProcessing = false;
+					dialog.close();
+				}
+			}]
+		});
+
+		processNextCallbookItem();
+	});
+
+	$('#checkBoxAll').change(function (event) {
+		if (this.checked) {
+			$('#qsoList tbody tr').each(function (i) {
+				selectQsoID($(this).data('qsoID'))
+			});
+		}else{
+			$('#qsoList tbody tr').each(function (i) {
+				unselectQsoID($(this).data('qsoID'))
+			});
+		}
+	});
+
+	$('#searchForm').submit();
+});

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "autoload": {
+        "psr-4": {
+            "Cloudlog\\": "src/",
+            "Tests\\Cloudlog\\": "tests/"
+        }
+    },
+    "require": {
+        "php": "^7.4",
+        "phpunit/phpunit": "^9.5"
+    }
+}

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -1,0 +1,660 @@
+<?php
+declare(strict_types=1);
+
+namespace Cloudlog\QSLManager;
+
+use DateTime;
+use DateTimeZone;
+use DomainException;
+
+class QSO
+{
+	private string $qsoID;
+	private DateTime $qsoDateTime;
+	private string $de;
+	private string $dx;
+	private string $mode;
+	private string $submode;
+	private string $band;
+	private string $bandRX;
+	private string $rstR;
+	private string $rstS;
+	private string $propagationMode;
+	private string $satelliteMode;
+	private string $satelliteName;
+	private string $name;
+	private string $email;
+	private string $address;
+	private string $deGridsquare;
+	private string $deIOTA;
+	private string $deSig;
+	private string $deSigInfo;
+	private string $deIOTAIslandID;
+	private string $deSOTAReference;
+	/** @var string[] */
+	private array $deVUCCGridsquares;
+	private string $dxGridsquare;
+	private string $dxIOTA;
+	private string $dxSig;
+	private string $dxSigInfo;
+	private string $dxDARCDOK;
+	private string $dxSOTAReference;
+	/** @var string[] */
+	private array $dxVUCCGridsquares;
+	private string $QSLMsg;
+	private ?DateTime $QSLReceivedDate;
+	private string $QSLReceived;
+	private string $QSLReceivedVia;
+	private ?DateTime $QSLSentDate;
+	private string $QSLSent;
+	private string $QSLSentVia;
+	private string $QSLVia;
+
+	/**
+	 * @param array $data Does no validation, it's assumed to be a row from the database in array format
+	 */
+	public function __construct(array $data)
+	{
+		$requiredKeys = [
+			'COL_PRIMARY_KEY',
+			'COL_ADDRESS',
+			'COL_BAND',
+			'COL_BAND_RX',
+			'COL_CALL',
+			'COL_EMAIL',
+			'COL_GRIDSQUARE',
+			'COL_IOTA',
+			'COL_MODE',
+			'COL_MY_GRIDSQUARE',
+			'COL_MY_IOTA',
+			'COL_MY_SIG',
+			'COL_MY_SIG_INFO',
+			'COL_NAME',
+			'COL_PROP_MODE',
+			'COL_QSLMSG',
+			'COL_QSLRDATE',
+			'COL_QSLSDATE',
+			'COL_QSL_RCVD',
+			'COL_QSL_RCVD_VIA',
+			'COL_QSL_SENT',
+			'COL_QSL_SENT_VIA',
+			'COL_QSL_VIA',
+			'COL_RST_RCVD',
+			'COL_RST_SENT',
+			'COL_SAT_MODE',
+			'COL_SAT_NAME',
+			'COL_SIG',
+			'COL_SIG_INFO',
+			'COL_STATION_CALLSIGN',
+			'COL_TIME_ON',
+			'COL_DARC_DOK',
+			'COL_MY_IOTA_ISLAND_ID',
+			'COL_MY_SOTA_REF',
+			'COL_MY_VUCC_GRIDS',
+			'COL_SOTA_REF',
+			'COL_SUBMODE',
+			'COL_VUCC_GRIDS'
+		];
+
+
+		foreach ($requiredKeys as $requiredKey) {
+			if (!array_key_exists($requiredKey, $data)) {
+				throw new DomainException("Required key $requiredKey does not exist");
+			}
+		}
+
+		$this->qsoID = $data['COL_PRIMARY_KEY'];
+
+		$this->qsoDateTime = DateTime::createFromFormat("Y-m-d H:i:s", $data['COL_TIME_ON'], new DateTimeZone("UTC"));
+
+		$this->de = $data['COL_STATION_CALLSIGN'];
+		$this->dx = $data['COL_CALL'];
+
+		$this->mode = $data['COL_MODE'] ?? '';
+		$this->submode = $data['COL_SUBMODE'] ?? '';
+		$this->band = $data['COL_BAND'];
+		$this->bandRX = $data['COL_BAND_RX'] ?? '';
+		$this->rstR = $data['COL_RST_RCVD'];
+		$this->rstS = $data['COL_RST_SENT'];
+		$this->propagationMode = $data['COL_PROP_MODE'] ?? '';
+		$this->satelliteMode = $data['COL_SAT_MODE'] ?? '';
+		$this->satelliteName = $data['COL_SAT_NAME'] ?? '';
+
+
+		$this->name = $data['COL_NAME'] ?? '';
+		$this->email = $data['COL_EMAIL'] ?? '';
+		$this->address = $data['COL_ADDRESS'] ?? '';
+
+		$this->deGridsquare = $data['COL_MY_GRIDSQUARE'] ?? '';
+		$this->deIOTA = $data['COL_MY_IOTA'] ?? '';
+		$this->deSig = $data['COL_MY_SIG'] ?? '';
+		$this->deSigInfo = $data['COL_MY_SIG_INFO'] ?? '';
+		$this->deIOTAIslandID = $data['COL_MY_IOTA_ISLAND_ID'] ?? '';
+		$this->deSOTAReference = $data['COL_MY_SOTA_REF'] ?? '';
+		if (trim($data['COL_MY_VUCC_GRIDS']) === '') {
+			$this->deVUCCGridsquares = [];
+		} else {
+			$this->deVUCCGridsquares = explode(",", $data['COL_MY_VUCC_GRIDS'] ?? '');
+		}
+
+		$this->dxGridsquare = $data['COL_GRIDSQUARE'] ?? '';
+		$this->dxIOTA = $data['COL_IOTA'] ?? '';
+		$this->dxSig = $data['COL_SIG'] ?? '';
+		$this->dxSigInfo = $data['COL_SIG_INFO'] ?? '';
+		$this->dxDARCDOK = $data['COL_DARC_DOK'] ?? '';
+
+		$this->dxSOTAReference = $data['COL_SOTA_REF'] ?? '';
+		if (trim($data['COL_VUCC_GRIDS']) !== '') {
+			$this->dxVUCCGridsquares = explode(",", $data['COL_VUCC_GRIDS'] ?? '');
+		} else {
+			$this->dxVUCCGridsquares = [];
+		}
+
+		$this->QSLMsg = $data['COL_QSLMSG'] ?? '';
+
+		$this->QSLReceivedDate = ($data['COL_QSLRDATE'] === null) ? null : DateTime::createFromFormat("Y-m-d H:i:s", $data['COL_QSLRDATE'], new DateTimeZone('UTC'));
+		$this->QSLReceived = $data['COL_QSL_RCVD'];
+		$this->QSLReceivedVia = $data['COL_QSL_RCVD_VIA'];
+		$this->QSLSentDate = ($data['COL_QSLSDATE'] === null) ? null : DateTime::createFromFormat("Y-m-d H:i:s", $data['COL_QSLSDATE'], new DateTimeZone('UTC'));
+		$this->QSLSent = $data['COL_QSL_SENT'];
+		$this->QSLSentVia = $data['COL_QSL_SENT_VIA'];
+		$this->QSLVia = $data['COL_QSL_VIA'];
+
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getQsoID(): string
+	{
+		return $this->qsoID;
+	}
+
+	/**
+	 * @return DateTime
+	 */
+	public function getQsoDateTime(): DateTime
+	{
+		return $this->qsoDateTime;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDe(): string
+	{
+		return $this->de;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDx(): string
+	{
+		return $this->dx;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getMode(): string
+	{
+		return $this->mode;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSubmode(): string
+	{
+		return $this->submode;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getBand(): string
+	{
+		return $this->band;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getBandRX(): string
+	{
+		return $this->bandRX;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getRstR(): string
+	{
+		return $this->rstR;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getRstS(): string
+	{
+		return $this->rstS;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getPropagationMode(): string
+	{
+		return $this->propagationMode;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSatelliteMode(): string
+	{
+		return $this->satelliteMode;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSatelliteName(): string
+	{
+		return $this->satelliteName;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName(): string
+	{
+		return $this->name;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getEmail(): string
+	{
+		return $this->email;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getAddress(): string
+	{
+		return $this->address;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDeGridsquare(): string
+	{
+		return $this->deGridsquare;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDeIOTA(): string
+	{
+		return $this->deIOTA;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDeSig(): string
+	{
+		return $this->deSig;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDeSigInfo(): string
+	{
+		return $this->deSigInfo;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDeIOTAIslandID(): string
+	{
+		return $this->deIOTAIslandID;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDeSOTAReference(): string
+	{
+		return $this->deSOTAReference;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getDeVUCCGridsquares(): array
+	{
+		return $this->deVUCCGridsquares;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDxGridsquare(): string
+	{
+		return $this->dxGridsquare;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDxIOTA(): string
+	{
+		return $this->dxIOTA;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDxSig(): string
+	{
+		return $this->dxSig;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDxSigInfo(): string
+	{
+		return $this->dxSigInfo;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDxDARCDOK(): string
+	{
+		return $this->dxDARCDOK;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDxSOTAReference(): string
+	{
+		return $this->dxSOTAReference;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getDxVUCCGridsquares(): array
+	{
+		return $this->dxVUCCGridsquares;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getQSLMsg(): string
+	{
+		return $this->QSLMsg;
+	}
+
+	/**
+	 * @return ?DateTime
+	 */
+	public function getQSLReceivedDate(): ?DateTime
+	{
+		return $this->QSLReceivedDate;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getQSLReceived(): string
+	{
+		return $this->QSLReceived;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getQSLReceivedVia(): string
+	{
+		return $this->QSLReceivedVia;
+	}
+
+	/**
+	 * @return ?DateTime
+	 */
+	public function getQSLSentDate(): ?DateTime
+	{
+		return $this->QSLSentDate;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getQSLSent(): string
+	{
+		return $this->QSLSent;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getQSLSentVia(): string
+	{
+		return $this->QSLSentVia;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getQSLVia(): string
+	{
+		return $this->QSLVia;
+	}
+
+	public function toArray(): array
+	{
+		return [
+			'qsoID' => $this->qsoID,
+			'qsoDateTime' => $this->qsoDateTime->format("Y-m-d H:i"),
+			'de' => $this->de,
+			'dx' => $this->dx,
+			'mode' => $this->getFormattedMode(),
+			'rstS' => $this->rstS,
+			'rstR' => $this->rstR,
+			'band' => $this->getFormattedBand(),
+			'deRefs' => $this->getFormattedDeRefs(),
+			'dxRefs' => $this->getFormattedDxRefs(),
+			'qslVia' => $this->QSLVia,
+			'qslSent' => $this->getFormattedQSLSent(),
+			'qslReceived' => $this->getFormattedQSLReceived(),
+			'qslMessage' => $this->getQSLMsg(),
+			'name' => $this->getName(),
+		];
+	}
+
+	private function getFormattedMode(): string
+	{
+		if ($this->submode !== '') {
+			return $this->submode;
+		} else {
+			return $this->mode;
+		}
+	}
+
+	private function getFormattedBand(): string
+	{
+		$label = "";
+		if ($this->propagationMode !== '') {
+			$label .= $this->propagationMode;
+			if ($this->satelliteName !== '') {
+				$label .= " " . $this->satelliteName;
+				if ($this->satelliteMode !== '') {
+					$label .= " " . $this->satelliteMode;
+				}
+			}
+		}
+		$label .= " " . $this->band;
+		if ($this->bandRX !== '' && $this->band !== '') {
+			$label .= "/" . $this->bandRX;
+		}
+		return trim($label);
+	}
+
+	private function getFormattedDeRefs(): string
+	{
+		$refs = [];
+		if ($this->deVUCCGridsquares !== []) {
+			$refs[] = implode(",", $this->deVUCCGridsquares);
+		} else {
+			if ($this->deGridsquare !== '') {
+				$refs[] = $this->deGridsquare;
+			}
+		}
+		if ($this->deIOTA !== '') {
+			if ($this->deIOTAIslandID !== '') {
+				$refs[] = "IOTA:" . $this->deIOTA . "(" . $this->deIOTAIslandID . ")";
+			} else {
+				$refs[] = "IOTA:" . $this->deIOTA;
+			}
+		}
+		if ($this->deSOTAReference !== '') {
+			$refs[] = "SOTA:" . $this->deSOTAReference;
+		}
+		if ($this->deSig !== '') {
+			$refs[] = $this->deSig . ":" . $this->deSigInfo;
+		}
+		return trim(implode(" ", $refs));
+	}
+
+	private function getFormattedDxRefs(): string
+	{
+		$refs = [];
+		if ($this->dxVUCCGridsquares !== []) {
+			$refs[] = implode(",", $this->dxVUCCGridsquares);
+		} else if ($this->dxGridsquare !== '') {
+			$refs[] = $this->dxGridsquare;
+		}
+		if ($this->dxIOTA !== '') {
+			$refs[] = "IOTA:" . $this->dxIOTA;
+		}
+		if ($this->dxSOTAReference !== '') {
+			$refs[] = "SOTA:" . $this->dxSOTAReference;
+		}
+		if ($this->dxSig !== '') {
+			$refs[] = $this->dxSig . ":" . $this->dxSigInfo;
+		}
+		if ($this->dxDARCDOK !== '') {
+			$refs[] = "DOK:" . $this->dxDARCDOK;
+		}
+		return implode(" ", $refs);
+	}
+
+	private function getFormattedQSLSent(): string
+	{
+		$showVia = false;
+		$label = [];
+		if ($this->QSLSent === "Y") {
+			if ($this->QSLSentDate !== null) {
+				$label[] = $this->QSLSentDate->format("Y-m-d");
+			} else {
+				$label[] = "Yes";
+			}
+			$showVia = true;
+		} else if ($this->QSLSent === "N") {
+			$label[] = "No";
+		} else if ($this->QSLSent === "Q") {
+			$label[] = "Queued";
+			if ($this->QSLSentDate !== null) {
+				$label[] = $this->QSLSentDate->format("Y-m-d");
+			}
+			$showVia = true;
+		} else if ($this->QSLSent === "R") {
+			$label[] = "Requested";
+			if ($this->QSLSentDate !== null) {
+				$label[] = $this->QSLSentDate->format("Y-m-d");
+			}
+			$showVia = true;
+		}
+
+		if ($showVia && $this->QSLSentVia !== '') {
+			switch ($this->QSLSentVia) {
+				case 'B':
+					$label[] = "Bureau";
+					break;
+				case 'D':
+					$label[] = "Direct";
+					break;
+				case 'E':
+					$label[] = "Electronic";
+					break;
+				case 'M':
+					$label[] = "Manager";
+					break;
+			}
+		}
+
+		return trim(implode(" ", $label));
+	}
+
+	private function getFormattedQSLReceived(): string
+	{
+		$showVia = false;
+		$label = [];
+		if ($this->QSLReceived === "Y") {
+			if ($this->QSLReceivedDate !== null) {
+				$label[] = $this->QSLReceivedDate->format("Y-m-d");
+			} else {
+				$label[] = "Yes";
+			}
+			$showVia = true;
+		} else if ($this->QSLReceived === "N") {
+			$label[] = "No";
+		} else if ($this->QSLReceived === "Q") {
+			$label[] = "Queued";
+			if ($this->QSLReceivedDate !== null) {
+				$label[] = $this->QSLReceivedDate->format("Y-m-d");
+			}
+			$showVia = true;
+		} else if ($this->QSLReceived === "R") {
+			$label[] = "Requested";
+			if ($this->QSLReceivedDate !== null) {
+				$label[] = $this->QSLReceivedDate->format("Y-m-d");
+			}
+			$showVia = true;
+		}
+
+		if ($showVia && $this->QSLReceivedVia !== '') {
+			switch ($this->QSLReceivedVia) {
+				case 'B':
+					$label[] = "Bureau";
+					break;
+				case 'D':
+					$label[] = "Direct";
+					break;
+				case 'E':
+					$label[] = "Electronic";
+					break;
+				case 'M':
+					$label[] = "Manager";
+					break;
+			}
+		}
+
+		return trim(implode(" ", $label));
+	}
+}

--- a/src/QSLManager/SearchCriteria.php
+++ b/src/QSLManager/SearchCriteria.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace Cloudlog\QSLManager;
+
+use DateTime;
+use DateTimeZone;
+
+class SearchCriteria
+{
+	private int $userId;
+	private ?DateTime $dateFrom = null;
+	private ?DateTime $dateTo = null;
+	private string $de;
+	private string $dx;
+	private string $mode;
+	private string $band;
+	private string $qslSent;
+	private string $qslReceived;
+
+	/**
+	 * @param int $userId
+	 * @param string $dateFrom
+	 * @param string $dateTo
+	 * @param string $de
+	 * @param string $dx
+	 * @param string $mode
+	 * @param string $band
+	 * @param string $qslSent
+	 * @param string $qslReceived
+	 */
+	public function __construct(
+		int    $userId,
+		string $dateFrom,
+		string $dateTo,
+		string $de,
+		string $dx,
+		string $mode,
+		string $band,
+		string $qslSent,
+		string $qslReceived
+	)
+	{
+		$this->userId = $userId;
+		$dateFrom = trim($dateFrom);
+		if ($dateFrom !== "") {
+			$dateFromParts = explode("-", $dateFrom);
+			if (checkdate((int)$dateFromParts[1], (int)$dateFromParts[2], (int)$dateFromParts[0])) {
+				$this->dateFrom = DateTime::createFromFormat("Y-m-d", $dateFrom, new DateTimeZone('UTC'));
+			}
+		}
+
+		$dateTo = trim($dateTo);
+		if ($dateTo !== "") {
+			$dateToParts = explode("-", $dateTo);
+			if (checkdate((int)$dateToParts[1], (int)$dateToParts[2], (int)$dateToParts[0])) {
+				$this->dateTo = DateTime::createFromFormat("Y-m-d", $dateTo, new DateTimeZone('UTC'));
+			}
+		}
+
+		if ($this->dateFrom !== null && $this->dateTo !== null && $this->dateTo->getTimestamp() < $this->dateFrom->getTimestamp()) {
+			$temp = $this->dateFrom;
+			$this->dateFrom = $this->dateTo;
+			$this->dateTo = $temp;
+		}
+
+		$this->de = trim($de);
+		$this->dx = trim($dx);
+		$this->mode = trim($mode);
+		$this->band = trim($band);
+		$this->qslSent = $qslSent;
+		$this->qslReceived = $qslReceived;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getUserId(): int
+	{
+		return $this->userId;
+	}
+
+	/**
+	 * @return DateTime|false|null
+	 */
+	public function getDateFrom()
+	{
+		return $this->dateFrom;
+	}
+
+	/**
+	 * @return DateTime|false|null
+	 */
+	public function getDateTo()
+	{
+		return $this->dateTo;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDe(): string
+	{
+		return $this->de;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDx(): string
+	{
+		return $this->dx;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getMode(): string
+	{
+		return $this->mode;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getBand(): string
+	{
+		return $this->band;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getQslSent(): string
+	{
+		return $this->qslSent;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getQslReceived(): string
+	{
+		return $this->qslReceived;
+	}
+
+}

--- a/tests/QSLManager/QSOTest.php
+++ b/tests/QSLManager/QSOTest.php
@@ -1,0 +1,697 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Cloudlog\QSLManager;
+
+use DomainException;
+use PHPUnit\Framework\TestCase;
+use Cloudlog\QSLManager\QSO;
+
+class QSOTest extends TestCase
+{
+	public function testCanCreateObject()
+	{
+		$data = $this->getTestData();
+		$sut = new QSO($data);
+
+		$this->assertEquals($data['COL_PRIMARY_KEY'], $sut->getQsoID());
+		$this->assertEquals($data['COL_ADDRESS'], $sut->getAddress());
+		$this->assertEquals($data['COL_BAND'], $sut->getBand());
+		$this->assertEquals($data['COL_BAND_RX'], $sut->getBandRX());
+		$this->assertEquals($data['COL_CALL'], $sut->getDx());
+		$this->assertEquals($data['COL_EMAIL'], $sut->getEmail());
+		$this->assertEquals($data['COL_GRIDSQUARE'], $sut->getDxGridsquare());
+		$this->assertEquals($data['COL_IOTA'], $sut->getDxIOTA());
+		$this->assertEquals($data['COL_MODE'], $sut->getMode());
+		$this->assertEquals($data['COL_MY_GRIDSQUARE'], $sut->getDeGridsquare());
+		$this->assertEquals($data['COL_MY_IOTA'], $sut->getDeIOTA());
+		$this->assertEquals($data['COL_MY_SIG'], $sut->getDeSig());
+		$this->assertEquals($data['COL_MY_SIG_INFO'], $sut->getDeSigInfo());
+		$this->assertEquals($data['COL_NAME'], $sut->getName());
+		$this->assertEquals($data['COL_PROP_MODE'], $sut->getPropagationMode());
+		$this->assertEquals($data['COL_QSLMSG'], $sut->getQSLMsg());
+		$this->assertEquals($data['COL_QSLRDATE'], $sut->getQSLReceivedDate()->format("Y-m-d H:i:s"));
+		$this->assertEquals($data['COL_QSLSDATE'], $sut->getQSLSentDate()->format("Y-m-d H:i:s"));
+		$this->assertEquals($data['COL_QSL_RCVD'], $sut->getQSLReceived());
+		$this->assertEquals($data['COL_QSL_RCVD_VIA'], $sut->getQSLReceivedVia());
+		$this->assertEquals($data['COL_QSL_SENT'], $sut->getQSLSent());
+		$this->assertEquals($data['COL_QSL_SENT_VIA'], $sut->getQSLSentVia());
+		$this->assertEquals($data['COL_QSL_VIA'], $sut->getQSLVia());
+		$this->assertEquals($data['COL_RST_RCVD'], $sut->getRstR());
+		$this->assertEquals($data['COL_RST_SENT'], $sut->getRstS());
+		$this->assertEquals($data['COL_SAT_MODE'], $sut->getSatelliteMode());
+		$this->assertEquals($data['COL_SAT_NAME'], $sut->getSatelliteName());
+		$this->assertEquals($data['COL_SIG'], $sut->getDxSig());
+		$this->assertEquals($data['COL_SIG_INFO'], $sut->getDxSigInfo());
+		$this->assertEquals($data['COL_STATION_CALLSIGN'], $sut->getDe());
+		$this->assertEquals($data['COL_TIME_ON'], $sut->getQsoDateTime()->format("Y-m-d H:i:s"));
+		$this->assertEquals($data['COL_DARC_DOK'], $sut->getDxDARCDOK());
+		$this->assertEquals($data['COL_MY_IOTA_ISLAND_ID'], $sut->getDeIOTAIslandID());
+		$this->assertEquals($data['COL_MY_SOTA_REF'], $sut->getDeSOTAReference());
+		$this->assertEquals($data['COL_MY_VUCC_GRIDS'], implode(",", $sut->getDeVUCCGridsquares()));
+		$this->assertEquals($data['COL_SOTA_REF'], $sut->getDxSOTAReference());
+		$this->assertEquals($data['COL_SUBMODE'], $sut->getSubmode());
+		$this->assertEquals($data['COL_VUCC_GRIDS'], implode(",", $sut->getDxVUCCGridsquares()));
+	}
+
+	public function testCreateFailsIfOneKeyIsMissing()
+	{
+		$data = $this->getTestData();
+		$keys = array_keys($data);
+		foreach ($keys as $key) {
+			$dataWithMissingKey = $data;
+			unset($dataWithMissingKey[$key]);
+			try {
+				new QSO($dataWithMissingKey);
+				$this->fail();
+			} catch (DomainException $e) {
+				$this->assertEquals("Required key $key does not exist", $e->getMessage());
+			}
+		}
+	}
+
+	/**
+	 * @param string $testDescription
+	 * @param array $testData
+	 * @param array $expectedResult
+	 * @return void
+	 * @dataProvider toArrayTestDataProvider
+	 */
+	public function testToArrayReturnsValidData(string $testDescription, array $testData, array $expectedResult)
+	{
+		$testDescription = "Testing for $testDescription";
+		$sut = new QSO($testData);
+		$result = $sut->toArray();
+		foreach ($expectedResult as $expectedKey => $expectedValue) {
+			$this->assertArrayHasKey($expectedKey, $result, $testDescription);
+			$this->assertEquals($expectedValue, $result[$expectedKey], $testDescription);
+		}
+	}
+
+	private function getTestData(): array
+	{
+		return [
+			'COL_PRIMARY_KEY' => 'COL_PRIMARY_KEY',
+			'COL_ADDRESS' => 'COL_ADDRESS',
+			'COL_BAND' => 'COL_BAND',
+			'COL_BAND_RX' => 'COL_BAND_RX',
+			'COL_CALL' => 'COL_CALL',
+			'COL_EMAIL' => 'COL_EMAIL',
+			'COL_GRIDSQUARE' => 'COL_GRIDSQUARE',
+			'COL_IOTA' => 'COL_IOTA',
+			'COL_MODE' => 'COL_MODE',
+			'COL_MY_GRIDSQUARE' => 'COL_MY_GRIDSQUARE',
+			'COL_MY_IOTA' => 'COL_MY_IOTA',
+			'COL_MY_SIG' => 'COL_MY_SIG',
+			'COL_MY_SIG_INFO' => 'COL_MY_SIG_INFO',
+			'COL_NAME' => 'COL_NAME',
+			'COL_PROP_MODE' => 'COL_PROP_MODE',
+			'COL_QSLMSG' => 'COL_QSLMSG',
+			'COL_QSLRDATE' => '2022-01-02 03:04:06',
+			'COL_QSLSDATE' => '2022-01-02 03:04:07',
+			'COL_QSL_RCVD' => 'COL_QSL_RCVD',
+			'COL_QSL_RCVD_VIA' => 'COL_QSL_RCVD_VIA',
+			'COL_QSL_SENT' => 'COL_QSL_SENT',
+			'COL_QSL_SENT_VIA' => 'COL_QSL_SENT_VIA',
+			'COL_QSL_VIA' => 'COL_QSL_VIA',
+			'COL_RST_RCVD' => 'COL_RST_RCVD',
+			'COL_RST_SENT' => 'COL_RST_SENT',
+			'COL_SAT_MODE' => 'COL_SAT_MODE',
+			'COL_SAT_NAME' => 'COL_SAT_NAME',
+			'COL_SIG' => 'COL_SIG',
+			'COL_SIG_INFO' => 'COL_SIG_INFO',
+			'COL_STATION_CALLSIGN' => 'COL_STATION_CALLSIGN',
+			'COL_TIME_ON' => '2022-01-02 03:04:05',
+			'COL_DARC_DOK' => 'COL_DARC_DOK',
+			'COL_MY_IOTA_ISLAND_ID' => 'COL_MY_IOTA_ISLAND_ID',
+			'COL_MY_SOTA_REF' => 'COL_MY_SOTA_REF',
+			'COL_MY_VUCC_GRIDS' => 'COL_MY_VUCC_GRIDS',
+			'COL_SOTA_REF' => 'COL_SOTA_REF',
+			'COL_SUBMODE' => 'COL_SUBMODE',
+			'COL_VUCC_GRIDS' => 'COL_VUCC_GRIDS',
+		];
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function toArrayTestDataProvider() : array
+	{
+		return [
+			[
+				'minimal qso',
+				$this->getBaseTestQSO(),
+				[
+					'qsoID' => '1',
+					'qsoDateTime' => '2022-01-02 03:04',
+					'de' => 'AA0AAA',
+					'dx' => 'AA0AAB',
+					'mode' => 'SSB',
+					'rstS' => '59',
+					'rstR' => '95',
+					'band' => '20m',
+				]
+			],
+			[
+				'QSO with submode',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_SUBMODE' => 'USB'
+					]
+				),
+				[
+					'mode' => 'USB'
+				]
+			],
+			[
+				'QSO with band rx and tx',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_BAND_RX' => '10m'
+					]
+				),
+				[
+					'band' => '20m/10m'
+				]
+			],
+			[
+				'QSO with propagatiom mode',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_PROP_MODE' => 'SAT'
+					]
+				),
+				[
+					'band' => 'SAT 20m'
+				]
+			],
+			[
+				'QSO with propagatiom mode and sat name',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_PROP_MODE' => 'SAT',
+						'COL_SAT_NAME' => 'QO-100'
+					]
+				),
+				[
+					'band' => 'SAT QO-100 20m'
+				]
+			],
+			[
+				'QSO with propagatiom mode and sat name and satmode',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_PROP_MODE' => 'SAT',
+						'COL_SAT_NAME' => 'QO-100',
+						'COL_SAT_MODE' => 'S/X',
+					]
+				),
+				[
+					'band' => 'SAT QO-100 S/X 20m'
+				]
+			],
+			[
+				'QSO with my gridsquare',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_MY_GRIDSQUARE' => 'AA00',
+					]
+				),
+				[
+					'deRefs' => 'AA00'
+				]
+			],
+			[
+				'QSO with my vucc_gridsquares',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_MY_VUCC_GRIDS' => 'AA00,BB00',
+					]
+				),
+				[
+					'deRefs' => 'AA00,BB00'
+				]
+			],
+			[
+				'QSO with my IOTA',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_MY_IOTA' => 'EU-123',
+					]
+				),
+				[
+					'deRefs' => 'IOTA:EU-123'
+				]
+			],
+			[
+				'QSO with my IOTA and Island Reference',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_MY_IOTA' => 'EU-123',
+						'COL_MY_IOTA_ISLAND_ID' => '321'
+					]
+				),
+				[
+					'deRefs' => 'IOTA:EU-123(321)'
+				]
+			],
+			[
+				'QSO with my SOTA',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_MY_SOTA_REF' => 'AA/BB-000',
+					]
+				),
+				[
+					'deRefs' => 'SOTA:AA/BB-000'
+				]
+			],
+			[
+				'QSO with my SIG',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_MY_SIG' => 'ABC',
+						'COL_MY_SIG_INFO' => '987',
+					]
+				),
+				[
+					'deRefs' => 'ABC:987'
+				]
+			],
+			[
+				'QSO with gridsquare',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_GRIDSQUARE' => 'AA00',
+					]
+				),
+				[
+					'dxRefs' => 'AA00'
+				]
+			],
+			[
+				'QSO with vucc_gridsquares',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_VUCC_GRIDS' => 'AA00,BB00',
+					]
+				),
+				[
+					'dxRefs' => 'AA00,BB00'
+				]
+			],
+			[
+				'QSO with IOTA',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_IOTA' => 'EU-123',
+					]
+				),
+				[
+					'dxRefs' => 'IOTA:EU-123'
+				]
+			],
+			[
+				'QSO with SOTA',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_SOTA_REF' => 'AA/BB-000',
+					]
+				),
+				[
+					'dxRefs' => 'SOTA:AA/BB-000'
+				]
+			],
+			[
+				'QSO with SIG',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_SIG' => 'ABC',
+						'COL_SIG_INFO' => '987',
+					]
+				),
+				[
+					'dxRefs' => 'ABC:987'
+				]
+			],
+			[
+				'QSO with DOK',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_DARC_DOK' => '123',
+					]
+				),
+				[
+					'dxRefs' => 'DOK:123'
+				]
+			],
+			[
+				'QSO with QSL Sent',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_SENT' => 'Y',
+					]
+				),
+				[
+					'qslSent' => 'Yes'
+				]
+			],
+			[
+				'QSO with QSL Sent with Date',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_SENT' => 'Y',
+						'COL_QSLSDATE' => '2022-01-02 03:04:05',
+					]
+				),
+				[
+					'qslSent' => '2022-01-02'
+				]
+			],
+			[
+				'QSO with QSL Sent with Date and method Bureau',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_SENT' => 'Y',
+						'COL_QSLSDATE' => '2022-01-02 03:04:05',
+						'COL_QSL_SENT_VIA' => 'B'
+					]
+				),
+				[
+					'qslSent' => '2022-01-02 Bureau'
+				]
+			],
+			[
+				'QSO with QSL Sent with Date and method Direct',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_SENT' => 'Y',
+						'COL_QSLSDATE' => '2022-01-02 03:04:05',
+						'COL_QSL_SENT_VIA' => 'D'
+					]
+				),
+				[
+					'qslSent' => '2022-01-02 Direct'
+				]
+			],
+			[
+				'QSO with QSL Sent with Date and method Electronic',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_SENT' => 'Y',
+						'COL_QSLSDATE' => '2022-01-02 03:04:05',
+						'COL_QSL_SENT_VIA' => 'E'
+					]
+				),
+				[
+					'qslSent' => '2022-01-02 Electronic'
+				]
+			],
+			[
+				'QSO with QSL Sent with Date and method Manager',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_SENT' => 'Y',
+						'COL_QSLSDATE' => '2022-01-02 03:04:05',
+						'COL_QSL_SENT_VIA' => 'M'
+					]
+				),
+				[
+					'qslSent' => '2022-01-02 Manager'
+				]
+			],
+			[
+				'QSO with QSL Not Sent',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_SENT' => 'N'
+					]
+				),
+				[
+					'qslSent' => 'No'
+				]
+			],
+			[
+				'QSO with QSL Sent Queued',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_SENT' => 'Q'
+					]
+				),
+				[
+					'qslSent' => 'Queued'
+				]
+			],
+			[
+				'QSO with QSL Sent Queued with Date',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_SENT' => 'Q',
+						'COL_QSLSDATE' => '2022-01-02 03:04:05',
+					]
+				),
+				[
+					'qslSent' => 'Queued 2022-01-02'
+				]
+			],
+			[
+				'QSO with QSL Sent Requested',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_SENT' => 'R'
+					]
+				),
+				[
+					'qslSent' => 'Requested'
+				]
+			],
+			[
+				'QSO with QSL Sent Requested with Date',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_SENT' => 'R',
+						'COL_QSLSDATE' => '2022-01-02 03:04:05',
+					]
+				),
+				[
+					'qslSent' => 'Requested 2022-01-02'
+				]
+			],
+			[
+				'QSO with QSL Received',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_RCVD' => 'Y',
+					]
+				),
+				[
+					'qslReceived' => 'Yes'
+				]
+			],
+			[
+				'QSO with QSL Received with Date',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_RCVD' => 'Y',
+						'COL_QSLRDATE' => '2022-01-02 03:04:05',
+					]
+				),
+				[
+					'qslReceived' => '2022-01-02'
+				]
+			],
+			[
+				'QSO with QSL Received with Date and method Bureau',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_RCVD' => 'Y',
+						'COL_QSLRDATE' => '2022-01-02 03:04:05',
+						'COL_QSL_RCVD_VIA' => 'B'
+					]
+				),
+				[
+					'qslReceived' => '2022-01-02 Bureau'
+				]
+			],
+			[
+				'QSO with QSL Received with Date and method Direct',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_RCVD' => 'Y',
+						'COL_QSLRDATE' => '2022-01-02 03:04:05',
+						'COL_QSL_RCVD_VIA' => 'D'
+					]
+				),
+				[
+					'qslReceived' => '2022-01-02 Direct'
+				]
+			],
+			[
+				'QSO with QSL Received with Date and method Electronic',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_RCVD' => 'Y',
+						'COL_QSLRDATE' => '2022-01-02 03:04:05',
+						'COL_QSL_RCVD_VIA' => 'E'
+					]
+				),
+				[
+					'qslReceived' => '2022-01-02 Electronic'
+				]
+			],
+			[
+				'QSO with QSL Received with Date and method Manager',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_RCVD' => 'Y',
+						'COL_QSLRDATE' => '2022-01-02 03:04:05',
+						'COL_QSL_RCVD_VIA' => 'M'
+					]
+				),
+				[
+					'qslReceived' => '2022-01-02 Manager'
+				]
+			],
+			[
+				'QSO with QSL Not Received',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_RCVD' => 'N'
+					]
+				),
+				[
+					'qslReceived' => 'No'
+				]
+			],
+			[
+				'QSO with QSL Received Queued',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_RCVD' => 'Q'
+					]
+				),
+				[
+					'qslReceived' => 'Queued'
+				]
+			],
+			[
+				'QSO with QSL Received Queued with Date',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_RCVD' => 'Q',
+						'COL_QSLRDATE' => '2022-01-02 03:04:05',
+					]
+				),
+				[
+					'qslReceived' => 'Queued 2022-01-02'
+				]
+			],
+			[
+				'QSO with QSL Received Requested',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_RCVD' => 'R'
+					]
+				),
+				[
+					'qslReceived' => 'Requested'
+				]
+			],
+			[
+				'QSO with QSL Received Requested with Date',
+				array_merge(
+					$this->getBaseTestQSO(),
+					[
+						'COL_QSL_RCVD' => 'R',
+						'COL_QSLRDATE' => '2022-01-02 03:04:05',
+					]
+				),
+				[
+					'qslReceived' => 'Requested 2022-01-02'
+				]
+			],
+		];
+	}
+
+	private function getBaseTestQSO(): array
+	{
+		return [
+			'COL_PRIMARY_KEY' => '1',
+			'COL_ADDRESS' => '',
+			'COL_BAND' => '20m',
+			'COL_BAND_RX' => '',
+			'COL_CALL' => 'AA0AAB',
+			'COL_EMAIL' => '',
+			'COL_GRIDSQUARE' => '',
+			'COL_IOTA' => '',
+			'COL_MODE' => 'SSB',
+			'COL_MY_GRIDSQUARE' => '',
+			'COL_MY_IOTA' => '',
+			'COL_MY_SIG' => '',
+			'COL_MY_SIG_INFO' => '',
+			'COL_NAME' => '',
+			'COL_PROP_MODE' => '',
+			'COL_QSLMSG' => '',
+			'COL_QSLRDATE' => null,
+			'COL_QSLSDATE' => null,
+			'COL_QSL_RCVD' => 'I',
+			'COL_QSL_RCVD_VIA' => '',
+			'COL_QSL_SENT' => 'I',
+			'COL_QSL_SENT_VIA' => '',
+			'COL_QSL_VIA' => '',
+			'COL_RST_RCVD' => '95',
+			'COL_RST_SENT' => '59',
+			'COL_SAT_MODE' => '',
+			'COL_SAT_NAME' => '',
+			'COL_SIG' => '',
+			'COL_SIG_INFO' => '',
+			'COL_STATION_CALLSIGN' => 'AA0AAA',
+			'COL_TIME_ON' => '2022-01-02 03:04:05',
+			'COL_DARC_DOK' => '',
+			'COL_MY_IOTA_ISLAND_ID' => '',
+			'COL_MY_SOTA_REF' => '',
+			'COL_MY_VUCC_GRIDS' => '',
+			'COL_SOTA_REF' => '',
+			'COL_SUBMODE' => '',
+			'COL_VUCC_GRIDS' => '',
+		];
+	}
+}

--- a/tests/QSLManager/SearchCriteriaTest.php
+++ b/tests/QSLManager/SearchCriteriaTest.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Cloudlog\QSLManager;
+
+use Cloudlog\QSLManager\SearchCriteria;
+use DateTime;
+use DateTimeZone;
+use PHPUnit\Framework\TestCase;
+
+class SearchCriteriaTest extends TestCase
+{
+	public function testSearchCriteria()
+	{
+		$testUserId = 1;
+		$testDateFrom = '2022-01-02';
+		$testDateFromObject = DateTime::createFromFormat('Y-m-d', $testDateFrom, new DateTimeZone('UTC'));
+		$testDateTo = '2022-01-03';
+		$testDateToObject = DateTime::createFromFormat('Y-m-d', $testDateTo, new DateTimeZone('UTC'));
+		$testDe = 'De';
+		$testDx = 'Dx';
+		$testMode = 'Mode';
+		$testBand = 'Band';
+		$testQSLSent = 'S';
+		$testQSLReceived = 'R';
+
+		$sut = new SearchCriteria(
+			$testUserId,
+			$testDateFrom,
+			$testDateTo,
+			$testDe,
+			$testDx,
+			$testMode,
+			$testBand,
+			$testQSLSent,
+			$testQSLReceived
+		);
+
+		$this->assertEquals($testUserId, $sut->getUserId());
+		$this->assertEquals($testDateFromObject, $sut->getDateFrom());
+		$this->assertEquals($testDateToObject, $sut->getDateTo());
+		$this->assertEquals($testDe, $sut->getDe());
+		$this->assertEquals($testDx, $sut->getDx());
+		$this->assertEquals($testMode, $sut->getMode());
+		$this->assertEquals($testBand, $sut->getBand());
+		$this->assertEquals($testQSLSent, $sut->getQSLSent());
+		$this->assertEquals($testQSLReceived, $sut->getQSLReceived());
+	}
+
+	public function testSearchCriteriaCorrectsWrongDateOrder()
+	{
+		$testUserId = 1;
+		$testDateFrom = '2022-01-03';
+		$testDateTo = '2022-01-02';
+		$testDe = 'De';
+		$testDx = 'Dx';
+		$testMode = 'Mode';
+		$testBand = 'Band';
+		$testQSLSent = 'S';
+		$testQSLReceived = 'R';
+
+		$sut = new SearchCriteria(
+			$testUserId,
+			$testDateFrom,
+			$testDateTo,
+			$testDe,
+			$testDx,
+			$testMode,
+			$testBand,
+			$testQSLSent,
+			$testQSLReceived
+		);
+
+		$this->assertEquals(
+			DateTime::createFromFormat(
+				'Y-m-d',
+				$testDateTo,
+				new DateTimeZone('UTC')
+			),
+			$sut->getDateFrom()
+		);
+
+		$this->assertEquals(
+			DateTime::createFromFormat(
+				'Y-m-d',
+				$testDateFrom,
+				new DateTimeZone('UTC')
+			),
+			$sut->getDateTo()
+		);
+
+	}
+}


### PR DESCRIPTION
## Introduction
I have started work on a "QSL Manager" to help me process paper QSL for my activations (I do a lot of portable, mainly WWFF but also SOTA and HEMA, and some grids on SAT QT-100).
This is not yet a MVP but it shows my approach to code and I tought that it might be useful to show to the community to gather feedback.

## Look and Feel
The functionality is accessible trough the QSO menu, and consists of a large full width table with QSOs from **all the stations** belonging to current user, a search form with filters, and a set of buttons for bulk actions.

**Only the first button**, "Update from Callbook", that should go the callbook and query information about the Dx station's preferences and updates the QSO is partially working (it only reads from the callbook and updates the view, not the QSO on database)

![ss_qsl_manager](https://user-images.githubusercontent.com/8115510/184214814-fd125bae-091b-4dcb-afdb-ad15d414ceb4.png)

The basic mode of operation is:
- you search for QSOs that are part of a "group" you wish to manage for QSL (out)
- you get information from the callbook about the Dx station QSL preference
- you copy your reference data to the QSL MSG field (for the automated QSL bureaus)
- you (bulk, or single) update the QSOs with the method (Bureau, Direct, etc.) and status
- you export the QSOs as ADIF for uploading (or label generation, or...)
- you are now closer to having all your pending QSLs processed

## Code
Code structure departs a bit on the common CodeIgniter project. There is a controler `Qslmanager` that does what's expected, and some code was added to the existing models so as not break too much, but the two main classes for this domain, `QSO` and `SearchCriteria` exist inside a `QSLManager` namespace that is in a `src/` directory working according to the PSR-4 standard.
An helper was created to do the class autoloading (with an extremely simple approach) that is loaded on the controller's constructor.

Finally, a `composer.json` file was added to the project just to support the Unit Tests that were written, and it's not needed for running the code. The same is true for `tests/` directory.

Some other small changes were made to accommodate the loading of the proper javascript libraries (and some other minor details) at the right places, on the header and the footer.

## Future Plans
- Finish the half-working button, and the remaining functionality
- More testing, I'm not 100% sure the front end works across other (than Firefox Linux) browsers
- Try to refactor database code to make it more decoupled (if it's exclusive of this domain should it be on separate repository?)

## Expectation
This isn't useful yet, so I don't expect it to be merged right away, but since I've taken the liberty of not coupling *too much* with CodeIgniter I would like to get some feedback. 
