### PR TITLE
Link Mountain QRP Club references from SIG_INFO

### DIFF
--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -223,6 +223,9 @@
                         case "GMA":
                            echo "<td><a href=\"https://www.cqgma.org/zinfo.php?ref=".$row->COL_SIG_INFO."\" target=\"_blank\">".$row->COL_SIG_INFO."</a></td>";
                            break;
+                        case "MQC":
+                           echo "<td><a href=\"https://www.mountainqrp.it/awards/referenza.php?ref=".$row->COL_SIG_INFO."\" target=\"_blank\">".$row->COL_SIG_INFO."</a></td>";
+                           break;
                         case "WWFF":
                            echo "<td><a href=\"https://wwff.co/directory/?showRef=".$row->COL_SIG_INFO."\" target=\"_blank\">".$row->COL_SIG_INFO."</a></td>";
                            break;


### PR DESCRIPTION
When `SIG` id `MQC` link the `SIG_INFO` value to the proper reference page from Mountain QRP Club's website.

<img width="914" alt="Screen Shot 2022-08-16 at 13 54 30" src="https://user-images.githubusercontent.com/78752/184873619-47733698-6953-4b60-9d9a-10efd3d68e0b.png">


[Mountain QRP Club (MQC)](https://www.mountainqrp.it) is an Italian club for hamradio outdoor activities. It counts about 500 members. The club manage several awards and also provide a localized community for SOTA and POTA.

73 de IU5BON