### PR TITLE
Add station copy to easily duplicate station locations

### DIFF
--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -31,7 +31,7 @@ class Station extends CI_Controller {
 		$this->load->view('interface_assets/footer');
 	}
 
-	public function create() 
+	public function create()
 	{
 		$this->load->model('stations');
 		$this->load->model('dxcc');
@@ -52,49 +52,76 @@ class Station extends CI_Controller {
 			$this->load->view('interface_assets/footer');
 		}
 		else
-		{	
+		{
 			$this->stations->add();
-			
+
 			redirect('station');
 		}
 	}
 
 	public function edit($id)
 	{
+		$data = $this->load_station_for_editing($id);
+		$data['page_title'] = "Edit Station Location: {$data['my_station_profile']->station_profile_name}";
+
+		if ($this->form_validation->run() == FALSE) {
+			$this->load->view('interface_assets/header', $data);
+			$this->load->view('station_profile/edit');
+			$this->load->view('interface_assets/footer');
+		} else {
+			$this->stations->edit();
+
+			$data['notice'] = "Station Profile " . $this->security->xss_clean($this->input->post('station_profile_name', true)) . " Updated";
+
+			redirect('station');
+		}
+	}
+
+	public function copy($id)
+	{
+		$data = $this->load_station_for_editing($id);
+		$data['page_title'] = "Duplicate Station Location: {$data['my_station_profile']->station_profile_name}";
+
+		// we NULLify station_id and station_profile_name to make sure we are creating a new station
+		$data['copy_from'] = $data['my_station_profile']->station_id;
+		$data['my_station_profile']->station_id = NULL;
+		$data['my_station_profile']->station_profile_name = '';
+
+		if ($this->form_validation->run() == FALSE)
+		{
+			$this->load->view('interface_assets/header', $data);
+			$this->load->view('station_profile/edit');
+			$this->load->view('interface_assets/footer');
+		}
+		else
+		{
+			$this->stations->add();
+
+			redirect('station');
+		}
+	}
+
+	function load_station_for_editing($id): array
+	{
 		$this->load->library('form_validation');
 
 		$this->load->model('stations');
 		$this->load->model('dxcc');
-        $this->load->model('logbook_model');
+		$this->load->model('logbook_model');
 
-        $data['iota_list'] = $this->logbook_model->fetchIota();
+		$data['iota_list'] = $this->logbook_model->fetchIota();
 
 		$item_id_clean = $this->security->xss_clean($id);
 
 		$station_profile_query = $this->stations->profile($item_id_clean);
 
 		$data['my_station_profile'] = $station_profile_query->row();
-		
-		$data['dxcc_list'] = $this->dxcc->list();
 
-		$data['page_title'] = "Edit Station Location";
+		$data['dxcc_list'] = $this->dxcc->list();
 
 		$this->form_validation->set_rules('station_profile_name', 'Station Profile Name', 'required');
 
-        if ($this->form_validation->run() == FALSE)
-        {
-        	$this->load->view('interface_assets/header', $data);
-            $this->load->view('station_profile/edit');
-            $this->load->view('interface_assets/footer');
-        }
-        else
-        {
-            $this->stations->edit();
-
-            $data['notice'] = "Station Profile ".$this->security->xss_clean($this->input->post('station_profile_name', true))." Updated";
-
-            redirect('station');
-        }
+		return $data;
 	}
 
 	// This function allows a user to claim ownership of a station location
@@ -104,7 +131,7 @@ class Station extends CI_Controller {
 		$this->stations->claim_user($id);
 
 		echo $this->session->userdata('user_id');
-		
+
 		redirect('station');
 	}
 
@@ -112,7 +139,7 @@ class Station extends CI_Controller {
 		// $id is the profile that needs reassigned to QSOs
 		$this->load->model('stations');
 		$this->stations->reassign($id);
-		
+
 		//$this->stations->logbook_session_data();
 		redirect('station');
 	}
@@ -120,7 +147,7 @@ class Station extends CI_Controller {
 	function set_active($current, $new) {
 		$this->load->model('stations');
 		$this->stations->set_active($current, $new);
-		
+
 		//$this->stations->logbook_session_data();
 		redirect('station');
 	}
@@ -128,14 +155,14 @@ class Station extends CI_Controller {
 	function assign_all() {
 		$this->load->model('Logbook_model');
 		$this->Logbook_model->update_all_station_ids();
-		
+
 		redirect('station');
 	}
 
 	public function delete($id) {
 		$this->load->model('stations');
 		$this->stations->delete($id);
-		
+
 		redirect('station');
 	}
 

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -18,16 +18,24 @@
 
 	<?php echo validation_errors(); ?>
 
-	<form method="post" action="<?php echo site_url('station/edit/'); ?><?php echo $my_station_profile->station_id; ?>" name="create_profile">
+	<?php if($my_station_profile->station_id != NULL) {
+		$form_action = "Update";
+	?>
+		<form method="post" action="<?php echo site_url('station/edit/'); ?><?php echo $my_station_profile->station_id; ?>" name="create_profile">
+			<input type="hidden" name="station_id" value="<?php echo $my_station_profile->station_id; ?>">
 
-	<input type="hidden" name="station_id" value="<?php echo $my_station_profile->station_id; ?>">
+	<?php } else {
+		$form_action = "Create";
+	?>
+		<form method="post" action="<?php echo site_url('station/copy/'); ?><?php echo $copy_from; ?>" name="create_profile">
+	<?php } ?>
 
 	<div class="row">
 		<div class="col-md">
 			<div class="card">
-				<div class="card-header"><?php echo $page_title; ?>: <?php echo $my_station_profile->station_profile_name; ?> (Callsign: <?php echo $my_station_profile->station_callsign; ?>)</div>
+				<div class="card-header"><?php echo $page_title; ?> (Callsign: <?php echo $my_station_profile->station_callsign; ?>)</div>
 				<div class="card-body">
-				
+
 					<div class="form-group">
 						<label for="stationNameInput">Station Name</label>
 						<input type="text" class="form-control" name="station_profile_name" id="stationNameInput" aria-describedby="stationNameInputHelp" value="<?php if(set_value('station_profile_name') != "") { echo set_value('station_profile_name'); } else { echo $my_station_profile->station_profile_name; } ?>" required>
@@ -241,7 +249,7 @@
                     			}
                     		?>
                 		</select>
-                		
+
 						<small id="stationIOTAInputHelp" class="form-text text-muted">Station IOTA reference. For example: EU-005</small>
                 		<small id="stationIOTAInputHelp" class="form-text text-muted">You can look up IOTA references at the <a target="_blank" href="https://www.iota-world.org/iota-directory/annex-f-short-title-iota-reference-number-list.html">IOTA World</a> website.</small>
             		</div>
@@ -320,7 +328,7 @@
 		</div>
 	</div>
 
-	<button type="submit" class="btn btn-primary"><i class="fas fa-plus-square"></i> Update Station Location</button>
+	<button type="submit" class="btn btn-primary"><i class="fas fa-plus-square"></i> <?php echo $form_action; ?> Station Location</button>
 
 	</form>
 

--- a/application/views/station_profile/index.php
+++ b/application/views/station_profile/index.php
@@ -79,6 +79,7 @@
 							<a href="<?php echo site_url('station/claim_user')."/".$row->station_id; ?>" class="btn btn-outline-primary btn-sm"><i class="fas fa-user-plus"></i> Claim Ownership</a>
 						<?php } ?>
 						<a href="<?php echo site_url('station/edit')."/".$row->station_id; ?>" class="btn btn-outline-primary btn-sm"><i class="fas fa-edit"></i> Edit</a>
+						<a href="<?php echo site_url('station/copy')."/".$row->station_id; ?>" class="btn btn-outline-primary btn-sm"><i class="fas fa-copy"></i> Copy</a>
 					</td>
                     <td>
                         <a href="<?php echo site_url('station/deletelog')."/".$row->station_id; ?>" class="btn btn-danger btn-sm" onclick="return confirm('Are you sure you want to delete all QSOs within this station profile?');"><i class="fas fa-trash-alt"></i> Empty Log</a></td>


### PR DESCRIPTION
When doing portable activations, often times you need a new station location that is identical to another one with just a few changes like the grid square, SIG, and/or SOTA.

This PR implements a copy function for station locations.