### PR TITLE
Make specification of city name optional

### DIFF
--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -56,7 +56,7 @@
 
 		  <div class="form-group">
 		    <label for="stationCityInput">Station City</label>
-		    <input type="text" class="form-control" name="city" id="stationCityInput" aria-describedby="stationCityInputHelp" required>
+		    <input type="text" class="form-control" name="city" id="stationCityInput" aria-describedby="stationCityInputHelp">
 		    <small id="stationCityInputHelp" class="form-text text-muted">Station city. For example: Inverness</small>
 		  </div>
 

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -68,7 +68,7 @@
 					<!-- City -->
 					<div class="form-group">
 						<label for="stationCityInput">Station City</label>
-						<input type="text" class="form-control" name="city" id="stationCityInput" aria-describedby="stationCityInputHelp" value="<?php if(set_value('city') != "") { echo set_value('city'); } else { echo $my_station_profile->station_city; } ?>" required>
+						<input type="text" class="form-control" name="city" id="stationCityInput" aria-describedby="stationCityInputHelp" value="<?php if(set_value('city') != "") { echo set_value('city'); } else { echo $my_station_profile->station_city; } ?>">
 		    			<small id="stationCityInputHelp" class="form-text text-muted">Station city. For example: Inverness</small>
 		  			</div>
 


### PR DESCRIPTION
This addresses https://github.com/magicbug/Cloudlog/issues/1539 and removes the need to specify a city name upon creation or editing a station location. 