### PR TITLE
Fix eQSL upload for linked account

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -149,7 +149,7 @@ class eqsl extends CI_Controller {
 			$active_station_id = $this->stations->find_active();
         	$station_profile = $this->stations->profile($active_station_id);
 			$active_station_info = $station_profile->row();
-			// Query the logbook to determine when the last LoTW confirmation was
+			// Query the logbook to determine when the last eQSL confirmation was
 			$eqsl_last_qsl_date = $this->logbook_model->eqsl_last_qsl_rcvd_date();
 
 			// Build parameters for eQSL inbox file
@@ -307,6 +307,11 @@ class eqsl extends CI_Controller {
 			// Build out the ADIF info string according to specs http://eqsl.cc/qslcard/ADIFContentSpecs.cfm
 			foreach ($qslsnotsent->result_array() as $qsl)
 			{
+				// eQSL username changes for linked account.
+				// i.e. when operating /P it must be callsign/p
+				// the password, however, is always the same as the main account
+				$data['user_eqsl_name'] = $qsl['station_callsign'];
+
 				$COL_QSO_DATE = date('Ymd',strtotime($qsl['COL_TIME_ON']));
 				$COL_TIME_ON = date('Hi',strtotime($qsl['COL_TIME_ON']));
 				

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2152,7 +2152,7 @@ class Logbook_model extends CI_Model {
     function eqsl_not_yet_sent() {
       $this->db->select('station_profile.*, '.$this->config->item('table_name').'.COL_PRIMARY_KEY, '.$this->config->item('table_name').'.COL_TIME_ON, '.$this->config->item('table_name').'.COL_CALL, '.$this->config->item('table_name').'.COL_MODE, '.$this->config->item('table_name').'.COL_SUBMODE, '.$this->config->item('table_name').'.COL_BAND, '.$this->config->item('table_name').'.COL_COMMENT, '.$this->config->item('table_name').'.COL_RST_SENT, '.$this->config->item('table_name').'.COL_PROP_MODE, '.$this->config->item('table_name').'.COL_SAT_NAME, '.$this->config->item('table_name').'.COL_SAT_MODE, '.$this->config->item('table_name').'.COL_QSLMSG');
       $this->db->from('station_profile');
-      $this->db->join($this->config->item('table_name'),'station_profile.station_id = '.$this->config->item('table_name').'.station_id AND station_profile.eqslqthnickname != ""','left');
+      $this->db->join($this->config->item('table_name'),'station_profile.station_id = '.$this->config->item('table_name').'.station_id AND station_profile.eqslqthnickname != ""','right');
       $this->db->where($this->config->item('table_name').'.COL_CALL !=', '');
       $this->db->where($this->config->item('table_name').'.COL_EQSL_QSL_SENT !=', 'Y');
       $this->db->where($this->config->item('table_name').'.COL_EQSL_QSL_SENT !=', 'I');


### PR DESCRIPTION
When uploading QSOs for a linked account the username must match the
station callsign. i.e. when operating portable it should be callsign/p.

While working on this I realized that if a station location has a QTH nickname but no QSO assigned, it will show up as an empty line in the log to be updated.

![Screen Shot 2022-08-24 at 17 33 59](https://user-images.githubusercontent.com/78752/186463482-976cb59b-2973-4a2d-af39-03579a0946a9.png)
Here I have 2 locations with the same QTH nickname but no QSO.

Changing the join type from `left` to `right` fixed that issue.

