### PR TITLE
eQSL import from multiple QTH nicknames

### DIFF
--- a/application/libraries/Adif_parser.php
+++ b/application/libraries/Adif_parser.php
@@ -111,6 +111,7 @@ class ADIF_Parser
 		};
 
         $this->datasplit = preg_split("/<eor>/i", mb_substr($this->data, $this->i, NULL, "UTF-8"));
+		$this->currentarray = 0;
 		return 1;
 	}
 	

--- a/application/libraries/EqslImporter.php
+++ b/application/libraries/EqslImporter.php
@@ -1,0 +1,197 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed');
+
+// EqslImporter handle eQSL inboxes for multiple QTH locations.
+// It can fetch confirmations from eqsl.cc or analyze a user-provided ADIF file
+class EqslImporter
+{
+	private $name;
+	private $callsign;
+	private $qth_nickname;
+	private $adif_file;
+
+	// CodeIgniter super-ojbect
+	private $CI;
+
+	public function __construct() {
+		// Assign the CodeIgniter super-object
+		$this->CI =& get_instance();
+
+		$this->CI->load->model('logbook_model');
+		$this->CI->load->library('adif_parser');
+	}
+
+	private function init($name, $adif_file) {
+		$this->name = $name;
+		$this->adif_file = $adif_file;
+	}
+
+	public function from_callsign_and_QTH($callsign, $qth, $upload_path) {
+		$this->init(
+			$qth . " - " . $callsign,
+			self::safe_filepath($callsign, $qth, $upload_path)
+		);
+
+		$this->callsign = $callsign;
+		$this->qth_nickname = $qth;
+	}
+
+	public function from_file($adif_file) {
+		$this->init('ADIF upload', $adif_file);
+	}
+
+	// generate a sanitized file name from a callsign and a QTH nickname
+	private static function safe_filepath($callsign, $qth, $upload_path) {
+		$eqsl_id = $callsign . '-' . $qth;
+
+		// Replace anything which isn't a word, whitespace, number or any of the following caracters -_~,;[](). with a '.'
+		$eqsl_id = mb_ereg_replace("([^\w\s\d\-_~,;\[\]\(\).])", '.', $eqsl_id);
+		$eqsl_id = mb_ereg_replace("([\.]{2,})", '', $eqsl_id);
+
+		return $upload_path . $eqsl_id . '-eqslreport_download.adi';
+	}
+
+	// Download confirmed QSO from eQSL inbox and import them
+	public function fetch($password) {
+		if (empty($password) || empty($this->callsign)) {
+			$this->status = "Missing username and/or password";
+
+			return;
+		}
+
+		// Get URL for downloading the eqsl.cc inbox
+		$query = $this->CI->db->query('SELECT eqsl_download_url FROM config');
+		$q = $query->row();
+		$eqsl_url = $q->eqsl_download_url;
+
+		// Query the logbook to determine when the last eQSL confirmation was
+		$eqsl_last_qsl_date = $this->CI->logbook_model->eqsl_last_qsl_rcvd_date($this->callsign, $this->qth_nickname);
+
+		// Build parameters for eQSL inbox file
+		$eqsl_params = http_build_query(array(
+			'UserName' => $this->callsign,
+			'Password' => $password,
+			'RcvdSince' => $eqsl_last_qsl_date,
+			'QTHNickname' => $this->qth_nickname,
+			'ConfirmedOnly' => 1
+		));
+
+		// At this point, what we get isn't the ADI file we need, but rather
+		// an HTML page, which contains a link to the generated ADI file that we want.
+		// Adapted from Original PHP code by Chirp Internet: www.chirp.com.au (regex)
+
+		// Let's use cURL instead of file_get_contents
+		// begin script
+		$ch = curl_init();
+
+		// basic curl options for all requests
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($ch, CURLOPT_HEADER, 1);
+
+		// use the URL and params we built
+		curl_setopt($ch, CURLOPT_URL, $eqsl_url);
+		curl_setopt($ch, CURLOPT_POST, 1);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $eqsl_params);
+
+		$input = curl_exec($ch);
+		$chi = curl_getinfo($ch);
+
+		// "You have no log entries" -> Nothing else to do here
+		// "Your ADIF log file has been built" -> We've got an ADIF file we need to grab.
+
+		if ($chi['http_code'] == "200") {
+			if (stristr($input, "You have no log entries")) {
+				return $this->result('There are no QSLs waiting for download at eQSL.cc.'); // success
+			} else if (stristr($input, "Error: No such Username/Password found")) {
+				return $this->result('No such Username/Password found This could mean the wrong callsign or the wrong password, or the user does not exist.'); // warning
+			} else {
+				if (stristr($input, "Your ADIF log file has been built")) {
+					// Get all the links on the page and grab the URL for the ADI file.
+					$regexp = "<a\s[^>]*href=(\"??)([^\" >]*?)\\1[^>]*>(.*)<\/a>";
+					if (preg_match_all("/$regexp/siU", $input, $matches)) {
+						foreach ($matches[2] as $match) {
+							// Look for the link that has the .adi file, and download it to $file
+							if (substr($match, -4, 4) == ".adi") {
+								file_put_contents($this->adif_file, file_get_contents("http://eqsl.cc/qslcard/" . $match));
+								return $this->import();
+							}
+						}
+					}
+				}
+			}
+		} else {
+			if ($chi['http_code'] == "500") {
+				return $this->result('eQSL.cc is experiencing issues. Please try importing QSOs later.'); // warning
+			} else {
+				if ($chi['http_code'] == "404") {
+					return $this->result('It seems that the eQSL site has changed. Please open up an issue on GitHub.');
+				}
+			}
+		}
+
+		// Close cURL handle
+		curl_close($ch);
+	}
+
+	// Read the ADIF file and set QSO confirmation status according to the settings
+	public function import(): array {
+		// Figure out how we should be marking QSLs confirmed via eQSL
+		$query = $this->CI->db->query('SELECT eqsl_rcvd_mark FROM config');
+		$q = $query->row();
+		$config['eqsl_rcvd_mark'] = $q->eqsl_rcvd_mark;
+
+		$this->CI->adif_parser->load_from_file($this->adif_file);
+		$this->CI->adif_parser->initialize();
+
+		$qsos = array();
+		$records = $updated = $not_found = $dupes = 0;
+		while ($record = $this->CI->adif_parser->get_record()) {
+			$records += 1;
+			$time_on = date('Y-m-d', strtotime($record['qso_date'])) . " " . date('H:i', strtotime($record['time_on']));
+
+			// The report from eQSL should only contain entries that have been confirmed via eQSL
+			// If there's a match for the QSO from the report in our log, it's confirmed via eQSL.
+
+			// If we have a positive match from eQSL, record it in the DB according to the user's preferences
+			if ($record['qsl_sent'] == "Y") {
+				$record['qsl_sent'] = $config['eqsl_rcvd_mark'];
+			}
+
+			$status = $this->CI->logbook_model->import_check($time_on, $record['call'], $record['band']);
+			if ($status == "Found") {
+				$dupe = $this->CI->logbook_model->eqsl_dupe_check($time_on, $record['call'], $record['band'], $config['eqsl_rcvd_mark']);
+				if ($dupe == false) {
+					$updated += 1;
+					$eqsl_status = $this->CI->logbook_model->eqsl_update($time_on, $record['call'], $record['band'], $config['eqsl_rcvd_mark']);
+				} else {
+					$dupes += 1;
+					$eqsl_status = "Already received an eQSL for this QSO.";
+				}
+			} else {
+				$not_found += 1;
+				$eqsl_status = "QSO not found";
+			}
+
+			$qsos[] = array(
+				'date' => $time_on,
+				'call' => str_replace("0", "&Oslash;", $record['call']),
+				'mode' => $record['mode'],
+				'submode' => $record['submode'] ?? null,
+				'status' => $status,
+				'eqsl_status' => $eqsl_status,
+			);
+		}
+
+		unlink($this->adif_file);
+
+		return $this->result("$records QSO: $updated updated / $dupes duplicates / $not_found not found", $qsos);
+	}
+
+	private function result($status, $qsos = array()): array {
+		return array(
+			'name' => $this->name,
+			'adif_file' => $this->adif_file,
+			'qsos' => $qsos,
+			'status' => $status,
+		);
+	}
+}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2109,13 +2109,21 @@ class Logbook_model extends CI_Model {
   }
 
   // Get the last date we received an eQSL
-  function eqsl_last_qsl_rcvd_date() {
+  function eqsl_last_qsl_rcvd_date($callsign, $nickname) {
+	  $qso_table_name = $this->config->item('table_name');
+	  $this->db->from($qso_table_name);
+
+	  $this->db->join('station_profile',
+		  'station_profile.station_id = '.$qso_table_name.'.station_id AND station_profile.eqslqthnickname != ""');
+	  $this->db->where('station_profile.station_callsign', $callsign);
+	  $this->db->where('station_profile.eqslqthnickname', $nickname);
+
       $this->db->select("DATE_FORMAT(COL_EQSL_QSLRDATE,'%Y%m%d') AS COL_EQSL_QSLRDATE", FALSE);
       $this->db->where('COL_EQSL_QSLRDATE IS NOT NULL');
       $this->db->order_by("COL_EQSL_QSLRDATE", "desc");
       $this->db->limit(1);
 
-      $query = $this->db->get($this->config->item('table_name'));
+      $query = $this->db->get();
       $row = $query->row();
 
       if (isset($row->COL_EQSL_QSLRDATE)){

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -322,6 +322,18 @@ class Stations extends CI_Model {
 		return $query->num_rows();
     }
 
+	// Returns all the distinct callsing, eqsl nick pair for the current user
+	function all_of_user_with_eqsl_nick_defined() {
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('eqslqthnickname IS NOT NULL');
+		$this->db->where('eqslqthnickname !=', '');
+		$this->db->from('station_profile');
+		$this->db->select('station_callsign, eqslqthnickname');
+		$this->db->distinct(TRUE);
+
+		return $this->db->get();
+	}
+
 	public function check_station_is_accessible($id) {
 		// check if station belongs to user
 		$this->db->select('station_id');

--- a/application/views/eqsl/analysis.php
+++ b/application/views/eqsl/analysis.php
@@ -16,22 +16,40 @@
     </ul>
   </div>
 
-  <div class="card-body">
-    <?php $this->load->view('layout/messages'); ?>
+	<div class="card-body">
+		<?php $this->load->view('layout/messages'); ?>
 
-<?php
-    if (isset($eqsl_results_table_headers))
-    {
-        echo "<p>The following QSLs have been received from eQSL.cc</p>";
-        echo $eqsl_results_table_headers;
-        echo $eqsl_results_table;
-    }
-    else
-    {
-        echo "<p>There are no QSO confirmations waiting for you at eQSL.cc</p>";
-    }
-?>
-</div>
+		<?php foreach ($eqsl_results as $import) { ?>
+			<h3><?php echo $import['name']; ?></h3>
+			<div class="alert alert-info" role="alert">
+				<?php echo $import['status']; ?>
+			</div>
+			<?php if (count($import['qsos']) > 0) { ?>
+				<table>
+					<tr class="titles">
+						<td>Date</td>
+						<td>Call</td>
+						<td>Mode</td>
+						<td>Submode</td>
+						<td>Log Status</td>
+						<td>eQSL Status</td>
+					</tr>
+					<?php foreach ($import['qsos'] as $qso) { ?>
+						<tr>
+							<td><?php echo $qso['date']; ?></td>
+							<td><?php echo $qso['call']; ?></td>
+							<td><?php echo $qso['mode']; ?></td>
+							<td><?php echo $qso['submode']; ?></td>
+							<td><?php echo $qso['status']; ?></td>
+							<td><?php echo $qso['eqsl_status']; ?></td>
+						</tr>
+					<?php } ?>
+				</table>
+			<?php } else { ?>
+				<p>There are no QSO confirmations waiting for you at eQSL.cc</p>
+			<?php } ?>
+		<?php } ?>
+	</div>
 </div>
 
 </div>


### PR DESCRIPTION
Each eQSL account can define multiple QTH, these are linked accounts.

On top of that, it is also possible to define multiple callsigns using a "/something" suffix. And any of those can still define multiple QTH.

The only common element is the password.

With this MR, when importing from eQSL, each station_callsing/QTH couple will be fetched and imported according to the last QSL received date for that given callsign/QTH.


<img width="1139" alt="Screen Shot 2022-08-24 at 18 09 50" src="https://user-images.githubusercontent.com/78752/186468780-cf193fe2-9408-42f8-bcdb-32543d4c64d8.png">
