### PR TITLE
[Install] add missing user_id to table cat

### DIFF
--- a/install/assets/install.sql
+++ b/install/assets/install.sql
@@ -32,6 +32,7 @@ CREATE TABLE `cat` (
                      `uplink_mode` varchar(255) DEFAULT NULL,
                      `sat_name` varchar(255) DEFAULT NULL,
                      `timestamp` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+                     `user_id` bigint(20) DEFAULT NULL,
                      PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 


### PR DESCRIPTION
Seems the user_id column in cat table is missing. Just checked by code, have not done a new installation. For migrations this is done by [`application/migrations/078_add_userid_to_hardware.php`](https://github.com/magicbug/Cloudlog/blob/station_logbooks/application/migrations/078_add_userid_to_hardware.php).