### PR TITLE
Also export QSOs with LotW QSL SENT date of NULL

### DIFF
--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -93,7 +93,7 @@ class adif_data extends CI_Model {
             $this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) <= '".$to."'");
         }
         if ($exportLotw) {
-            $this->db-group_start();
+            $this->db->group_start();
             $this->db->where($this->config->item('table_name').".COL_LOTW_QSL_SENT != 'Y'");
             $this->db->or_where($this->config->item('table_name').".COL_LOTW_QSL_SENT", NULL);
             $this->db->group_end();
@@ -114,7 +114,7 @@ class adif_data extends CI_Model {
         $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*');
         $this->db->from($this->config->item('table_name'));
         $this->db->where($this->config->item('table_name').'.station_id', $active_station_id);
-        $this->db-group_start();
+        $this->db->group_start();
         $this->db->where($this->config->item('table_name').".COL_LOTW_QSL_SENT != 'Y'");
         $this->db->or_where($this->config->item('table_name').".COL_LOTW_QSL_SENT", NULL);
         $this->db->group_end();

--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -93,7 +93,10 @@ class adif_data extends CI_Model {
             $this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) <= '".$to."'");
         }
         if ($exportLotw) {
+            $this->db-group_start();
             $this->db->where($this->config->item('table_name').".COL_LOTW_QSL_SENT != 'Y'");
+            $this->db->or_where($this->config->item('table_name').".COL_LOTW_QSL_SENT", NULL);
+            $this->db->group_end();
         }
 
         $this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");
@@ -111,7 +114,10 @@ class adif_data extends CI_Model {
         $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*');
         $this->db->from($this->config->item('table_name'));
         $this->db->where($this->config->item('table_name').'.station_id', $active_station_id);
+        $this->db-group_start();
         $this->db->where($this->config->item('table_name').".COL_LOTW_QSL_SENT != 'Y'");
+        $this->db->or_where($this->config->item('table_name').".COL_LOTW_QSL_SENT", NULL);
+        $this->db->group_end();
 
         $this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");
 


### PR DESCRIPTION
This fixes issue https://github.com/magicbug/Cloudlog/issues/1586 by also exporting QSOs with QSL SENT date being NULL (besides "N"). The rest of my idea concerning setting the SQL columns to be `NOT NULL DEFAULT 'N'` to be discussed seaparately.