### PR TITLE
User Selectable bands

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 97;
+$config['migration_version'] = 98;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -90,7 +90,7 @@ class Awards extends CI_Controller {
         $this->load->model('modes');
         $this->load->model('bands');
 
-        $data['worked_bands'] = $this->bands->get_worked_bands(); // Used in the view for band select
+        $data['worked_bands'] = $this->bands->get_worked_bands('dxcc'); // Used in the view for band select
         $data['modes'] = $this->modes->active(); // Used in the view for mode select
 
         if ($this->input->post('band') != NULL) {   // Band is not set when page first loads.
@@ -156,7 +156,7 @@ class Awards extends CI_Controller {
     public function vucc()	{
         $this->load->model('vucc');
         $this->load->model('bands');
-        $data['worked_bands'] = $this->bands->get_worked_bands();
+        $data['worked_bands'] = $this->bands->get_worked_bands('vucc');
 
         $data['vucc_array'] = $this->vucc->get_vucc_array($data);
 
@@ -249,7 +249,7 @@ class Awards extends CI_Controller {
 		$this->load->model('modes');
         $this->load->model('bands');
 
-        $data['worked_bands'] = $this->bands->get_worked_bands();
+        $data['worked_bands'] = $this->bands->get_worked_bands('cq');
 		$data['modes'] = $this->modes->active(); // Used in the view for mode select
 
         if ($this->input->post('band') != NULL) {   // Band is not set when page first loads.
@@ -307,7 +307,7 @@ class Awards extends CI_Controller {
 		$this->load->model('modes');
         $this->load->model('bands');
 
-        $data['worked_bands'] = $this->bands->get_worked_bands();
+        $data['worked_bands'] = $this->bands->get_worked_bands('was');
 		$data['modes'] = $this->modes->active(); // Used in the view for mode select
 
         if ($this->input->post('band') != NULL) {   // Band is not set when page first loads.
@@ -358,7 +358,7 @@ class Awards extends CI_Controller {
 		$this->load->model('modes');
         $this->load->model('bands');
 
-        $data['worked_bands'] = $this->bands->get_worked_bands(); // Used in the view for band select
+        $data['worked_bands'] = $this->bands->get_worked_bands('iota'); // Used in the view for band select
 
         if ($this->input->post('band') != NULL) {   // Band is not set when page first loads.
             if ($this->input->post('band') == 'All') {         // Did the user specify a band? If not, use all bands

--- a/application/controllers/Band.php
+++ b/application/controllers/Band.php
@@ -65,7 +65,11 @@ class Band extends CI_Controller {
 		$this->load->model('bands');
 
 		$id = $this->security->xss_clean($this->input->post('id', true));
-		$band = $this->security->xss_clean($this->input->post('band', true));
+		$band['band'] 		= $this->security->xss_clean($this->input->post('band', true));
+		$band['bandgroup'] 	= $this->security->xss_clean($this->input->post('bandgroup', true));
+		$band['ssbqrg'] 	= $this->security->xss_clean($this->input->post('ssbqrg', true));
+		$band['dataqrg'] 	= $this->security->xss_clean($this->input->post('dataqrg', true));
+		$band['cwqrg'] 		= $this->security->xss_clean($this->input->post('cwqrg', true));
 
         $this->bands->saveupdatedband($id, $band);
 		echo json_encode(array('message' => 'OK'));

--- a/application/controllers/Band.php
+++ b/application/controllers/Band.php
@@ -27,4 +27,117 @@ class Band extends CI_Controller {
 		$this->load->view('bands/index');
 		$this->load->view('interface_assets/footer');
 	}
+
+	public function create() 
+	{
+		$this->load->model('bands');
+		$this->load->library('form_validation');
+
+		$this->form_validation->set_rules('mode', 'Mode', 'required');
+		$this->form_validation->set_rules('qrgmode', 'QRG-Mode', 'required');
+
+		if ($this->form_validation->run() == FALSE)
+		{
+			$data['page_title'] = "Create Mode";
+			$this->load->view('mode/create', $data);
+		}
+		else
+		{	
+			$this->bands->add();
+		}
+	}
+
+	public function edit($id)
+	{
+		$this->load->library('form_validation');
+
+		$this->load->model('bands');
+
+		$item_id_clean = $this->security->xss_clean($id);
+
+		$mode_query = $this->bands->mode($item_id_clean);
+
+		$data['my_mode'] = $mode_query->row();
+		
+		$data['page_title'] = "Edit Mode";
+
+		$this->form_validation->set_rules('mode', 'Mode', 'required');
+		$this->form_validation->set_rules('qrgmode', 'QRG-Mode', 'required');
+		
+        if ($this->form_validation->run() == FALSE)
+        {
+        	$this->load->view('interface_assets/header', $data);
+            $this->load->view('mode/edit');
+            $this->load->view('interface_assets/footer');
+        }
+        else
+        {
+            $this->bands->edit();
+
+            $data['notice'] = "Mode ".$this->security->xss_clean($this->input->post('mode', true))." Updated";
+
+            redirect('mode');
+        }
+	}
+
+	public function delete() {
+	    $id = $this->input->post('id');
+		$this->load->model('bands');
+		$this->bands->delete($id);
+	}
+
+	public function activate() {
+        $id = $this->input->post('id');
+        $this->load->model('bands');
+        $this->bands->activate($id);
+        header('Content-Type: application/json');
+        echo json_encode(array('message' => 'OK'));
+        return;
+    }
+
+    public function deactivate() {
+	    $id = $this->input->post('id');
+        $this->load->model('bands');
+        $this->bands->deactivate($id);
+        header('Content-Type: application/json');
+        echo json_encode(array('message' => 'OK'));
+        return;
+    }
+
+	public function activateall() {
+        $this->load->model('bands');
+        $this->bands->activateall();
+        header('Content-Type: application/json');
+        echo json_encode(array('message' => 'OK'));
+        return;
+    }
+
+    public function deactivateall() {
+        $this->load->model('bands');
+        $this->bands->deactivateall();
+        header('Content-Type: application/json');
+        echo json_encode(array('message' => 'OK'));
+		return;
+    }
+
+	public function saveBand() {
+		$id 				= $this->security->xss_clean($this->input->post('id'));
+		$band['status'] 	= $this->security->xss_clean($this->input->post('status'));
+		$band['cq'] 		= $this->security->xss_clean($this->input->post('cq'));
+		$band['dok'] 		= $this->security->xss_clean($this->input->post('dok'));
+		$band['dxcc'] 		= $this->security->xss_clean($this->input->post('dxcc'));
+		$band['iota'] 		= $this->security->xss_clean($this->input->post('iota'));
+		$band['sig'] 		= $this->security->xss_clean($this->input->post('sig'));
+		$band['sota']		= $this->security->xss_clean($this->input->post('sota'));
+		$band['uscounties'] = $this->security->xss_clean($this->input->post('uscounties'));
+		$band['was'] 		= $this->security->xss_clean($this->input->post('was'));
+		$band['vucc'] 		= $this->security->xss_clean($this->input->post('vucc'));
+        
+		$this->load->model('bands');
+        $this->bands->saveBand($id, $band);
+        
+		header('Content-Type: application/json');
+        echo json_encode(array('message' => 'OK'));
+		return;
+    }
 }

--- a/application/controllers/Band.php
+++ b/application/controllers/Band.php
@@ -46,37 +46,30 @@ class Band extends CI_Controller {
 		}
 	}
 
-	public function edit($id)
+	public function edit()
 	{
-		$this->load->library('form_validation');
-
 		$this->load->model('bands');
 
-		$item_id_clean = $this->security->xss_clean($id);
+		$item_id_clean = $this->security->xss_clean($this->input->post('id'));
 
-		$mode_query = $this->bands->mode($item_id_clean);
+		$band_query = $this->bands->getband($item_id_clean);
 
-		$data['my_mode'] = $mode_query->row();
+		$data['my_band'] = $band_query->row();
 		
-		$data['page_title'] = "Edit Mode";
+		$data['page_title'] = "Edit Band";
 
-		$this->form_validation->set_rules('mode', 'Mode', 'required');
-		$this->form_validation->set_rules('qrgmode', 'QRG-Mode', 'required');
-		
-        if ($this->form_validation->run() == FALSE)
-        {
-        	$this->load->view('interface_assets/header', $data);
-            $this->load->view('mode/edit');
-            $this->load->view('interface_assets/footer');
-        }
-        else
-        {
-            $this->bands->edit();
+        $this->load->view('bands/edit', $data);
+	}
 
-            $data['notice'] = "Mode ".$this->security->xss_clean($this->input->post('mode', true))." Updated";
+	public function saveupdatedband() {
+		$this->load->model('bands');
 
-            redirect('mode');
-        }
+		$id = $this->security->xss_clean($this->input->post('id', true));
+		$band = $this->security->xss_clean($this->input->post('band', true));
+
+        $this->bands->saveupdatedband($id, $band);
+		echo json_encode(array('message' => 'OK'));
+        return;
 	}
 
 	public function delete() {

--- a/application/controllers/Band.php
+++ b/application/controllers/Band.php
@@ -33,13 +33,12 @@ class Band extends CI_Controller {
 		$this->load->model('bands');
 		$this->load->library('form_validation');
 
-		$this->form_validation->set_rules('mode', 'Mode', 'required');
-		$this->form_validation->set_rules('qrgmode', 'QRG-Mode', 'required');
+		$this->form_validation->set_rules('band', 'Band', 'required');
 
 		if ($this->form_validation->run() == FALSE)
 		{
 			$data['page_title'] = "Create Mode";
-			$this->load->view('mode/create', $data);
+			$this->load->view('bands/create', $data);
 		}
 		else
 		{	

--- a/application/controllers/Band.php
+++ b/application/controllers/Band.php
@@ -19,7 +19,7 @@ class Band extends CI_Controller {
 	{
 		$this->load->model('bands');
 
-		$data['bands'] = $this->bands->all();
+		$data['bands'] = $this->bands->get_all_bands_for_user();
 		
 		// Render Page
 		$data['page_title'] = "Bands";

--- a/application/controllers/Band.php
+++ b/application/controllers/Band.php
@@ -1,0 +1,30 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+/*
+	Handles Displaying of band information
+*/
+
+class Band extends CI_Controller {
+
+	function __construct()
+	{
+		parent::__construct();
+		$this->load->helper(array('form', 'url'));
+
+		$this->load->model('user_model');
+		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+	}
+
+	public function index()
+	{
+		$this->load->model('bands');
+
+		$data['bands'] = $this->bands->all();
+		
+		// Render Page
+		$data['page_title'] = "Bands";
+		$this->load->view('interface_assets/header', $data);
+		$this->load->view('bands/index');
+		$this->load->view('interface_assets/footer');
+	}
+}

--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -20,11 +20,13 @@ class Contesting extends CI_Controller {
         $this->load->model('stations');
         $this->load->model('modes');
 		$this->load->model('contesting_model');
+		$this->load->model('bands');
 
 		$data['my_gridsquare'] = $this->stations->find_gridsquare();
         $data['radios'] = $this->cat->radios();
         $data['modes'] = $this->modes->active();
 		$data['contestnames'] = $this->contesting_model->getActivecontests();
+		$data['bands'] = $this->bands->get_user_bands_for_qso_entry();
 
 		$this->load->library('form_validation');
 

--- a/application/controllers/Gridsquares.php
+++ b/application/controllers/Gridsquares.php
@@ -313,7 +313,8 @@ class Gridsquares extends CI_Controller {
 		$data['grid_4char'] = js_array($array_grid_4char);
 		$data['grid_6char'] = js_array($array_grid_6char);
 
-		$data['bands_available'] = js_array($this->config->item('bands_available'));
+		$this->load->model('bands');
+        $data['bands_available'] = js_array($this->bands->get_worked_bands());
 
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('gridsquares/index.php');

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -20,7 +20,6 @@ class QSO extends CI_Controller {
 
 	public function index()
 	{
-
 		$this->load->model('cat');
 		$this->load->model('stations');
 		$this->load->model('logbook_model');
@@ -39,7 +38,6 @@ class QSO extends CI_Controller {
 		$data['iota'] = $this->logbook_model->fetchIota();
 		$data['modes'] = $this->modes->active();
         $data['bands'] = $this->bands->get_user_bands_for_qso_entry();
-
 
 		$this->load->library('form_validation');
 
@@ -157,6 +155,7 @@ class QSO extends CI_Controller {
         $this->load->model('logbook_model');
         $this->load->model('user_model');
         $this->load->model('modes');
+        $this->load->model('bands');
 		$this->load->model('contesting_model');
 
         $this->load->library('form_validation');
@@ -172,6 +171,7 @@ class QSO extends CI_Controller {
         $data['dxcc'] = $this->logbook_model->fetchDxcc();
         $data['iota'] = $this->logbook_model->fetchIota();
         $data['modes'] = $this->modes->all();
+        $data['bands'] = $this->bands->get_user_bands_for_qso_entry(true);
         $data['contest'] = $this->contesting_model->getActivecontests();
 
         $this->load->view('qso/edit_ajax', $data);

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -26,6 +26,7 @@ class QSO extends CI_Controller {
 		$this->load->model('logbook_model');
 		$this->load->model('user_model');
 		$this->load->model('modes');
+        $this->load->model('bands');
         if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
 
 		$data['active_station_profile'] = $this->stations->find_active();
@@ -37,6 +38,7 @@ class QSO extends CI_Controller {
 		$data['dxcc'] = $this->logbook_model->fetchDxcc();
 		$data['iota'] = $this->logbook_model->fetchIota();
 		$data['modes'] = $this->modes->active();
+        $data['bands'] = $this->bands->get_user_bands_for_qso_entry();
 
 
 		$this->load->library('form_validation');

--- a/application/libraries/Frequency.php
+++ b/application/libraries/Frequency.php
@@ -100,7 +100,21 @@ class Frequency {
 		  $mode= "DATA";
 		}
 
-		return $this->defaultFrequencies[$band][$mode];
+		return $this->getDefaultFrequency($band, $mode);
+	}
+
+	function getDefaultFrequency($band, $mode) {
+		$CI =& get_instance();
+		$db =& $CI->db;
+
+		$db->from('bands');
+		$db->where('bands.band', $band);
+
+		$result = $db->get()->row();
+
+		$mode = strtolower($mode);
+
+		return $result->$mode;
 	}
 
 	public function GetBand($Frequency) {

--- a/application/migrations/098_add_band_bandxuser.php
+++ b/application/migrations/098_add_band_bandxuser.php
@@ -1,0 +1,163 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_add_band_bandxuser extends CI_Migration {
+    public function up()
+    {
+        if (!$this->db->table_exists('bands')) {
+            $this->dbforge->add_field(array(
+                'id' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => TRUE,
+                    'unique' => TRUE
+                ),
+
+                'band' => array(
+                    'type' => 'VARCHAR',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                )
+            ));
+
+            $this->dbforge->add_key('id', TRUE);
+
+            $this->dbforge->create_table('bands');
+
+            $this->db->query("INSERT INTO bands (band) values ('160m');");
+            $this->db->query("INSERT INTO bands (band) values ('80m');");
+            $this->db->query("INSERT INTO bands (band) values ('60m');");
+            $this->db->query("INSERT INTO bands (band) values ('40m');");
+            $this->db->query("INSERT INTO bands (band) values ('300m');");
+            $this->db->query("INSERT INTO bands (band) values ('20m');");
+            $this->db->query("INSERT INTO bands (band) values ('170m');");
+            $this->db->query("INSERT INTO bands (band) values ('15m');");
+            $this->db->query("INSERT INTO bands (band) values ('12m');");
+            $this->db->query("INSERT INTO bands (band) values ('10m');");
+            $this->db->query("INSERT INTO bands (band) values ('6m');");
+            $this->db->query("INSERT INTO bands (band) values ('4m');");
+            $this->db->query("INSERT INTO bands (band) values ('2m');");
+            $this->db->query("INSERT INTO bands (band) values ('1.25m');");
+            $this->db->query("INSERT INTO bands (band) values ('70cm');");
+            $this->db->query("INSERT INTO bands (band) values ('33cm');");
+            $this->db->query("INSERT INTO bands (band) values ('23cm');");
+            $this->db->query("INSERT INTO bands (band) values ('13cm');");
+            $this->db->query("INSERT INTO bands (band) values ('9cm');");
+            $this->db->query("INSERT INTO bands (band) values ('6cm');");
+            $this->db->query("INSERT INTO bands (band) values ('3cm');");
+            $this->db->query("INSERT INTO bands (band) values ('1.25cm');");
+            $this->db->query("INSERT INTO bands (band) values ('SAT');");
+        }
+
+        if (!$this->db->table_exists('bandxuser')) {
+            $this->dbforge->add_field(array(
+                'id' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => TRUE,
+                    'unique' => TRUE
+                ),
+
+                'bandid' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+                
+                'userid' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+
+                'active' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+                
+                'cq' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+
+                'dok' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+
+                'dxcc' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+
+                'iota' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+
+                'sig' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+
+                'sota' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+
+                'uscounties' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+
+                'was' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+
+                'vucc' => array(
+                    'type' => 'INT',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+            ));
+
+            $this->dbforge->add_key('id', TRUE);
+
+            $this->dbforge->create_table('bandxuser');
+
+            $this->db->query("insert into bandxuser (bandid, userid, active, cq, dok, dxcc, iota, sig, sota, uscounties, was, vucc) select bands.id, users.user_id, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 from bands join users on 1 = 1;");
+        }
+    }
+
+    public function down()
+    {
+        $this->dbforge->drop_table('bandxuser');
+        $this->dbforge->drop_table('bands');
+    }
+}

--- a/application/migrations/098_add_band_bandxuser.php
+++ b/application/migrations/098_add_band_bandxuser.php
@@ -20,6 +20,12 @@ class Migration_add_band_bandxuser extends CI_Migration {
                     'constraint' => 20,
                     'unsigned' => TRUE,
                     'auto_increment' => FALSE
+                ),
+                'bandgroup' => array(
+                    'type' => 'VARCHAR',
+                    'constraint' => 20,
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
                 )
             ));
 
@@ -27,29 +33,29 @@ class Migration_add_band_bandxuser extends CI_Migration {
 
             $this->dbforge->create_table('bands');
 
-            $this->db->query("INSERT INTO bands (band) values ('160m');");
-            $this->db->query("INSERT INTO bands (band) values ('80m');");
-            $this->db->query("INSERT INTO bands (band) values ('60m');");
-            $this->db->query("INSERT INTO bands (band) values ('40m');");
-            $this->db->query("INSERT INTO bands (band) values ('30m');");
-            $this->db->query("INSERT INTO bands (band) values ('20m');");
-            $this->db->query("INSERT INTO bands (band) values ('17m');");
-            $this->db->query("INSERT INTO bands (band) values ('15m');");
-            $this->db->query("INSERT INTO bands (band) values ('12m');");
-            $this->db->query("INSERT INTO bands (band) values ('10m');");
-            $this->db->query("INSERT INTO bands (band) values ('6m');");
-            $this->db->query("INSERT INTO bands (band) values ('4m');");
-            $this->db->query("INSERT INTO bands (band) values ('2m');");
-            $this->db->query("INSERT INTO bands (band) values ('1.25m');");
-            $this->db->query("INSERT INTO bands (band) values ('70cm');");
-            $this->db->query("INSERT INTO bands (band) values ('33cm');");
-            $this->db->query("INSERT INTO bands (band) values ('23cm');");
-            $this->db->query("INSERT INTO bands (band) values ('13cm');");
-            $this->db->query("INSERT INTO bands (band) values ('9cm');");
-            $this->db->query("INSERT INTO bands (band) values ('6cm');");
-            $this->db->query("INSERT INTO bands (band) values ('3cm');");
-            $this->db->query("INSERT INTO bands (band) values ('1.25cm');");
-            $this->db->query("INSERT INTO bands (band) values ('SAT');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('160m', 'hf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('80m', 'hf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('60m', 'hf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('40m', 'hf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('30m', 'hf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('20m', 'hf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('17m', 'hf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('15m', 'hf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('12m', 'hf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('10m', 'hf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('6m', 'vhf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('4m', 'vhf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('2m', 'vhf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('1.25m', 'vhf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('70cm', 'uhf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('33cm', 'uhf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('23cm', 'shf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('13cm', 'shf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('9cm', 'shf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('6cm', 'shf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('3cm', 'shf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('1.25cm', 'shf');");
+            $this->db->query("INSERT INTO bands (band, bandgroup) values ('SAT', 'sat');");
         }
 
         if (!$this->db->table_exists('bandxuser')) {

--- a/application/migrations/098_add_band_bandxuser.php
+++ b/application/migrations/098_add_band_bandxuser.php
@@ -31,9 +31,9 @@ class Migration_add_band_bandxuser extends CI_Migration {
             $this->db->query("INSERT INTO bands (band) values ('80m');");
             $this->db->query("INSERT INTO bands (band) values ('60m');");
             $this->db->query("INSERT INTO bands (band) values ('40m');");
-            $this->db->query("INSERT INTO bands (band) values ('300m');");
+            $this->db->query("INSERT INTO bands (band) values ('30m');");
             $this->db->query("INSERT INTO bands (band) values ('20m');");
-            $this->db->query("INSERT INTO bands (band) values ('170m');");
+            $this->db->query("INSERT INTO bands (band) values ('17m');");
             $this->db->query("INSERT INTO bands (band) values ('15m');");
             $this->db->query("INSERT INTO bands (band) values ('12m');");
             $this->db->query("INSERT INTO bands (band) values ('10m');");

--- a/application/migrations/098_add_band_bandxuser.php
+++ b/application/migrations/098_add_band_bandxuser.php
@@ -26,6 +26,21 @@ class Migration_add_band_bandxuser extends CI_Migration {
                     'constraint' => 20,
                     'unsigned' => TRUE,
                     'auto_increment' => FALSE
+                ),
+                'ssb' => array(
+                    'type' => 'bigint',
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+                'data' => array(
+                    'type' => 'bigint',
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
+                ),
+                'cw' => array(
+                    'type' => 'bigint',
+                    'unsigned' => TRUE,
+                    'auto_increment' => FALSE
                 )
             ));
 
@@ -33,29 +48,29 @@ class Migration_add_band_bandxuser extends CI_Migration {
 
             $this->dbforge->create_table('bands');
 
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('160m', 'hf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('80m', 'hf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('60m', 'hf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('40m', 'hf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('30m', 'hf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('20m', 'hf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('17m', 'hf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('15m', 'hf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('12m', 'hf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('10m', 'hf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('6m', 'vhf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('4m', 'vhf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('2m', 'vhf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('1.25m', 'vhf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('70cm', 'uhf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('33cm', 'uhf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('23cm', 'shf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('13cm', 'shf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('9cm', 'shf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('6cm', 'shf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('3cm', 'shf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('1.25cm', 'shf');");
-            $this->db->query("INSERT INTO bands (band, bandgroup) values ('SAT', 'sat');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('160m', 'hf', '1900000', '1838000', '1830000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('80m', 'hf', '3700000', '3583000', '3550000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('60m', 'hf', '5330000', '5330000', '5260000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('40m', 'hf', '7100000', '7040000', '7020000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('30m', 'hf', '10120000', '10145000', '10120000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('20m', 'hf', '14200000', '14080000', '14020000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('17m', 'hf', '18130000', '18105000', '18080000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('15m', 'hf', '21300000', '21080000', '21020000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('12m', 'hf', '24950000', '24925000', '24900000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('10m', 'hf', '28300000', '28120000', '28050000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('6m', 'vhf', '50150000', '50230000', '50090000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('4m', 'vhf', '70200000', '70200000', '70200000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('2m', 'vhf', '144300000', '144370000', '144050000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('1.25m', 'vhf', '222100000', '222100000', '222100000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('70cm', 'uhf', '432200000', '432088000', '432050000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('33cm', 'uhf', '902100000', '902100000', '902100000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('23cm', 'shf', '1296000000', '1296138000', '129600000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('13cm', 'shf', '2320800000', '2320800000', '2320800000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('9cm', 'shf', '3410000000', '3410000000', '3400000000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('6cm', 'shf', '5670000000', '5670000000', '5670000000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('3cm', 'shf', '10225000000', '10225000000', '10225000000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('1.25cm', 'shf', '24000000000', '24000000000', '240000000000');");
+            $this->db->query("INSERT INTO bands (band, bandgroup, ssb, data, cw) values ('SAT', 'sat', '', '', '');");
         }
 
         if (!$this->db->table_exists('bandxuser')) {

--- a/application/models/Bands.php
+++ b/application/models/Bands.php
@@ -257,6 +257,23 @@ class Bands extends CI_Model {
 		$this->db->query("insert into bandxuser (bandid, userid, active, cq, dok, dxcc, iota, sig, sota, uscounties, was, vucc) 
 		select bands.id, " . $this->session->userdata('user_id') . ", 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 from bands where band ='".$data['band']."' and not exists (select 1 from bandxuser where userid = " . $this->session->userdata('user_id') . " and bandid = bands.id);");
 	}
+
+	function getband($id) {
+		$this->db->where('id', $id);
+		return $this->db->get('bands');
+	}
+
+	function saveupdatedband($id, $band) {
+		$data = array(
+			'band' => $band,
+        );
+
+        $this->db->where('bands.id', $id);
+
+        $this->db->update('bands', $data);
+
+        return true;
+	}
 }
 
 ?>

--- a/application/models/Bands.php
+++ b/application/models/Bands.php
@@ -28,6 +28,15 @@ class Bands extends CI_Model {
 		"SAT"=>0,
 	);
 
+	function all2() {
+		$this->db->order_by('band', 'ASC');
+		return $this->db->get('bands');
+	}
+
+	function all() {
+		return $this->bandslots;
+	}
+
 	function get_worked_bands() {
 		$CI =& get_instance();
 		$CI->load->model('logbooks_model');

--- a/application/models/Bands.php
+++ b/application/models/Bands.php
@@ -28,16 +28,41 @@ class Bands extends CI_Model {
 		"SAT"=>0,
 	);
 
-	function all2() {
-		$this->db->order_by('band', 'ASC');
-		return $this->db->get('bands');
+	function get_user_bands($award = 'None') {
+		$this->db->from('bands');
+		$this->db->join('bandxuser', 'bandxuser.bandid = bands.id');
+		$this->db->where('bandxuser.userid', $this->session->userdata('user_id'));
+		$this->db->where('bandxuser.active', 1);
+
+		if ($award != 'None') {
+			$this->db->where('bandxuser.".$award', 1);
+		}
+		
+		$result = $this->db->get()->result();
+
+		$results = array();
+
+		foreach($result as $band) {
+			array_push($results, $band->band);
+		}
+
+		return $results;
+	}
+
+	function get_all_bands_for_user() {
+		$this->db->from('bands');
+		$this->db->join('bandxuser', 'bandxuser.bandid = bands.id');
+		$this->db->where('bandxuser.userid', $this->session->userdata('user_id'));
+
+		return $this->db->get()->result();
 	}
 
 	function all() {
 		return $this->bandslots;
 	}
 
-	function get_worked_bands() {
+	function get_worked_bands($award = 'None') {
+		
 		$CI =& get_instance();
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
@@ -65,10 +90,10 @@ class Bands extends CI_Model {
 			array_push($worked_slots, strtoupper($row->COL_PROP_MODE));
 		}
 
+		$bandslots = $this->get_user_bands($award);
 
-		// bring worked-slots in order of defined $bandslots
 		$results = array();
-		foreach(array_keys($this->bandslots) as $slot) {
+		foreach($bandslots as $slot) {
 			if(in_array($slot, $worked_slots)) {
 				array_push($results, $slot);
 			}

--- a/application/models/Bands.php
+++ b/application/models/Bands.php
@@ -179,7 +179,7 @@ class Bands extends CI_Model {
 		}
 
 		// bring worked-slots in order of defined $bandslots
-		$bandslots = $this->get_user_bands();
+		$bandslots = $this->get_user_bands('dok');
 
 		$results = array();
 		foreach($bandslots as $slot) {

--- a/application/models/Bands.php
+++ b/application/models/Bands.php
@@ -35,7 +35,7 @@ class Bands extends CI_Model {
 		$this->db->where('bandxuser.active', 1);
 
 		if ($award != 'None') {
-			$this->db->where('bandxuser.".$award', 1);
+			$this->db->where('bandxuser.'.$award, 1);
 		}
 		
 		$result = $this->db->get()->result();
@@ -90,6 +90,7 @@ class Bands extends CI_Model {
 			array_push($worked_slots, strtoupper($row->COL_PROP_MODE));
 		}
 
+		// bring worked-slots in order of defined $bandslots
 		$bandslots = $this->get_user_bands($award);
 
 		$results = array();
@@ -122,12 +123,14 @@ class Bands extends CI_Model {
         }
 
         // bring worked-slots in order of defined $bandslots
-        $results = array();
-        foreach(array_keys($this->bandslots) as $slot) {
-            if(in_array($slot, $worked_slots)) {
-                array_push($results, $slot);
-            }
-        }
+		$bandslots = $this->get_user_bands();
+
+		$results = array();
+		foreach($bandslots as $slot) {
+			if(in_array($slot, $worked_slots)) {
+				array_push($results, $slot);
+			}
+		}
         return $results;
     }
 
@@ -175,16 +178,69 @@ class Bands extends CI_Model {
 			array_push($worked_slots, $row->COL_BAND);
 		}
 
-
 		// bring worked-slots in order of defined $bandslots
+		$bandslots = $this->get_user_bands();
+
 		$results = array();
-		foreach(array_keys($this->bandslots) as $slot) {
+		foreach($bandslots as $slot) {
 			if(in_array($slot, $worked_slots)) {
 				array_push($results, $slot);
 			}
 		}
 		return $results;
 	}
+
+	function activateall() {
+        $data = array(
+            'active' => '1',
+        );
+		$this->db->where('bandxuser.userid', $this->session->userdata('user_id'));
+
+        $this->db->update('bandxuser', $data);
+
+        return true;
+    }
+
+    function deactivateall() {
+        $data = array(
+            'active' => '0',
+        );
+		$this->db->where('bandxuser.userid', $this->session->userdata('user_id'));
+
+        $this->db->update('bandxuser', $data);
+
+        return true;
+    }
+
+	function delete($id) {
+		// Clean ID
+		$clean_id = $this->security->xss_clean($id);
+
+		// Delete Mode
+		$this->db->delete('bandxuser', array('id' => $clean_id)); 
+	}
+
+	function saveBand($id, $band) {
+        $data = array(
+			'active' 	 => $band['status']		== "true" ? '1' : '0',
+			'cq' 		 => $band['cq'] 		== "true" ? '1' : '0',
+			'dok' 		 => $band['dok'] 		== "true" ? '1' : '0',
+			'dxcc' 		 => $band['dxcc'] 		== "true" ? '1' : '0',
+			'iota' 		 => $band['iota'] 		== "true" ? '1' : '0',
+			'sig' 		 => $band['sig'] 		== "true" ? '1' : '0',
+			'sota'		 => $band['sota'] 		== "true" ? '1' : '0',
+			'uscounties' => $band['uscounties'] == "true" ? '1' : '0',
+			'was' 		 => $band['was'] 		== "true" ? '1' : '0',
+			'vucc'		 => $band['vucc'] 		== "true" ? '1' : '0'
+        );
+
+		$this->db->where('bandxuser.userid', $this->session->userdata('user_id'));
+        $this->db->where('bandxuser.id', $id);
+
+        $this->db->update('bandxuser', $data);
+
+        return true;
+    }
 
 }
 

--- a/application/models/Bands.php
+++ b/application/models/Bands.php
@@ -262,7 +262,11 @@ class Bands extends CI_Model {
 
 	function add() {
 		$data = array(
-			'band' => xss_clean($this->input->post('band', true)),
+			'band' 		=> xss_clean($this->input->post('band', true)),
+			'bandgroup' => xss_clean($this->input->post('bandgroup', true)),
+			'ssb'	 	=> xss_clean($this->input->post('ssbqrg', true)),
+			'data' 		=> xss_clean($this->input->post('dataqrg', true)),
+			'cw' 		=> xss_clean($this->input->post('cwqrg', true)),
 		);
 
 		$this->db->where('band', xss_clean($this->input->post('band', true)));
@@ -283,7 +287,11 @@ class Bands extends CI_Model {
 
 	function saveupdatedband($id, $band) {
 		$data = array(
-			'band' => $band,
+			'band' 		=> $band['band'],
+			'bandgroup' => $band['bandgroup'],
+			'ssb'	 	=> $band['ssbqrg'],
+			'data' 		=> $band['dataqrg'],
+			'cw' 		=> $band['cwqrg'],
         );
 
         $this->db->where('bands.id', $id);

--- a/application/models/Bands.php
+++ b/application/models/Bands.php
@@ -49,6 +49,24 @@ class Bands extends CI_Model {
 		return $results;
 	}
 
+	function get_user_bands_for_qso_entry() {
+		$this->db->from('bands');
+		$this->db->join('bandxuser', 'bandxuser.bandid = bands.id');
+		$this->db->where('bandxuser.userid', $this->session->userdata('user_id'));
+		$this->db->where('bandxuser.active', 1);
+		$this->db->where('bands.bandgroup != "sat"');
+
+		$result = $this->db->get()->result();
+
+		$results = array();
+
+		foreach($result as $band) {
+			$results[$band->bandgroup][] = $band->band;
+		}
+
+		return $results;
+	}
+
 	function get_all_bands_for_user() {
 		$this->db->from('bands');
 		$this->db->join('bandxuser', 'bandxuser.bandid = bands.id');

--- a/application/models/Bands.php
+++ b/application/models/Bands.php
@@ -49,11 +49,13 @@ class Bands extends CI_Model {
 		return $results;
 	}
 
-	function get_user_bands_for_qso_entry() {
+	function get_user_bands_for_qso_entry($includeall = false) {
 		$this->db->from('bands');
 		$this->db->join('bandxuser', 'bandxuser.bandid = bands.id');
 		$this->db->where('bandxuser.userid', $this->session->userdata('user_id'));
-		$this->db->where('bandxuser.active', 1);
+		if (!$includeall) {
+			$this->db->where('bandxuser.active', 1);
+		}
 		$this->db->where('bands.bandgroup != "sat"');
 
 		$result = $this->db->get()->result();

--- a/application/models/Bands.php
+++ b/application/models/Bands.php
@@ -242,6 +242,21 @@ class Bands extends CI_Model {
         return true;
     }
 
+	function add() {
+		$data = array(
+			'band' => xss_clean($this->input->post('band', true)),
+		);
+
+		$this->db->where('band', xss_clean($this->input->post('band', true)));
+		$result = $this->db->get('bands');
+	 
+		if ($result->num_rows() == 0) {
+		   $this->db->insert('bands', $data);
+		}
+
+		$this->db->query("insert into bandxuser (bandid, userid, active, cq, dok, dxcc, iota, sig, sota, uscounties, was, vucc) 
+		select bands.id, " . $this->session->userdata('user_id') . ", 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 from bands where band ='".$data['band']."' and not exists (select 1 from bandxuser where userid = " . $this->session->userdata('user_id') . " and bandid = bands.id);");
+	}
 }
 
 ?>

--- a/application/models/Counties.php
+++ b/application/models/Counties.php
@@ -33,12 +33,19 @@ class Counties extends CI_Model
 
 		$location_list = "'".implode("','",$logbooks_locations_array)."'";
 
+        $this->load->model('bands');
+
+		$bandslots = $this->bands->get_worked_bands('uscounties');
+
+		$bandslots_list = "'".implode("','",$bandslots)."'";
+
         $sql = "select count(distinct COL_CNTY) countycountworked, coalesce(x.countycountconfirmed, 0) countycountconfirmed, thcv.COL_STATE
                 from " . $this->config->item('table_name') . " thcv
                  left outer join (
                         select count(distinct COL_CNTY) countycountconfirmed, COL_STATE
                         from " . $this->config->item('table_name') .
             " where station_id in (" . $location_list . ")" .
+            " and col_band in (" . $bandslots_list . ")" .
             " and COL_DXCC in ('291', '6', '110')
                     and coalesce(COL_CNTY, '') <> ''
                     and COL_BAND != 'SAT'
@@ -47,6 +54,7 @@ class Counties extends CI_Model
                     order by COL_STATE
                 ) x on thcv.COL_STATE = x.COL_STATE
                  where station_id in (" . $location_list . ")" .
+                 " and col_band in (" . $bandslots_list . ")" .
             " and COL_DXCC in ('291', '6', '110')
                 and coalesce(COL_CNTY, '') <> ''
                 and COL_BAND != 'SAT'
@@ -85,9 +93,16 @@ class Counties extends CI_Model
 
 		$location_list = "'".implode("','",$logbooks_locations_array)."'";
 
+        $this->load->model('bands');
+
+		$bandslots = $this->bands->get_worked_bands('uscounties');
+
+		$bandslots_list = "'".implode("','",$bandslots)."'";
+
         $sql = "select distinct COL_CNTY, COL_STATE
                 from " . $this->config->item('table_name') . " thcv
                  where station_id in (" . $location_list . ")" .
+                 " and col_band in (" . $bandslots_list . ")" .
                 " and COL_DXCC in ('291', '6', '110')
                 and coalesce(COL_CNTY, '') <> ''
                 and COL_BAND != 'SAT'";

--- a/application/models/Cq.php
+++ b/application/models/Cq.php
@@ -187,7 +187,14 @@ class CQ extends CI_Model{
         if ($band == 'SAT') {
             $sql .= " and thcv.col_prop_mode ='" . $band . "'";
         } else if ($band == 'All') {
-            $sql .= " and thcv.col_prop_mode !='SAT'";
+            $this->load->model('bands');
+
+			$bandslots = $this->bands->get_worked_bands('cq');
+	
+			$bandslots_list = "'".implode("','",$bandslots)."'";
+			
+			$sql .= " and thcv.col_band in (" . $bandslots_list . ")" .
+					" and thcv.col_prop_mode !='SAT'";
         } else {
             $sql .= " and thcv.col_prop_mode !='SAT'";
             $sql .= " and thcv.col_band ='" . $band . "'";
@@ -210,7 +217,14 @@ class CQ extends CI_Model{
         if ($band == 'SAT') {
             $sql .= " and thcv.col_prop_mode ='" . $band . "'";
         } else if ($band == 'All') {
-            $sql .= " and thcv.col_prop_mode !='SAT'";
+            $this->load->model('bands');
+
+			$bandslots = $this->bands->get_worked_bands('cq');
+	
+			$bandslots_list = "'".implode("','",$bandslots)."'";
+			
+			$sql .= " and thcv.col_band in (" . $bandslots_list . ")" .
+					" and thcv.col_prop_mode !='SAT'";
         } else {
             $sql .= " and thcv.col_prop_mode !='SAT'";
             $sql .= " and thcv.col_band ='" . $band . "'";

--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -427,7 +427,14 @@ class DXCC extends CI_Model {
 		if ($band == 'SAT') {
 			$sql .= " and thcv.col_prop_mode ='" . $band . "'";
 		} else if ($band == 'All') {
-			$sql .= " and thcv.col_prop_mode !='SAT'";
+			$this->load->model('bands');
+
+			$bandslots = $this->bands->get_worked_bands('dxcc');
+	
+			$bandslots_list = "'".implode("','",$bandslots)."'";
+			
+			$sql .= " and thcv.col_band in (" . $bandslots_list . ")" .
+					" and thcv.col_prop_mode !='SAT'";
 		} else {
 			$sql .= " and thcv.col_prop_mode !='SAT'";
 			$sql .= " and thcv.col_band ='" . $band . "'";
@@ -458,7 +465,14 @@ class DXCC extends CI_Model {
 		if ($band == 'SAT') {
 			$sql .= " and thcv.col_prop_mode ='" . $band . "'";
 		} else if ($band == 'All') {
-			$sql .= " and thcv.col_prop_mode !='SAT'";
+			$this->load->model('bands');
+
+			$bandslots = $this->bands->get_worked_bands('dxcc');
+	
+			$bandslots_list = "'".implode("','",$bandslots)."'";
+			
+			$sql .= " and thcv.col_band in (" . $bandslots_list . ")" .
+					" and thcv.col_prop_mode !='SAT'";
 		} else {
 			$sql .= " and thcv.col_prop_mode !='SAT'";
 			$sql .= " and thcv.col_band ='" . $band . "'";

--- a/application/models/Iota.php
+++ b/application/models/Iota.php
@@ -325,7 +325,14 @@ class IOTA extends CI_Model {
         if ($band == 'SAT') {
             $sql .= " and thcv.col_prop_mode ='" . $band . "'";
         } else if ($band == 'All') {
-            $sql .= " and thcv.col_prop_mode !='SAT'";
+            $this->load->model('bands');
+
+			$bandslots = $this->bands->get_worked_bands('iota');
+	
+			$bandslots_list = "'".implode("','",$bandslots)."'";
+			
+			$sql .= " and thcv.col_band in (" . $bandslots_list . ")" .
+					" and thcv.col_prop_mode !='SAT'";
         } else {
             $sql .= " and thcv.col_prop_mode !='SAT'";
             $sql .= " and thcv.col_band ='" . $band . "'";
@@ -356,7 +363,14 @@ class IOTA extends CI_Model {
         if ($band == 'SAT') {
             $sql .= " and thcv.col_prop_mode ='" . $band . "'";
         } else if ($band == 'All') {
-            $sql .= " and thcv.col_prop_mode !='SAT'";
+            $this->load->model('bands');
+
+			$bandslots = $this->bands->get_worked_bands('iota');
+	
+			$bandslots_list = "'".implode("','",$bandslots)."'";
+			
+			$sql .= " and thcv.col_band in (" . $bandslots_list . ")" .
+					" and thcv.col_prop_mode !='SAT'";
         } else {
             $sql .= " and thcv.col_prop_mode !='SAT'";
             $sql .= " and thcv.col_band ='" . $band . "'";

--- a/application/models/Sig.php
+++ b/application/models/Sig.php
@@ -11,7 +11,12 @@ class Sig extends CI_Model {
             return null;
         }
 
+		$this->load->model('bands');
+
+		$bandslots = $this->bands->get_worked_bands('sig');
+
 		$this->db->where_in("station_id", $logbooks_locations_array);
+		$this->db->where_in("col_band", $bandslots);
 		$this->db->order_by("COL_SIG_INFO", "ASC");
 		$this->db->where('COL_SIG =', $type);
 
@@ -29,9 +34,16 @@ class Sig extends CI_Model {
 
 		$location_list = "'".implode("','",$logbooks_locations_array)."'";
 
+		$this->load->model('bands');
+
+		$bandslots = $this->bands->get_worked_bands('sig');
+
+		$bandslots_list = "'".implode("','",$bandslots)."'";
+
         $sql = "select col_sig, count(*) qsos, count(distinct col_sig_info) refs from " . $this->config->item('table_name') .
                 " where col_sig <> ''" .
                 " and station_id in (" . $location_list . ")" .
+				" and col_band in (" . $bandslots_list . ")" .
                 " group by col_sig";
 
         $query = $this->db->query($sql);

--- a/application/models/Sota.php
+++ b/application/models/Sota.php
@@ -11,7 +11,12 @@ class Sota extends CI_Model {
             return null;
         }
 
+		$this->load->model('bands');
+
+		$bandslots = $this->bands->get_worked_bands('sota');
+
 		$this->db->where_in("station_id", $logbooks_locations_array);
+		$this->db->where_in("col_band", $bandslots);
 		$this->db->order_by("COL_SOTA_REF", "ASC");
 		$this->db->where('COL_SOTA_REF !=', '');
 

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -149,8 +149,10 @@ class User_Model extends CI_Model {
 				return EEMAILEXISTS;
 			}
 
-			// Add user
+			// Add user and insert bandsettings for user
 			$this->db->insert($this->config->item('auth_table'), $data);
+			$insert_id = $this->db->insert_id();
+			$this->db->query("insert into bandxuser (bandid, userid, active, cq, dok, dxcc, iota, sig, sota, uscounties, was, vucc) select bands.id, " . $insert_id . ", 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 from bands;");
 			return OK;
 		} else {
 			return EUSERNAMEEXISTS;

--- a/application/models/Was.php
+++ b/application/models/Was.php
@@ -117,7 +117,14 @@ class was extends CI_Model {
         if ($band == 'SAT') {
             $sql .= " and thcv.col_prop_mode ='" . $band . "'";
         } else if ($band == 'All') {
-            $sql .= " and thcv.col_prop_mode !='SAT'";
+            $this->load->model('bands');
+
+			$bandslots = $this->bands->get_worked_bands('was');
+	
+			$bandslots_list = "'".implode("','",$bandslots)."'";
+			
+			$sql .= " and thcv.col_band in (" . $bandslots_list . ")" .
+					" and thcv.col_prop_mode !='SAT'";
         } else {
             $sql .= " and thcv.col_prop_mode !='SAT'";
             $sql .= " and thcv.col_band ='" . $band . "'";
@@ -143,7 +150,14 @@ class was extends CI_Model {
         if ($band == 'SAT') {
             $sql .= " and thcv.col_prop_mode ='" . $band . "'";
         } else if ($band == 'All') {
-            $sql .= " and thcv.col_prop_mode !='SAT'";
+            $this->load->model('bands');
+
+			$bandslots = $this->bands->get_worked_bands('was');
+	
+			$bandslots_list = "'".implode("','",$bandslots)."'";
+			
+			$sql .= " and thcv.col_band in (" . $bandslots_list . ")" .
+					" and thcv.col_prop_mode !='SAT'";
         } else {
             $sql .= " and thcv.col_prop_mode !='SAT'";
             $sql .= " and thcv.col_band ='" . $band . "'";
@@ -247,6 +261,15 @@ class was extends CI_Model {
                 $sql .= " and col_prop_mode !='SAT'";
                 $sql .= " and col_band ='" . $band . "'";
             }
+        } else {
+            $this->load->model('bands');
+
+			$bandslots = $this->bands->get_worked_bands('was');
+	
+			$bandslots_list = "'".implode("','",$bandslots)."'";
+			
+			$sql .= " and col_band in (" . $bandslots_list . ")" .
+					" and col_prop_mode !='SAT'";
         }
         return $sql;
     }

--- a/application/views/bands/create.php
+++ b/application/views/bands/create.php
@@ -1,0 +1,32 @@
+
+<div class="container" id="create_mode">
+
+<br>
+	<?php if($this->session->flashdata('message')) { ?>
+		<!-- Display Message -->
+		<div class="alert-message error">
+		  <p><?php echo $this->session->flashdata('message'); ?></p>
+		</div>
+	<?php } ?>
+
+		<?php if($this->session->flashdata('notice')) { ?>
+			<div id="message" >
+			<?php echo $this->session->flashdata('notice'); ?>
+			</div>
+		<?php } ?>
+
+		<?php $this->load->helper('form'); ?>
+
+		<?php echo validation_errors(); ?>
+
+		<form>
+		<div class="form-group">
+		    <label for="bandInput">Band</label>
+		    <input type="text" class="form-control" name="band" id="bandInput" aria-describedby="bandInputHelp" required>
+		    <small id="bandInputHelp" class="form-text text-muted">Band name</small>
+		  </div>
+		  
+			<button type="button" onclick="createBand(this.form);" class="btn btn-primary"><i class="fas fa-plus-square"></i> Create band</button>
+
+		</form>
+</div>

--- a/application/views/bands/create.php
+++ b/application/views/bands/create.php
@@ -25,6 +25,26 @@
 		    <input type="text" class="form-control" name="band" id="bandInput" aria-describedby="bandInputHelp" required>
 		    <small id="bandInputHelp" class="form-text text-muted">Band name</small>
 		  </div>
+		  <div class="form-group">
+			<label for="bandGroup">Bandgroup</label>
+			<input type="text" class="form-control" name="bandgroup" id="bandGroup" aria-describedby="bandgroupInputHelp" required>
+			<small id="bandgroupInputHelp" class="form-text text-muted">Name of bandgroup (E.g. hf, vhf, uhf, shf)</small>
+		</div>
+		<div class="form-group">
+			<label for="ssbqrg">SSB QRG</label>
+			<input type="text" class="form-control" name="ssbqrg" id="ssbqrg" aria-describedby="ssbqrgInputHelp" required>
+			<small id="ssbqrgInputHelp" class="form-text text-muted">Frequency for SSB QRG in band (must be in Hz)</small>
+		</div>
+		<div class="form-group">
+			<label for="dataqrg">DATA QRG</label>
+			<input type="text" class="form-control" name="dataqrg" id="dataqrg" aria-describedby="dataqrgInputHelp" required>
+			<small id="dataqrgInputHelp" class="form-text text-muted">Frequency for DATA QRG in band (must be in Hz)</small>
+		</div>
+		<div class="form-group">
+			<label for="cwqrg">CW QRG</label>
+			<input type="text" class="form-control" name="cwqrg" id="cwqrg" aria-describedby="cwqrgInputHelp" required>
+			<small id="cwqrgInputHelp" class="form-text text-muted">Frequency for CW QRG in band (must be in Hz)</small>
+		</div>
 		  
 			<button type="button" onclick="createBand(this.form);" class="btn btn-primary"><i class="fas fa-plus-square"></i> Create band</button>
 

--- a/application/views/bands/edit.php
+++ b/application/views/bands/edit.php
@@ -3,9 +3,29 @@
 
 		<input type="hidden" name="id" value="<?php echo $my_band->id; ?>">
 		<div class="form-group">
-			<label for="modeInput">Band</label>
+			<label for="bandInput">Band</label>
 			<input type="text" class="form-control" name="band" id="bandInput" aria-describedby="bandInputHelp" value="<?php if(set_value('band') != "") { echo set_value('band'); } else { echo $my_band->band; } ?>" required>
 			<small id="bandInputHelp" class="form-text text-muted">Name of band</small>
+		</div>
+		<div class="form-group">
+			<label for="bandGroup">Bandgroup</label>
+			<input type="text" class="form-control" name="bandgroup" id="bandGroup" aria-describedby="bandgroupInputHelp" value="<?php if(set_value('bandgroup') != "") { echo set_value('bandgroup'); } else { echo $my_band->bandgroup; } ?>" required>
+			<small id="bandgroupInputHelp" class="form-text text-muted">Name of bandgroup (E.g. hf, vhf, uhf, shf)</small>
+		</div>
+		<div class="form-group">
+			<label for="ssbqrg">SSB QRG</label>
+			<input type="text" class="form-control" name="ssbqrg" id="ssbqrg" aria-describedby="ssbqrgInputHelp" value="<?php echo $my_band->ssb; ?>" required>
+			<small id="ssbqrgInputHelp" class="form-text text-muted">Frequency for SSB QRG in band (must be in Hz)</small>
+		</div>
+		<div class="form-group">
+			<label for="dataqrg">DATA QRG</label>
+			<input type="text" class="form-control" name="dataqrg" id="dataqrg" aria-describedby="dataqrgInputHelp" value="<?php echo $my_band->data; ?>" required>
+			<small id="dataqrgInputHelp" class="form-text text-muted">Frequency for DATA QRG in band (must be in Hz)</small>
+		</div>
+		<div class="form-group">
+			<label for="cwqrg">CW QRG</label>
+			<input type="text" class="form-control" name="cwqrg" id="cwqrg" aria-describedby="cwqrgInputHelp" value="<?php echo $my_band->cw; ?>" required>
+			<small id="cwqrgInputHelp" class="form-text text-muted">Frequency for CW QRG in band (must be in Hz)</small>
 		</div>
 
 		<button type="button" onclick="saveUpdatedBand(this.form);" class="btn btn-primary"><i class="fas fa-plus-square"></i> Update band</button>

--- a/application/views/bands/edit.php
+++ b/application/views/bands/edit.php
@@ -1,0 +1,14 @@
+<div class="container" id="edit_band_dialog">
+	<form>
+
+		<input type="hidden" name="id" value="<?php echo $my_band->id; ?>">
+		<div class="form-group">
+			<label for="modeInput">Band</label>
+			<input type="text" class="form-control" name="band" id="bandInput" aria-describedby="bandInputHelp" value="<?php if(set_value('band') != "") { echo set_value('band'); } else { echo $my_band->band; } ?>" required>
+			<small id="bandInputHelp" class="form-text text-muted">Name of band</small>
+		</div>
+
+		<button type="button" onclick="saveUpdatedBand(this.form);" class="btn btn-primary"><i class="fas fa-plus-square"></i> Update band</button>
+
+	</form>
+</div>

--- a/application/views/bands/index.php
+++ b/application/views/bands/index.php
@@ -1,0 +1,93 @@
+<div class="container">
+
+<br>
+	<?php if($this->session->flashdata('message')) { ?>
+		<!-- Display Message -->
+		<div class="alert-message error">
+		  <p><?php echo $this->session->flashdata('message'); ?></p>
+		</div>
+	<?php } ?>
+
+<h2><?php echo $page_title; ?></h2>
+
+<div class="card">
+  <div class="card-header">
+    Bands
+  </div>
+  <div class="card-body">
+    <p class="card-text">
+		Using the band list you can control which bands are shown when creating a new QSO.
+	</p>
+    <p class="card-text">
+		Active bands will be shown in the QSO "Band" drop-down, while inactive bands will be hidden and cannot be selected.
+	</p>
+    <div class="table-responsive">
+		
+    <table style="width:100%" class="modetable table table-striped">
+			<thead>
+				<tr>
+					<th class="select-filter" scope="col">Band</th>
+					<th class="select-filter" scope="col">Status</th>
+					<th scope="col">CQ</th>
+                    <th scope="col">DOK</th>
+                    <th scope="col">DXCC</th>
+                    <th scope="col">IOTA</th>
+					<th scope="col">SIG</th>
+                    <th scope="col">SOTA</th>
+                    <th scope="col">US Counties</th>
+                    <th scope="col">WAS</th>
+                    <th scope="col">VUCC</th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+                    <th scope="col"></th>
+
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ($bands as $key => $band) { ?>
+				<tr>
+					<td><?php echo $key?></td>
+                    <td>Active</td>
+					<td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td style="text-align: center">
+                        <button onclick='javascript:deactivateMode()' class=' btn btn-secondary btn-sm'>Deactivate</button>
+                    </td>
+					<td>
+						<a href="<?php echo site_url('mode/edit')?>" class="btn btn-outline-primary btn-sm"><i class="fas fa-edit"></i> Edit</a>
+					</td>
+					<td>
+						<a href="javascript:deleteMode('');" class="btn btn-danger btn-sm" ><i class="fas fa-trash-alt"></i> Delete</a>
+                    </td>
+				</tr>
+
+				<?php } ?>
+			</tbody>
+			<tfoot>
+				<tr>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+				</tr>
+			</tfoot>
+		<table>
+	</div>
+  <br/>
+  <p>
+	  	<button onclick="createBandDialog();" class="btn btn-primary btn-sm"><i class="fas fa-plus"></i> Create a Band</button>
+  		<button onclick="activateAllBands();" class="btn btn-primary btn-sm">Activate All</button>
+		<button onclick="deactivateAllBands();" class="btn btn-primary btn-sm">Deactivate All </button>
+	</p>
+</div>
+</div>

--- a/application/views/bands/index.php
+++ b/application/views/bands/index.php
@@ -23,11 +23,11 @@
 	</p>
     <div class="table-responsive">
 		
-    <table style="width:100%" class="bandtable table table-striped">
+    <table style="width:100%" class="bandtable table table-sm table-striped">
 			<thead>
 				<tr>
+					<th></th>
 					<th>Band</th>
-					<th>Active</th>
 					<th>CQ</th>
                     <th>DOK</th>
                     <th>DXCC</th>
@@ -37,6 +37,10 @@
                     <th>US Counties</th>
                     <th>WAS</th>
                     <th>VUCC</th>
+					<th>Bandgroup</th>
+					<th>SSB QRG</th>
+					<th>DATA QRG</th>
+					<th>CW QRG</th>
                     <th></th>
                     <th></th>
                     <th></th>
@@ -46,8 +50,8 @@
 			<tbody>
 				<?php foreach ($bands as $band) { ?>
 				<tr>
-					<td><?php echo $band->band;?></td>
                     <td class='band_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->active == 1) {echo 'checked';}?>></td>
+					<td><?php echo $band->band;?></td>
 					<td class='cq_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->cq == 1) {echo 'checked';}?>></td>
                     <td class='dok_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->dok == 1) {echo 'checked';}?>></td>
                     <td class='dxcc_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->dxcc == 1) {echo 'checked';}?>></td>
@@ -57,14 +61,18 @@
                     <td class='uscounties_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->uscounties == 1) {echo 'checked';}?>></td>
                     <td class='was_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->was == 1) {echo 'checked';}?>></td>
                     <td class='vucc_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->vucc == 1) {echo 'checked';}?>></td>
+					<td><?php echo $band->bandgroup;?></td>
+					<td><?php echo $band->ssb;?></td>
+					<td><?php echo $band->data;?></td>
+					<td><?php echo $band->cw;?></td>
 					<td>
-						<a href="javascript:editBandDialog('<?php echo $band->bandid ?>');" class="btn btn-outline-primary btn-sm"><i class="fas fa-edit"></i> Edit</a>
+						<a href="javascript:editBandDialog('<?php echo $band->bandid ?>');" class="btn btn-outline-primary btn-sm" title="Edit"><i class="fas fa-edit"></i></a>
 					</td>
 					<td>
-						<a href="javascript:deleteBand('<?php echo $band->id . '\',\'' . $band->band ?>');" class="btn btn-danger btn-sm" ><i class="fas fa-trash-alt"></i> Delete</a>
+						<a href="javascript:deleteBand('<?php echo $band->id . '\',\'' . $band->band ?>');" class="btn btn-danger btn-sm" title="Delete"><i class="fas fa-trash-alt"></i></a>
                     </td>
                     <td>
-						<a href="javascript:saveBand('<?php echo $band->id . '\',\'' . $band->band ?>');" class="btn btn-primary btn-sm ld-ext-right btnband_<?php echo $band->id ?>" ><i class="fas fa-save"></i></i> Save<div class="ld ld-ring ld-spin"></div></a>
+						<a href="javascript:saveBand('<?php echo $band->id . '\',\'' . $band->band ?>');" class="btn btn-primary btn-sm ld-ext-right btnband_<?php echo $band->id ?>" title="Save band"><i class="fas fa-save"></i></i><div class="ld ld-ring ld-spin"></div></a>
                     </td>
 				</tr>
 

--- a/application/views/bands/index.php
+++ b/application/views/bands/index.php
@@ -23,64 +23,53 @@
 	</p>
     <div class="table-responsive">
 		
-    <table style="width:100%" class="modetable table table-striped">
+    <table style="width:100%" class="bandtable table table-striped">
 			<thead>
 				<tr>
-					<th class="select-filter" scope="col">Band</th>
-					<th class="select-filter" scope="col">Status</th>
-					<th scope="col">CQ</th>
-                    <th scope="col">DOK</th>
-                    <th scope="col">DXCC</th>
-                    <th scope="col">IOTA</th>
-					<th scope="col">SIG</th>
-                    <th scope="col">SOTA</th>
-                    <th scope="col">US Counties</th>
-                    <th scope="col">WAS</th>
-                    <th scope="col">VUCC</th>
-                    <th scope="col"></th>
-                    <th scope="col"></th>
-                    <th scope="col"></th>
+					<th>Band</th>
+					<th>Active</th>
+					<th>CQ</th>
+                    <th>DOK</th>
+                    <th>DXCC</th>
+                    <th>IOTA</th>
+					<th>SIG</th>
+                    <th>SOTA</th>
+                    <th>US Counties</th>
+                    <th>WAS</th>
+                    <th>VUCC</th>
+                    <th></th>
+                    <th></th>
+                    <th></th>
 
 				</tr>
 			</thead>
 			<tbody>
 				<?php foreach ($bands as $band) { ?>
 				<tr>
-					<td><?php echo $band->band?></td>
-                    <td><?php if ($band->active == 1) {echo 'Active';} else {echo 'Not Active';}; ?></td>
-					<td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->cq == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->dok == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->dxcc == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->iota == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->sig == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->sota == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->uscounties == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->was == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->vucc == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td style="text-align: center">
-                        <button onclick='javascript:deactivateMode()' class=' btn btn-secondary btn-sm'>Deactivate</button>
-                    </td>
+					<td><?php echo $band->band;?></td>
+                    <td class='band_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->active == 1) {echo 'checked';}?>></td>
+					<td class='cq_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->cq == 1) {echo 'checked';}?>></td>
+                    <td class='dok_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->dok == 1) {echo 'checked';}?>></td>
+                    <td class='dxcc_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->dxcc == 1) {echo 'checked';}?>></td>
+                    <td class='iota_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->iota == 1) {echo 'checked';}?>></td>
+                    <td class='sig_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->sig == 1) {echo 'checked';}?>></td>
+                    <td class='sota_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->sota == 1) {echo 'checked';}?>></td>
+                    <td class='uscounties_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->uscounties == 1) {echo 'checked';}?>></td>
+                    <td class='was_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->was == 1) {echo 'checked';}?>></td>
+                    <td class='vucc_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->vucc == 1) {echo 'checked';}?>></td>
 					<td>
-						<a href="<?php echo site_url('mode/edit')?>" class="btn btn-outline-primary btn-sm"><i class="fas fa-edit"></i> Edit</a>
+						<a href="javascript:editBand('<?php echo $band->id ?>');" class="btn btn-outline-primary btn-sm"><i class="fas fa-edit"></i> Edit</a>
 					</td>
 					<td>
-						<a href="javascript:deleteMode('');" class="btn btn-danger btn-sm" ><i class="fas fa-trash-alt"></i> Delete</a>
+						<a href="javascript:deleteBand('<?php echo $band->id . '\',\'' . $band->band ?>');" class="btn btn-danger btn-sm" ><i class="fas fa-trash-alt"></i> Delete</a>
+                    </td>
+                    <td>
+						<a href="javascript:saveBand('<?php echo $band->id . '\',\'' . $band->band ?>');" class="btn btn-primary btn-sm" ><i class="fas fa-save"></i></i> Save</a>
                     </td>
 				</tr>
 
 				<?php } ?>
 			</tbody>
-			<tfoot>
-				<tr>
-					<th></th>
-					<th></th>
-					<th></th>
-					<th></th>
-					<th></th>
-					<th></th>
-					<th></th>
-				</tr>
-			</tfoot>
 		<table>
 	</div>
   <br/>

--- a/application/views/bands/index.php
+++ b/application/views/bands/index.php
@@ -44,19 +44,19 @@
 				</tr>
 			</thead>
 			<tbody>
-				<?php foreach ($bands as $key => $band) { ?>
+				<?php foreach ($bands as $band) { ?>
 				<tr>
-					<td><?php echo $key?></td>
-                    <td>Active</td>
-					<td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
-                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" checked><label class="custom-control-label" for="customCheck1"></label></div></td>
+					<td><?php echo $band->band?></td>
+                    <td><?php if ($band->active == 1) {echo 'Active';} else {echo 'Not Active';}; ?></td>
+					<td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->cq == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->dok == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->dxcc == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->iota == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->sig == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->sota == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->uscounties == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->was == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
+                    <td><div class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" id="customCheck1" <?php if ($band->vucc == 1) {echo 'checked';}?>><label class="custom-control-label" for="customCheck1"></label></div></td>
                     <td style="text-align: center">
                         <button onclick='javascript:deactivateMode()' class=' btn btn-secondary btn-sm'>Deactivate</button>
                     </td>

--- a/application/views/bands/index.php
+++ b/application/views/bands/index.php
@@ -58,7 +58,7 @@
                     <td class='was_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->was == 1) {echo 'checked';}?>></td>
                     <td class='vucc_<?php echo $band->id ?>'><input type="checkbox" <?php if ($band->vucc == 1) {echo 'checked';}?>></td>
 					<td>
-						<a href="javascript:editBand('<?php echo $band->id ?>');" class="btn btn-outline-primary btn-sm"><i class="fas fa-edit"></i> Edit</a>
+						<a href="javascript:editBandDialog('<?php echo $band->bandid ?>');" class="btn btn-outline-primary btn-sm"><i class="fas fa-edit"></i> Edit</a>
 					</td>
 					<td>
 						<a href="javascript:deleteBand('<?php echo $band->id . '\',\'' . $band->band ?>');" class="btn btn-danger btn-sm" ><i class="fas fa-trash-alt"></i> Delete</a>

--- a/application/views/bands/index.php
+++ b/application/views/bands/index.php
@@ -64,7 +64,7 @@
 						<a href="javascript:deleteBand('<?php echo $band->id . '\',\'' . $band->band ?>');" class="btn btn-danger btn-sm" ><i class="fas fa-trash-alt"></i> Delete</a>
                     </td>
                     <td>
-						<a href="javascript:saveBand('<?php echo $band->id . '\',\'' . $band->band ?>');" class="btn btn-primary btn-sm" ><i class="fas fa-save"></i></i> Save</a>
+						<a href="javascript:saveBand('<?php echo $band->id . '\',\'' . $band->band ?>');" class="btn btn-primary btn-sm ld-ext-right btnband_<?php echo $band->id ?>" ><i class="fas fa-save"></i></i> Save<div class="ld ld-ring ld-spin"></div></a>
                     </td>
 				</tr>
 

--- a/application/views/contesting/index.php
+++ b/application/views/contesting/index.php
@@ -65,38 +65,16 @@
                                 <label for="band"><?php echo $this->lang->line('gen_hamradio_band'); ?></label>
 
                                 <select id="band" class="form-control form-control-sm" name="band">
-                                    <optgroup label="HF">
-                                        <option value="160m" <?php if($this->session->userdata('band') == "160m") { echo "selected=\"selected\""; } ?>>160m</option>
-                                        <option value="80m" <?php if($this->session->userdata('band') == "80m") { echo "selected=\"selected\""; } ?>>80m</option>
-                                        <option value="60m" <?php if($this->session->userdata('band') == "60m") { echo "selected=\"selected\""; } ?>>60m</option>
-                                        <option value="40m" <?php if($this->session->userdata('band') == "40m") { echo "selected=\"selected\""; } ?>>40m</option>
-                                        <option value="30m" <?php if($this->session->userdata('band') == "30m") { echo "selected=\"selected\""; } ?>>30m</option>
-                                        <option value="20m" <?php if($this->session->userdata('band') == "20m") { echo "selected=\"selected\""; } ?>>20m</option>
-                                        <option value="17m" <?php if($this->session->userdata('band') == "17m") { echo "selected=\"selected\""; } ?>>17m</option>
-                                        <option value="15m" <?php if($this->session->userdata('band') == "15m") { echo "selected=\"selected\""; } ?>>15m</option>
-                                        <option value="12m" <?php if($this->session->userdata('band') == "12m") { echo "selected=\"selected\""; } ?>>12m</option>
-                                        <option value="10m" <?php if($this->session->userdata('band') == "10m") { echo "selected=\"selected\""; } ?>>10m</option>
-                                    </optgroup>
-
-                                    <optgroup label="VHF">
-                                        <option value="6m" <?php if($this->session->userdata('band') == "6m") { echo "selected=\"selected\""; } ?>>6m</option>
-                                        <option value="4m" <?php if($this->session->userdata('band') == "4m") { echo "selected=\"selected\""; } ?>>4m</option>
-                                        <option value="2m" <?php if($this->session->userdata('band') == "2m") { echo "selected=\"selected\""; } ?>>2m</option>
-                                        <option value="1.25m" <?php if($this->session->userdata('band') == "1.25m") { echo "selected=\"selected\""; } ?>>1.25m</option>
-                                    </optgroup>
-
-                                    <optgroup label="UHF">
-                                        <option value="70cm" <?php if($this->session->userdata('band') == "70cm") { echo "selected=\"selected\""; } ?>>70cm</option>
-                                        <option value="33cm" <?php if($this->session->userdata('band') == "33cm") { echo "selected=\"selected\""; } ?>>33cm</option>
-                                    </optgroup>
-
-                                    <optgroup label="Microwave">
-                                        <option value="23cm" <?php if($this->session->userdata('band') == "23cm") { echo "selected=\"selected\""; } ?>>23cm</option>
-                                        <option value="13cm" <?php if($this->session->userdata('band') == "13cm") { echo "selected=\"selected\""; } ?>>13cm</option>
-                                        <option value="9cm" <?php if($this->session->userdata('band') == "9cm") { echo "selected=\"selected\""; } ?>>9cm</option>
-                                        <option value="6cm" <?php if($this->session->userdata('band') == "6cm") { echo "selected=\"selected\""; } ?>>6cm</option>
-                                        <option value="3cm" <?php if($this->session->userdata('band') == "3cm") { echo "selected=\"selected\""; } ?>>3cm</option>
-                                    </optgroup>
+                                <?php foreach($bands as $key=>$bandgroup) {
+                                    echo '<optgroup label="' . strtoupper($key) . '">';
+                                    foreach($bandgroup as $band) {
+                                        echo '<option value="' . $band . '"';
+                                        if ($this->session->userdata('band') == $band) echo ' selected';
+                                        echo '>' . $band . '</option>'."\n";
+                                    }
+                                    echo '</optgroup>';
+                                    }
+                                ?>
                                 </select>
                             </div>
 

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2249,6 +2249,10 @@ $(document).ready(function(){
 		<script src="<?php echo base_url(); ?>assets/js/sections/mode.js"></script>
     <?php } ?>
 
+    <?php if ($this->uri->segment(1) == "band") { ?>
+		<script src="<?php echo base_url(); ?>assets/js/sections/bands.js"></script>
+    <?php } ?>
+
 <?php if ($this->uri->segment(1) == "accumulated") { ?>
     <script src="<?php echo base_url(); ?>assets/js/chart.js"></script>
 	<script src="<?php echo base_url(); ?>assets/js/sections/accumulatedstatistics.js"></script>

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -150,6 +150,10 @@
 
 					<div class="dropdown-divider"></div>
 
+					<a class="dropdown-item" href="<?php echo site_url('band');?>" title="Manage Bands"><i class="fas fa-cog"></i> Bands</a>
+
+					<div class="dropdown-divider"></div>
+
 					<a class="dropdown-item" href="<?php echo site_url('themes');?>" title="Manage Themes"><i class="fas fa-cog"></i> Themes</a>
 
 					<div class="dropdown-divider"></div>

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -88,38 +88,16 @@
                                     <div class="form-group col-sm-6">
                                         <label for="freq">Band</label>
                                         <select id="band" class="form-control form-control-sm" name="band">
-                                            <optgroup label="HF">
-                                                <option value="160m" <?php if(strtolower($qso->COL_BAND == "160m")) { echo "selected=\"selected\""; } ?>>160m</option>
-                                                <option value="80m" <?php if(strtolower($qso->COL_BAND == "80m")) { echo "selected=\"selected\""; } ?>>80m</option>
-                                                <option value="60m" <?php if(strtolower($qso->COL_BAND == "60m")) { echo "selected=\"selected\""; } ?>>60m</option>
-                                                <option value="40m" <?php if(strtolower($qso->COL_BAND == "40m")) { echo "selected=\"selected\""; } ?>>40m</option>
-                                                <option value="30m" <?php if(strtolower($qso->COL_BAND == "30m")) { echo "selected=\"selected\""; } ?>>30m</option>
-                                                <option value="20m" <?php if(strtolower($qso->COL_BAND == "20m")) { echo "selected=\"selected\""; } ?>>20m</option>
-                                                <option value="17m" <?php if(strtolower($qso->COL_BAND == "17m")) { echo "selected=\"selected\""; } ?>>17m</option>
-                                                <option value="15m" <?php if(strtolower($qso->COL_BAND == "15m")) { echo "selected=\"selected\""; } ?>>15m</option>
-                                                <option value="12m" <?php if(strtolower($qso->COL_BAND == "12m")) { echo "selected=\"selected\""; } ?>>12m</option>
-                                                <option value="10m" <?php if(strtolower($qso->COL_BAND == "10m")) { echo "selected=\"selected\""; } ?>>10m</option>
-                                            </optgroup>
-
-                                            <optgroup label="VHF">
-                                                <option value="6m" <?php if(strtolower($qso->COL_BAND == "6m")) { echo "selected=\"selected\""; } ?>>6m</option>
-                                                <option value="4m" <?php if(strtolower($qso->COL_BAND == "4m")) { echo "selected=\"selected\""; } ?>>4m</option>
-                                                <option value="2m" <?php if(strtolower($qso->COL_BAND == "2m")) { echo "selected=\"selected\""; } ?>>2m</option>
-                                                <option value="1.25m" <?php if(strtolower($qso->COL_BAND == "1.25m")) { echo "selected=\"selected\""; } ?>>1.25m</option>
-                                            </optgroup>
-
-                                            <optgroup label="UHF">
-                                                <option value="70cm" <?php if(strtolower($qso->COL_BAND == "70cm")) { echo "selected=\"selected\""; } ?>>70cm</option>
-                                                <option value="33cm" <?php if(strtolower($qso->COL_BAND == "33cm")) { echo "selected=\"selected\""; } ?>>33cm</option>
-                                            </optgroup>
-
-                                            <optgroup label="Microwave">
-                                                <option value="23cm" <?php if(strtolower($qso->COL_BAND == "23cm")) { echo "selected=\"selected\""; } ?>>23cm</option>
-                                                <option value="13cm" <?php if(strtolower($qso->COL_BAND == "13cm")) { echo "selected=\"selected\""; } ?>>13cm</option>
-                                                <option value="9cm" <?php if(strtolower($qso->COL_BAND == "9cm")) { echo "selected=\"selected\""; } ?>>9cm</option>
-                                                <option value="6cm" <?php if(strtolower($qso->COL_BAND == "6cm")) { echo "selected=\"selected\""; } ?>>6cm</option>
-                                                <option value="3cm" <?php if(strtolower($qso->COL_BAND == "3cm")) { echo "selected=\"selected\""; } ?>>3cm</option>
-                                            </optgroup>
+                                        <?php foreach($bands as $key=>$bandgroup) {
+                                            echo '<optgroup label="' . strtoupper($key) . '">';
+                                            foreach($bandgroup as $band) {
+                                                echo '<option value="' . $band . '"';
+                                                if (strtolower($qso->COL_BAND) == $band) echo ' selected';
+                                                echo '>' . $band . '</option>'."\n";
+                                            }
+                                            echo '</optgroup>';
+                                            }
+                                        ?>
                                         </select>
                                     </div>
 
@@ -127,37 +105,17 @@
                                         <label for="freq">RX Band</label>
                                         <select id="band_rx" class="form-control form-control-sm" name="band_rx">
                                             <option value="" <?php if(strtolower($qso->COL_BAND_RX == "")) { echo "selected=\"selected\""; } ?>></option>
-                                            <optgroup label="HF">
-                                                <option value="160m" <?php if(strtolower($qso->COL_BAND_RX == "160m")) { echo "selected=\"selected\""; } ?>>160m</option>
-                                                <option value="80m" <?php if(strtolower($qso->COL_BAND_RX == "80m")) { echo "selected=\"selected\""; } ?>>80m</option>
-                                                <option value="60m" <?php if(strtolower($qso->COL_BAND_RX == "60m")) { echo "selected=\"selected\""; } ?>>60m</option>
-                                                <option value="40m" <?php if(strtolower($qso->COL_BAND_RX == "40m")) { echo "selected=\"selected\""; } ?>>40m</option>
-                                                <option value="30m" <?php if(strtolower($qso->COL_BAND_RX == "30m")) { echo "selected=\"selected\""; } ?>>30m</option>
-                                                <option value="20m" <?php if(strtolower($qso->COL_BAND_RX == "20m")) { echo "selected=\"selected\""; } ?>>20m</option>
-                                                <option value="17m" <?php if(strtolower($qso->COL_BAND_RX == "17m")) { echo "selected=\"selected\""; } ?>>17m</option>
-                                                <option value="15m" <?php if(strtolower($qso->COL_BAND_RX == "15m")) { echo "selected=\"selected\""; } ?>>15m</option>
-                                                <option value="12m" <?php if(strtolower($qso->COL_BAND_RX == "12m")) { echo "selected=\"selected\""; } ?>>12m</option>
-                                                <option value="10m" <?php if(strtolower($qso->COL_BAND_RX == "10m")) { echo "selected=\"selected\""; } ?>>10m</option>
-                                            </optgroup>
-
-                                            <optgroup label="VHF">
-                                                <option value="6m" <?php if(strtolower($qso->COL_BAND_RX == "6m")) { echo "selected=\"selected\""; } ?>>6m</option>
-                                                <option value="4m" <?php if(strtolower($qso->COL_BAND_RX == "4m")) { echo "selected=\"selected\""; } ?>>4m</option>
-                                                <option value="2m" <?php if(strtolower($qso->COL_BAND_RX == "2m")) { echo "selected=\"selected\""; } ?>>2m</option>
-                                                <option value="1.25m" <?php if(strtolower($qso->COL_BAND_RX == "1.25m")) { echo "selected=\"selected\""; } ?>>1.25m</option>
-                                            </optgroup>
-
-                                            <optgroup label="UHF">
-                                                <option value="70cm" <?php if(strtolower($qso->COL_BAND_RX == "70cm")) { echo "selected=\"selected\""; } ?>>70cm</option>
-                                                <option value="23cm" <?php if(strtolower($qso->COL_BAND_RX == "23cm")) { echo "selected=\"selected\""; } ?>>23cm</option>
-                                            </optgroup>
-
-                                            <optgroup label="Microwave">
-                                                <option value="13cm" <?php if(strtolower($qso->COL_BAND_RX == "13cm")) { echo "selected=\"selected\""; } ?>>13cm</option>
-                                                <option value="9cm" <?php if(strtolower($qso->COL_BAND_RX == "9cm")) { echo "selected=\"selected\""; } ?>>9cm</option>
-                                                <option value="6cm" <?php if(strtolower($qso->COL_BAND_RX == "6cm")) { echo "selected=\"selected\""; } ?>>6cm</option>
-                                                <option value="3cm" <?php if(strtolower($qso->COL_BAND_RX == "3cm")) { echo "selected=\"selected\""; } ?>>3cm</option>
-                                            </optgroup>
+                                            <?php foreach($bands as $key=>$bandgroup) {
+                                            echo '<optgroup label="' . strtoupper($key) . '">';
+                                            foreach($bandgroup as $band) {
+                                                echo '<option value="' . $band . '"';
+                                                if (strtolower($qso->COL_BAND_RX) == $band) echo ' selected';
+                                                echo '>' . $band . '</option>'."\n";
+                                            }
+                                            echo '</optgroup>';
+                                            }
+                                        ?>
+                                        </select>
                                         </select>
                                     </div>
                                 </div>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -91,38 +91,16 @@
                   <label for="band"><?php echo $this->lang->line('gen_hamradio_band'); ?></label>
 
                   <select id="band" class="form-control form-control-sm" name="band">
-                    <optgroup label="HF">
-                      <option value="160m" <?php if($this->session->userdata('band') == "160m") { echo "selected=\"selected\""; } ?>>160m</option>
-                      <option value="80m" <?php if($this->session->userdata('band') == "80m") { echo "selected=\"selected\""; } ?>>80m</option>
-                      <option value="60m" <?php if($this->session->userdata('band') == "60m") { echo "selected=\"selected\""; } ?>>60m</option>
-                      <option value="40m" <?php if($this->session->userdata('band') == "40m") { echo "selected=\"selected\""; } ?>>40m</option>
-                      <option value="30m" <?php if($this->session->userdata('band') == "30m") { echo "selected=\"selected\""; } ?>>30m</option>
-                      <option value="20m" <?php if($this->session->userdata('band') == "20m") { echo "selected=\"selected\""; } ?>>20m</option>
-                      <option value="17m" <?php if($this->session->userdata('band') == "17m") { echo "selected=\"selected\""; } ?>>17m</option>
-                      <option value="15m" <?php if($this->session->userdata('band') == "15m") { echo "selected=\"selected\""; } ?>>15m</option>
-                      <option value="12m" <?php if($this->session->userdata('band') == "12m") { echo "selected=\"selected\""; } ?>>12m</option>
-                      <option value="10m" <?php if($this->session->userdata('band') == "10m") { echo "selected=\"selected\""; } ?>>10m</option>
-                    </optgroup>
-
-                    <optgroup label="VHF">
-                      <option value="6m" <?php if($this->session->userdata('band') == "6m") { echo "selected=\"selected\""; } ?>>6m</option>
-                      <option value="4m" <?php if($this->session->userdata('band') == "4m") { echo "selected=\"selected\""; } ?>>4m</option>
-                      <option value="2m" <?php if($this->session->userdata('band') == "2m") { echo "selected=\"selected\""; } ?>>2m</option>
-                      <option value="1.25m" <?php if($this->session->userdata('band') == "1.25m") { echo "selected=\"selected\""; } ?>>1.25m</option>
-                    </optgroup>
-
-                    <optgroup label="UHF">
-                      <option value="70cm" <?php if($this->session->userdata('band') == "70cm") { echo "selected=\"selected\""; } ?>>70cm</option>
-                      <option value="33cm" <?php if($this->session->userdata('band') == "33cm") { echo "selected=\"selected\""; } ?>>33cm</option>
-                    </optgroup>
-
-                    <optgroup label="Microwave">
-                      <option value="23cm" <?php if($this->session->userdata('band') == "23cm") { echo "selected=\"selected\""; } ?>>23cm</option>
-                      <option value="13cm" <?php if($this->session->userdata('band') == "13cm") { echo "selected=\"selected\""; } ?>>13cm</option>
-                      <option value="9cm" <?php if($this->session->userdata('band') == "9cm") { echo "selected=\"selected\""; } ?>>9cm</option>
-                      <option value="6cm" <?php if($this->session->userdata('band') == "6cm") { echo "selected=\"selected\""; } ?>>6cm</option>
-                      <option value="3cm" <?php if($this->session->userdata('band') == "3cm") { echo "selected=\"selected\""; } ?>>3cm</option>
-                    </optgroup>
+                  <?php foreach($bands as $key=>$bandgroup) {
+                          echo '<optgroup label="' . strtoupper($key) . '">';
+                          foreach($bandgroup as $band) {
+                            echo '<option value="' . $band . '"';
+                              if ($this->session->userdata('band') == $band) echo ' selected';
+                              echo '>' . $band . '</option>'."\n";
+                          }
+                          echo '</optgroup>';
+                        }
+                  ?>
                   </select>
                 </div>
               </div>
@@ -208,38 +186,16 @@
                   <select id="band_rx" class="form-control" name="band_rx">
                     <option value="" <?php if($this->session->userdata('band_rx') == "") { echo "selected=\"selected\""; } ?>></option>
 
-                    <optgroup label="HF">
-                      <option value="160m" <?php if($this->session->userdata('band_rx') == "160m") { echo "selected=\"selected\""; } ?>>160m</option>
-                      <option value="80m" <?php if($this->session->userdata('band_rx') == "80m") { echo "selected=\"selected\""; } ?>>80m</option>
-                      <option value="60m" <?php if($this->session->userdata('band_rx') == "60m") { echo "selected=\"selected\""; } ?>>60m</option>
-                      <option value="40m" <?php if($this->session->userdata('band_rx') == "40m") { echo "selected=\"selected\""; } ?>>40m</option>
-                      <option value="30m" <?php if($this->session->userdata('band_rx') == "30m") { echo "selected=\"selected\""; } ?>>30m</option>
-                      <option value="20m" <?php if($this->session->userdata('band_rx') == "20m") { echo "selected=\"selected\""; } ?>>20m</option>
-                      <option value="17m" <?php if($this->session->userdata('band_rx') == "17m") { echo "selected=\"selected\""; } ?>>17m</option>
-                      <option value="15m" <?php if($this->session->userdata('band_rx') == "15m") { echo "selected=\"selected\""; } ?>>15m</option>
-                      <option value="12m" <?php if($this->session->userdata('band_rx') == "12m") { echo "selected=\"selected\""; } ?>>12m</option>
-                      <option value="10m" <?php if($this->session->userdata('band_rx') == "10m") { echo "selected=\"selected\""; } ?>>10m</option>
-                    </optgroup>
-
-                    <optgroup label="VHF">
-                      <option value="6m" <?php if($this->session->userdata('band_rx') == "6m") { echo "selected=\"selected\""; } ?>>6m</option>
-                      <option value="4m" <?php if($this->session->userdata('band_rx') == "4m") { echo "selected=\"selected\""; } ?>>4m</option>
-                      <option value="2m" <?php if($this->session->userdata('band_rx') == "2m") { echo "selected=\"selected\""; } ?>>2m</option>
-                      <option value="1.25m" <?php if($this->session->userdata('band_rx') == "1.25m") { echo "selected=\"selected\""; } ?>>1.25m</option>
-                    </optgroup>
-
-                    <optgroup label="UHF">
-                      <option value="70cm" <?php if($this->session->userdata('band_rx') == "70cm") { echo "selected=\"selected\""; } ?>>70cm</option>
-                      <option value="33cm" <?php if($this->session->userdata('band_rx') == "33cm") { echo "selected=\"selected\""; } ?>>33cm</option>
-                    </optgroup>
-
-                    <optgroup label="Microwave">
-                      <option value="23cm" <?php if($this->session->userdata('band_rx') == "23cm") { echo "selected=\"selected\""; } ?>>23cm</option>
-                      <option value="13cm" <?php if($this->session->userdata('band_rx') == "13cm") { echo "selected=\"selected\""; } ?>>13cm</option>
-                      <option value="9cm" <?php if($this->session->userdata('band_rx') == "9cm") { echo "selected=\"selected\""; } ?>>9cm</option>
-                      <option value="6cm" <?php if($this->session->userdata('band_rx') == "6cm") { echo "selected=\"selected\""; } ?>>6cm</option>
-                      <option value="3cm" <?php if($this->session->userdata('band_rx') == "3cm") { echo "selected=\"selected\""; } ?>>3cm</option>
-                    </optgroup>
+                  <?php foreach($bands as $key=>$bandgroup) {
+                          echo '<optgroup label="' . strtoupper($key) . '">';
+                          foreach($bandgroup as $band) {
+                            echo '<option value="' . $band . '"';
+                              if ($this->session->userdata('band_rx') == $band) echo ' selected';
+                              echo '>' . $band . '</option>'."\n";
+                          }
+                          echo '</optgroup>';
+                        }
+                  ?>
                   </select>
             </div>
 

--- a/assets/js/sections/bands.js
+++ b/assets/js/sections/bands.js
@@ -40,7 +40,11 @@ function createBand(form) {
 			url: base_url + 'index.php/band/create',
 			type: 'post',
 			data: {
-				'band': form.band.value
+				'band': form.band.value,
+				'bandgroup': form.bandgroup.value,
+				'ssbqrg': form.ssbqrg.value,
+				'dataqrg': form.dataqrg.value,
+				'cwqrg': form.cwqrg.value
 			},
 			success: function (html) {
 				location.reload();
@@ -84,7 +88,11 @@ function saveUpdatedBand(form) {
 			url: base_url + 'index.php/band/saveupdatedband',
 			type: 'post',
 			data: {'id': form.id.value,  
-				'band': form.band.value
+				'band': form.band.value,
+				'bandgroup': form.bandgroup.value,
+				'ssbqrg': form.ssbqrg.value,
+				'dataqrg': form.dataqrg.value,
+				'cwqrg': form.cwqrg.value
 			},
 			success: function (html) {
 				location.reload();

--- a/assets/js/sections/bands.js
+++ b/assets/js/sections/bands.js
@@ -15,7 +15,7 @@ function createBandDialog() {
 		success: function (html) {
 			BootstrapDialog.show({
 				title: 'Create band',
-				size: BootstrapDialog.SIZE_WIDE,
+				size: BootstrapDialog.SIZE_NORMAL,
 				cssClass: 'create-band-dialog',
 				nl2br: false,
 				message: html,
@@ -31,11 +31,59 @@ function createBandDialog() {
 }
 
 function createBand(form) {
-	if (form.band.value != '') {
+	$(".alert").remove();
+	if (form.band.value == "") {
+		$('#create_mode').prepend('<div class="alert alert-danger" role="alert"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Please enter a band!</div>');
+	}
+	else {
 		$.ajax({
 			url: base_url + 'index.php/band/create',
 			type: 'post',
 			data: {
+				'band': form.band.value
+			},
+			success: function (html) {
+				location.reload();
+			}
+		});
+	}
+}
+
+function editBandDialog(id) {
+	$.ajax({
+		url: base_url + 'index.php/band/edit',
+		type: 'post',
+		data: {
+			'id': id
+		},
+		success: function (html) {
+			BootstrapDialog.show({
+				title: 'Edit band',
+				size: BootstrapDialog.SIZE_NORMAL,
+				cssClass: 'edit-band-dialog',
+				nl2br: false,
+				message: html,
+				buttons: [{
+					label: 'Close',
+					action: function (dialogItself) {
+						dialogItself.close();
+					}
+				}]
+			});
+		}
+	});
+}
+
+function saveUpdatedBand(form) {
+	$(".alert").remove();
+	if (form.band.value == "") {
+		$('#edit_band_dialog').prepend('<div class="alert alert-danger" role="alert"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Please enter a band!</div>');
+	}
+	else {
+		$.ajax({
+			url: base_url + 'index.php/band/saveupdatedband',
+			type: 'post',
+			data: {'id': form.id.value,  
 				'band': form.band.value
 			},
 			success: function (html) {
@@ -62,7 +110,7 @@ function deleteBand(id, band) {
 						'id': id
 					},
 					success: function (data) {
-						$(".band_" + id).parent("tr:first").remove(); // removes mode from table
+						$(".band_" + id).parent("tr:first").remove(); // removes band from table
 					}
 				});
 			}

--- a/assets/js/sections/bands.js
+++ b/assets/js/sections/bands.js
@@ -1,0 +1,163 @@
+$('.bandtable').DataTable({
+	"pageLength": 25,
+	responsive: false,
+	ordering: false,
+	"scrollY": "500px",
+	"scrollCollapse": true,
+	"paging": false,
+	"scrollX": true
+});
+
+function createBandDialog() {
+	$.ajax({
+		url: base_url + 'index.php/band/create',
+		type: 'post',
+		success: function (html) {
+			BootstrapDialog.show({
+				title: 'Create band',
+				size: BootstrapDialog.SIZE_WIDE,
+				cssClass: 'create-band-dialog',
+				nl2br: false,
+				message: html,
+				buttons: [{
+					label: 'Close',
+					action: function (dialogItself) {
+						dialogItself.close();
+					}
+				}]
+			});
+		}
+	});
+}
+
+function createBand(form) {
+	if (form.mode.value != '') {
+		$.ajax({
+			url: base_url + 'index.php/band/create',
+			type: 'post',
+			data: {
+				'band': form.band.value
+			},
+			success: function (html) {
+				location.reload();
+			}
+		});
+	}
+}
+
+function deactivateBand(bandid) {
+	$.ajax({
+		url: base_url + 'index.php/band/deactivate',
+		type: 'post',
+		data: { 'id': bandid },
+		success: function (html) {
+			$(".mode_" + modeid).text('not active');
+			$('.btn_' + modeid).html('Activate');
+			$('.btn_' + modeid).attr('onclick', 'activateMode(' + modeid + ')')
+		}
+	});
+}
+
+function activateBand(bandid) {
+	$.ajax({
+		url: base_url + 'index.php/band/activate',
+		type: 'post',
+		data: { 'id': bandid },
+		success: function (html) {
+			$('.mode_' + modeid).text('active');
+			$('.btn_' + modeid).html('Deactivate');
+			$('.btn_' + modeid).attr('onclick', 'deactivateMode(' + modeid + ')')
+		}
+	});
+}
+
+function deleteBand(id, band) {
+	BootstrapDialog.confirm({
+		title: 'DANGER',
+		message: 'Warning! Are you sure you want to delete the following band: ' + band + '?',
+		type: BootstrapDialog.TYPE_DANGER,
+		closable: true,
+		draggable: true,
+		btnOKClass: 'btn-danger',
+		callback: function (result) {
+			if (result) {
+				$.ajax({
+					url: base_url + 'index.php/band/delete',
+					type: 'post',
+					data: {
+						'id': id
+					},
+					success: function (data) {
+						$(".band_" + id).parent("tr:first").remove(); // removes mode from table
+					}
+				});
+			}
+		}
+	});
+}
+
+function activateAllBands() {
+	BootstrapDialog.confirm({
+		title: 'DANGER',
+		message: 'Warning! Are you sure you want to activate all bands?',
+		type: BootstrapDialog.TYPE_DANGER,
+		closable: true,
+		draggable: true,
+		btnOKClass: 'btn-danger',
+		callback: function (result) {
+			if (result) {
+				$.ajax({
+					url: base_url + 'index.php/band/activateall',
+					type: 'post',
+					success: function (data) {
+						location.reload();
+					}
+				});
+			}
+		}
+	});
+}
+
+function deactivateAllBands() {
+	BootstrapDialog.confirm({
+		title: 'DANGER',
+		message: 'Warning! Are you sure you want to deactivate all bands?',
+		type: BootstrapDialog.TYPE_DANGER,
+		closable: true,
+		draggable: true,
+		btnOKClass: 'btn-danger',
+		callback: function (result) {
+			if (result) {
+				$.ajax({
+					url: base_url + 'index.php/band/deactivateall',
+					type: 'post',
+					success: function (data) {
+						location.reload();
+					}
+				});
+			}
+		}
+	});
+}
+
+function saveBand(id) {
+	$.ajax({
+		url: base_url + 'index.php/band/saveBand',
+		type: 'post',
+		data: {'id': id,  
+			'status': $(".band_"+id+" input[type='checkbox']").is(":checked"),
+			'cq': $(".cq_"+id+" input[type='checkbox']").is(":checked"),
+			'dok': $(".dok_"+id+" input[type='checkbox']").is(":checked"),
+			'dxcc': $(".dxcc_"+id+" input[type='checkbox']").is(":checked"),
+			'iota': $(".iota_"+id+" input[type='checkbox']").is(":checked"),
+			'sig': $(".sig_"+id+" input[type='checkbox']").is(":checked"),
+			'sota': $(".sota_"+id+" input[type='checkbox']").is(":checked"),
+			'uscounties': $(".uscounties_"+id+" input[type='checkbox']").is(":checked"),
+			'was': $(".was_"+id+" input[type='checkbox']").is(":checked"),
+			'vucc': $(".vucc_"+id+" input[type='checkbox']").is(":checked")
+		},
+		success: function (html) {
+			// Add an alert to say that it is saved. Vanish after 5 seconds.
+		}
+	});
+}

--- a/assets/js/sections/bands.js
+++ b/assets/js/sections/bands.js
@@ -141,6 +141,8 @@ function deactivateAllBands() {
 }
 
 function saveBand(id) {
+	$(".btnband_"+id).addClass('running');
+	$(".btnband_"+id).prop('disabled', true);
 	$.ajax({
 		url: base_url + 'index.php/band/saveBand',
 		type: 'post',
@@ -157,7 +159,10 @@ function saveBand(id) {
 			'vucc': $(".vucc_"+id+" input[type='checkbox']").is(":checked")
 		},
 		success: function (html) {
-			// Add an alert to say that it is saved. Vanish after 5 seconds.
+			$(".alert").remove();
+			$('.card-body').prepend('<div class="alert alert-success" role="alert"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>'+$(".band_"+id).parent("tr:first").find("td:first").text()+' band has been saved!</div>');
+			$(".btnband_"+id).removeClass('running');
+			$(".btnband_"+id).prop('disabled', false);
 		}
 	});
 }

--- a/assets/js/sections/bands.js
+++ b/assets/js/sections/bands.js
@@ -31,7 +31,7 @@ function createBandDialog() {
 }
 
 function createBand(form) {
-	if (form.mode.value != '') {
+	if (form.band.value != '') {
 		$.ajax({
 			url: base_url + 'index.php/band/create',
 			type: 'post',
@@ -43,32 +43,6 @@ function createBand(form) {
 			}
 		});
 	}
-}
-
-function deactivateBand(bandid) {
-	$.ajax({
-		url: base_url + 'index.php/band/deactivate',
-		type: 'post',
-		data: { 'id': bandid },
-		success: function (html) {
-			$(".mode_" + modeid).text('not active');
-			$('.btn_' + modeid).html('Activate');
-			$('.btn_' + modeid).attr('onclick', 'activateMode(' + modeid + ')')
-		}
-	});
-}
-
-function activateBand(bandid) {
-	$.ajax({
-		url: base_url + 'index.php/band/activate',
-		type: 'post',
-		data: { 'id': bandid },
-		success: function (html) {
-			$('.mode_' + modeid).text('active');
-			$('.btn_' + modeid).html('Deactivate');
-			$('.btn_' + modeid).attr('onclick', 'deactivateMode(' + modeid + ')')
-		}
-	});
 }
 
 function deleteBand(id, band) {


### PR DESCRIPTION
This is what I have done so far.

1. Migration script for tables and values.
2. Menu item for editing bands (admin -> bands).
3. Settings can be saved.
4. Awards that use bands->get_worked_bands, use the active bands.
5. Some analytics use the active bands.
6. Inserts entries in bandxuser when a new user is created.
7. Message when band is saved.
8. Can now create new band.
9. Can now edit band.
10. Band dropdown in gridsquare map now uses active bands
11. Added bandgroup to bands table. To be used in band dropdown in qso entry/contest qso entry.
12. QSO entry now fetches band/bandrx from DB.
13. Contest logging dropdown now fetches band from DB.
14.  Frequency library updated to use db.
15. QSO edit also uses bands from db (shows disabled as well for editing purposes).

I say this is done. I think I've updated all places necessary.