### PR TITLE
Add "-(/" as separators to ucwords to display DXCCs (more) correctly

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -49,7 +49,7 @@ class Logbook_model extends CI_Model {
 
     if($this->input->post('country') == "") {
       $dxcc = $this->check_dxcc_table(strtoupper(trim($this->input->post('callsign'))), $datetime);
-      $country = ucwords(strtolower($dxcc[1]));
+      $country = ucwords(strtolower($dxcc[1]), "- (/");
     } else {
       $country = $this->input->post('country');
     }
@@ -559,7 +559,7 @@ class Logbook_model extends CI_Model {
 
     $entity = $this->get_entity($this->input->post('dxcc_id'));
     $stationId = $this->input->post('station_profile');
-    $country = ucwords(strtolower($entity['name']));
+    $country = ucwords(strtolower($entity['name']), "- (/");
 
     // be sure that station belongs to user
     $CI =& get_instance();
@@ -2234,7 +2234,7 @@ class Logbook_model extends CI_Model {
         // Store or find country name
         // dxcc has higher priority to be consistent with qso create and edit
         if (isset($dxcc[1])) {
-            $country = ucwords(strtolower($dxcc[1]));
+            $country = ucwords(strtolower($dxcc[1]), "- (/");
         } else if (isset($record['country'])) {
             $country = $record['country'];
         }
@@ -2891,10 +2891,10 @@ class Logbook_model extends CI_Model {
 
                 if ($d[0] != 'Not Found'){
                     $sql = sprintf("update %s set COL_COUNTRY = '%s', COL_DXCC='%s' where COL_PRIMARY_KEY=%d",
-                                    $this->config->item('table_name'), addslashes(ucwords(strtolower($d[1]))), $d[0], $row['COL_PRIMARY_KEY']);
+                                    $this->config->item('table_name'), addslashes(ucwords(strtolower($d[1]), "- (/")), $d[0], $row['COL_PRIMARY_KEY']);
                     $this->db->query($sql);
                     //print($sql."\n");
-                    printf("Updating %s to %s and %s\n<br/>", $row['COL_PRIMARY_KEY'], ucwords(strtolower($d[1])), $d[0]);
+                    printf("Updating %s to %s and %s\n<br/>", $row['COL_PRIMARY_KEY'], ucwords(strtolower($d[1]), "- (/"), $d[0]);
                     $count++;
                 }
             }

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -184,7 +184,7 @@
                     <?php if($row->COL_COUNTRY != null) { ?>
                     <tr>
                         <td><?php echo $this->lang->line('general_word_country'); ?></td>
-                        <td><?php echo ucwords(strtolower(($row->COL_COUNTRY))); ?></td>
+                        <td><?php echo ucwords(strtolower(($row->COL_COUNTRY)), "- (/"); ?></td>
                     </tr>
                     <?php } ?>
 
@@ -349,7 +349,7 @@
                     <?php if($row->station_country) { ?>
                     <tr>
                         <td>Station Country</td>
-                        <td><?php echo ucwords(strtolower(($row->station_country))); ?></td>
+                        <td><?php echo ucwords(strtolower(($row->station_country)), "- (/"); ?></td>
                     </tr>
                     <?php } ?>
 


### PR DESCRIPTION
Lgging my QSO with E7/4O4A I discovered that the country name is shown as "Bosnia-herzegovina". I guess "Bosnia-Herzegovina" would be a little nicer. So added "- (/" as separators to ucwords functions. I guess \t\r\n\f\v are not needed (from the default setting). The result is:

![Screenshot from 2022-09-19 08-57-10](https://user-images.githubusercontent.com/7112907/190964980-61c21aa6-09d3-42db-ae6b-c68b043fce2b.png)
