### PR TITLE
Add user-editable identifier to CAT API interface

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 99;
+$config['migration_version'] = 100;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -39,6 +39,7 @@
 		{
 			echo "<tr class=\"titles\">";
 				echo "<td>Radio</td>";
+				echo "<td>Identifier</td>";
 				echo "<td>Frequency</td>";
 				echo "<td>Mode</td>";
 				echo "<td>Timestamp</td>" ;
@@ -48,6 +49,7 @@
 			{
 				echo "<tr>";
 				echo "<td>".$row->radio."</td>";
+				echo "<td>".$row->identifier."</td>";
 				if($row->frequency != "0" && $row->frequency != NULL) {
 					echo "<td>".$this->frequency->hz_to_mhz($row->frequency)."</td>";
 				} else {

--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -49,7 +49,7 @@
 			{
 				echo "<tr>";
 				echo "<td>".$row->radio."</td>";
-				echo "<td>".$row->identifier."</td>";
+				echo $row->identifier != "" ? "<td>".$row->identifier."</td>" : "<td>n/a</td>";
 				if($row->frequency != "0" && $row->frequency != NULL) {
 					echo "<td>".$this->frequency->hz_to_mhz($row->frequency)."</td>";
 				} else {

--- a/application/migrations/100_add_cat_identifier.php
+++ b/application/migrations/100_add_cat_identifier.php
@@ -1,0 +1,28 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/*
+   Creates column CAT identifier to distinguish multiple istances 
+   of same CAT software
+*/
+
+class Migration_add_cat_identifier extends CI_Migration {
+
+    public function up()
+    {
+        if ($this->db->table_exists('cat')) {
+            if (!$this->db->field_exists('identifier', 'cat')) {
+                $fields = array(
+                    'identifier VARCHAR(250) NULL AFTER `radio`',
+                );
+                $this->dbforge->add_column('cat', $fields);
+            }
+        }
+    }
+
+    public function down()
+    {
+        $this->dbforge->drop_column('cat', 'identifier');
+    }
+}

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -11,6 +11,7 @@
 			}
 
 			$this->db->where('radio', $result['radio']);
+			$this->db->where('identifier', $result['identifier']);
 			$this->db->where('user_id', $user_id);
 			$query = $this->db->get('cat');
 
@@ -57,6 +58,9 @@
 							if (isset($result['power'])) {
 								$data['power'] = $result['power'];
 							}
+							if (isset($result['identifier'])) {
+								$data['identifier'] = $result['identifier'];
+							}
 						} else {
 							$data = array(
 								'prop_mode' => $result['prop_mode'],
@@ -70,6 +74,9 @@
 							);
 							if (isset($result['power'])) {
 								$data['power'] = $result['power'];
+							}
+							if (isset($result['identifier'])) {
+								$data['identifier'] = $result['identifier'];
 							}
 						}
 
@@ -92,8 +99,12 @@
 						if (isset($result['power'])) {
 							$data['power'] = $result['power'];
 						}
+						if (isset($result['identifier'])) {
+							$data['identifier'] = $result['identifier'];
+						}
 
 						$this->db->where('id', $radio_id);
+						$this->db->where('identifier', $data['identifier']);
 						$this->db->where('user_id', $user_id);
 						$this->db->update('cat', $data);
 					}
@@ -133,6 +144,9 @@
 						if (isset($result['power'])) {
 							$data['power'] = $result['power'];
 						}
+						if (isset($result['identifier'])) {
+							$data['identifier'] = $result['identifier'];
+						}
 					} else {
 						$data = array(
 							'radio' => $result['radio'],
@@ -149,6 +163,9 @@
 						if (isset($result['power'])) {
 							$data['power'] = $result['power'];
 						}
+						if (isset($result['identifier'])) {
+							$data['identifier'] = $result['identifier'];
+						}
 					}
 				} else {
 					$data = array(
@@ -161,6 +178,9 @@
 
 					if (isset($result['power'])) {
 						$data['power'] = $result['power'];
+					}
+					if (isset($result['identifier'])) {
+						$data['identifier'] = $result['identifier'];
 					}
 				}
 
@@ -187,7 +207,7 @@
 
 		/* Return list of radios */
 		function radios() {
-			$this->db->select('id, radio');
+			$this->db->select('id, radio, identifier');
 			$this->db->where('user_id', $this->session->userdata('user_id'));
 			$query = $this->db->get('cat');
 

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -11,7 +11,9 @@
 			}
 
 			$this->db->where('radio', $result['radio']);
-			$this->db->where('identifier', $result['identifier']);
+			if (isset($result['identifier'])) {
+				$this->db->where('identifier', $result['identifier']);
+			}
 			$this->db->where('user_id', $user_id);
 			$query = $this->db->get('cat');
 
@@ -104,7 +106,9 @@
 						}
 
 						$this->db->where('id', $radio_id);
-						$this->db->where('identifier', $data['identifier']);
+						if (isset($result['identifier'])) {
+							$this->db->where('identifier', $data['identifier']);
+						}
 						$this->db->where('user_id', $user_id);
 						$this->db->update('cat', $data);
 					}

--- a/application/views/contesting/index.php
+++ b/application/views/contesting/index.php
@@ -88,7 +88,7 @@
                                 <select class="form-control form-control-sm radios" id="radio" name="radio">
                                     <option value="0" selected="selected"><?php echo $this->lang->line('general_word_none'); ?></option>
                                         <?php foreach ($radios->result() as $row) { ?>
-                                        <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?></option>
+                                        <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio." (".$row->identifier.")"; ?></option>
                                         <?php } ?>
                                 </select>
                             </div>

--- a/application/views/contesting/index.php
+++ b/application/views/contesting/index.php
@@ -88,7 +88,7 @@
                                 <select class="form-control form-control-sm radios" id="radio" name="radio">
                                     <option value="0" selected="selected"><?php echo $this->lang->line('general_word_none'); ?></option>
                                         <?php foreach ($radios->result() as $row) { ?>
-                                        <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio." (".$row->identifier.")"; ?></option>
+                                        <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; if ($row->identifier != "") echo " (".$row->identifier.")"; ?></option>
                                         <?php } ?>
                                 </select>
                             </div>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -165,7 +165,7 @@
               <select class="custom-select radios" id="radio" name="radio">
                 <option value="0" selected="selected"><?php echo $this->lang->line('general_word_none'); ?></option>
                 <?php foreach ($radios->result() as $row) { ?>
-                <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio." (".$row->identifier.")"; ?></option>
+                <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; if ($row->identifier != "") echo " (".$row->identifier.")"; ?></option>
                 <?php } ?>
                 </select>
             </div>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -165,7 +165,7 @@
               <select class="custom-select radios" id="radio" name="radio">
                 <option value="0" selected="selected"><?php echo $this->lang->line('general_word_none'); ?></option>
                 <?php foreach ($radios->result() as $row) { ?>
-                <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?></option>
+                <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio." (".$row->identifier.")"; ?></option>
                 <?php } ?>
                 </select>
             </div>


### PR DESCRIPTION
This adds a separate column to the CAT interfaces table so that multiple instances of a CAT interface can be distinguished. CloudLogCatQt has a running PR under https://github.com/myzinsky/CloudLogCatQt/pull/8 which adds a user editable field to allow the user to enter an identifier. This is shown in the hardware interfaces as well as the radio selection during logging of QSOs. This is currently work in progress. Reports by testers would be fine :)

![Screenshot from 2022-09-20 22-59-06](https://user-images.githubusercontent.com/7112907/191365029-9ef62d1f-3bee-4229-967b-0c813bb7b581.png)

![Screenshot from 2022-09-20 22-59-28](https://user-images.githubusercontent.com/7112907/191365047-e040af38-d784-4d7d-b280-b2f157db52bc.png)
