### PR TITLE
Use globally configured tile URL from DB options

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -562,7 +562,7 @@ function newpath(latlng1, latlng2, locator1, locator2) {
 
     var maidenhead = L.maidenheadqrb().addTo(map);
 
-    var osmUrl='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+    var osmUrl='<?php echo $this->optionslib->get_option('option_map_tile_server');?>';
     var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
     var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 9, attribution: osmAttrib}); 
 
@@ -615,7 +615,7 @@ function showActivatorsMap(call, count, grids) {
 
     var maidenhead = new L.maidenheadactivators(grid_four).addTo(map);
 
-    var osmUrl='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+    var osmUrl='<?php echo $this->optionslib->get_option('option_map_tile_server');?>';
     var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
     var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 9, attribution: osmAttrib}); 
 

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -713,7 +713,7 @@ function getLookupResult() {
 <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/moment.min.js"></script>
 <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/tempusdominus-bootstrap-4.min.js"></script>
 <script type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/L.Maidenhead.js"></script>
-    <script type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/leafembed.js"></script>
+    <script id="leafembed" type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/leafembed.js" tileUrl="<?php echo $this->optionslib->get_option('option_map_tile_server');?>"></script>
     <script type="text/javascript">
       $(function () {
         $('[data-toggle="tooltip"]').tooltip()
@@ -744,7 +744,7 @@ function getLookupResult() {
 
 <?php if ($this->uri->segment(1) == "map" && $this->uri->segment(2) == "") { ?>
     <script type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/L.Maidenhead.js"></script>
-    <script type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/leafembed.js"></script>
+    <script id="leafembed" type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/leafembed.js" tileUrl="<?php echo $this->optionslib->get_option('option_map_tile_server');?>"></script>
     <script type="text/javascript">
       $(function () {
         $('[data-toggle="tooltip"]').tooltip()
@@ -775,7 +775,7 @@ function getLookupResult() {
 
 <?php if ($this->uri->segment(1) == "" || $this->uri->segment(1) == "dashboard" ) { ?>
     <script type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/L.Maidenhead.js"></script>
-    <script type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/leafembed.js"></script>
+    <script id="leafembed" type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/leafembed.js" tileUrl="<?php echo $this->optionslib->get_option('option_map_tile_server');?>"></script>
     <script type="text/javascript">
       $(function () {
         $('[data-toggle="tooltip"]').tooltip()
@@ -871,7 +871,7 @@ $(document).on('keypress',function(e) {
 
 <?php if ($this->uri->segment(1) == "logbook" && $this->uri->segment(2) != "view") { ?>
     <script type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/L.Maidenhead.js"></script>
-    <script type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/leafembed.js"></script>
+    <script id="leafembed" type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/leafembed.js" tileUrl="<?php echo $this->optionslib->get_option('option_map_tile_server');?>"></script>
     <script type="text/javascript">
       $(function () {
          $('[data-toggle="tooltip"]').tooltip()

--- a/assets/js/leaflet/leafembed.js
+++ b/assets/js/leaflet/leafembed.js
@@ -10,6 +10,8 @@ var greenIcon = L.icon({
     iconSize:     [10, 10], // size of the icon
 });
 
+var osmUrl = $('#leafembed').attr("tileUrl");
+
 function initmap(ShowGrid = 'No', MapTag = 'map') {
     // set up AJAX request
     ajaxRequest=getXmlHttpObject();
@@ -22,7 +24,6 @@ function initmap(ShowGrid = 'No', MapTag = 'map') {
     map = new L.Map(MapTag);
 
     // create the tile layer with correct attribution
-    var osmUrl='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
     var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
     var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 9, attribution: osmAttrib});        
 


### PR DESCRIPTION
This basically addresses https://github.com/magicbug/Cloudlog/issues/1276 and makes `leafembed.js` use the tile server URL configured in the DB options. In addition to that it makes the distance plots by @AndreasK79 also use the configured URL instead of a hardcoded one. 
So one could use `https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png` as URL and have the map "German-ized":

![Screenshot from 2022-09-22 23-42-51](https://user-images.githubusercontent.com/7112907/191856662-5ae54565-24c0-43f0-af9a-3e7836763687.png)
