### PR TITLE
[WIP] Reset County selectized input correctly

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -322,12 +322,14 @@ function reset_fields() {
 	var $select = $('#wwff_ref').selectize();
 	var selectize = $select[0].selectize;
 	selectize.clear();
-	var $select = $('#darc_dok').selectize();
-	var selectize = $select[0].selectize;
-	selectize.clear();
-	$select = $('#stationCntyInput').selectize();
-	selectize = $select[0].selectize;
-	selectize.clear();
+	var $dok_select = $('#darc_dok').selectize();
+	var dok_selectize = $dok_select[0].selectize;
+	dok_selectize.clear();
+	var $county_select = $('#stationCntyInput').selectize();
+	var county_selectize = $county_select[0].selectize;
+	county_selectize.enable();
+	county_selectize.destroy();
+	county_selectize.clear();
 
 	mymap.setView(pos, 12);
 	mymap.removeLayer(markers);


### PR DESCRIPTION
This addresses Issue https://github.com/magicbug/Cloudlog/issues/1618. It seems that the selectized input also needs a re-enable and a destroy to be reset properly. Besides that I also added independend variable names for the selectzizes to be reset (as done in https://github.com/magicbug/Cloudlog/pull/1616). 

With this patch the US county field can be filled after a previous QSO with a non-US station was reset.