### PR TITLE
Time and Date shortcuts also for contesting page

### DIFF
--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -159,6 +159,27 @@ document.onkeyup = function (e) {
 
 };
 
+/* time input shortcut */
+$('#start_time').change(function() {
+	var raw_time = $(this).val();
+	if(raw_time.match(/^\d\[0-6]d$/)) {
+		raw_time = "0"+raw_time;
+	}
+	if(raw_time.match(/^[012]\d[0-5]\d$/)) {
+		raw_time = raw_time.substring(0,2)+":"+raw_time.substring(2,4);
+		$('#start_time').val(raw_time);
+	}
+});
+
+/* date input shortcut */
+$('#start_date').change(function() {
+	 raw_date = $(this).val();
+	if(raw_date.match(/^[12]\d{3}[01]\d[0123]\d$/)) {
+		raw_date = raw_date.substring(0,4)+"-"+raw_date.substring(4,6)+"-"+raw_date.substring(6,8);
+		$('#start_date').val(raw_date);
+	}
+});
+
 // On Key up check and suggest callsigns
 $("#callsign").keyup(function () {
 	var call = $(this).val();


### PR DESCRIPTION
We could use the stuff from https://github.com/magicbug/Cloudlog/pull/1143 also in Contesting section.