### PR TITLE
Only serve JS if maps are really to be displayed

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1292,7 +1292,7 @@ $(document).ready(function(){
 
 <?php } ?>
 
-<?php if ($this->uri->segment(1) == "gridsquares") { ?>
+<?php if ($this->uri->segment(1) == "gridsquares" && !empty($this->uri->segment(2))) { ?>
 
 <script type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/L.MaidenheadColoured.js"></script>
 
@@ -1435,7 +1435,7 @@ $(document).ready(function(){
 </script>
 <?php } ?>
 
-<?php if ($this->uri->segment(1) == "activated_grids") { ?>
+<?php if ($this->uri->segment(1) == "activated_grids" && !empty($this->uri->segment(2))) { ?>
 
 <script type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/L.MaidenheadColoured.js"></script>
 


### PR DESCRIPTION
This addresses an issue with a PHP/JS error for the entry page to gridsquares (and activated gridsquares). A PHP error results in invalid JS code. See:

![Screenshot from 2022-10-06 08-02-22](https://user-images.githubusercontent.com/7112907/194297261-1959694f-f4f8-4abf-8535-d7b41b8b4468.png)

![Screenshot from 2022-10-06 08-02-55](https://user-images.githubusercontent.com/7112907/194297286-b7a3f0e8-eebd-48bf-8546-2c116e192eb0.png)

So this is a hot fix for V2 to prevent this error from web server logs to be filled with PHP errors. The idea to have a map with ALL grids for the entry page will be coded separately.

@magicbug This is the description for the errors I mentioned in https://twitter.com/flo_0_/status/1577798050185191424?s=20&t=_sihXA_Lda0_BNOSweyG7g.
