### PR TITLE
Hide station locations of other users

### DIFF
--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -530,7 +530,7 @@
                                 <?php
                                 $CI =& get_instance();
                                 $CI->load->model('stations');
-                                $my_stations = $CI->stations->all();
+                                $my_stations = $CI->stations->all_of_user();
                                 ?>
 
                                 <div class="form-group">


### PR DESCRIPTION
This proposes a fix for https://github.com/magicbug/Cloudlog/issues/1664.