### PR TITLE
Change WWFF link to CQGMA

### DIFF
--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -212,7 +212,7 @@
                     <?php if($row->COL_WWFF_REF != null) { ?>
                     <tr>
                         <td><?php echo $this->lang->line('gen_hamradio_wwff_reference'); ?></td>
-                        <td><a href="https://wwff.co/directory/?showRef=<?php echo $row->COL_WWFF_REF; ?>" target="_blank"><?php echo $row->COL_WWFF_REF; ?></a></td>
+                        <td><a href="https://www.cqgma.org/zinfo.php?ref=<?php echo $row->COL_WWFF_REF; ?>" target="_blank"><?php echo $row->COL_WWFF_REF; ?></a></td>
                     </tr>
                     <?php } ?>
 
@@ -235,7 +235,7 @@
                            echo "<td><a href=\"https://www.mountainqrp.it/awards/referenza.php?ref=".$row->COL_SIG_INFO."\" target=\"_blank\">".$row->COL_SIG_INFO."</a></td>";
                            break;
                         case "WWFF":
-                           echo "<td><a href=\"https://wwff.co/directory/?showRef=".$row->COL_SIG_INFO."\" target=\"_blank\">".$row->COL_SIG_INFO."</a></td>";
+                           echo "<td><a href=\"https://www.cqgma.org/zinfo.php?ref=".$row->COL_SIG_INFO."\" target=\"_blank\">".$row->COL_SIG_INFO."</a></td>";
                            break;
                         case "POTA":
                            echo "<td><a href=\"https://pota.app/#/park/".$row->COL_SIG_INFO."\" target=\"_blank\">".$row->COL_SIG_INFO."</a></td>";

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -122,8 +122,8 @@ $( document ).ready(function() {
 	});
 
 	$('#wwff_ref').change(function(){
-		$('#wwff_info').html('<a target="_blank" href="https://wwff.co/directory/?showRef='+$('#wwff_ref').val()+'"><img width="32" height="32" src="'+base_url+'images/icons/wwff.co.png"></a>'); 
-		$('#wwff_info').attr('title', 'Lookup '+$('#wwff_ref').val()+' reference info on wwff.co');
+		$('#wwff_info').html('<a target="_blank" href="https://www.cqgma.org/zinfo.php?ref='+$('#wwff_ref').val()+'"><img width="32" height="32" src="'+base_url+'images/icons/wwff.co.png"></a>'); 
+		$('#wwff_info').attr('title', 'Lookup '+$('#wwff_ref').val()+' reference info on cqgma.org');
 	});
 
 	$('#darc_dok').selectize({


### PR DESCRIPTION
Currently, if you click on a WWFF reference, you will be redirected to "https://wwff.co/". Unfortunately this link often has less information available about that reference than "https://www.cqgma.org/".  Even on the DX cluster page of "https://wwff.co/" you will be redirected to "https://www.cqgma.org/" if you click on a reference on that page. If you still want to go to the original entry on "https://wwff.co/" you can still do that directly from the page on "https://www.cqgma.org/".

I therefore suggest to change that link within Cloudlog as well.
