### PR TITLE
Power Setting is overwritten if RIG Control does not provide a value

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1206,7 +1206,7 @@ $(document).on('keypress',function(e) {
           }
           $("#sat_name").val(data.satname);
           $("#sat_mode").val(data.satmode);
-          if(data.power == null or data.power != 0) {
+          if(data.power != null && data.power != 0) {
             $("#transmit_power").val(data.power);
           }
           $("#selectPropagation").val(data.prop_mode);

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1206,7 +1206,7 @@ $(document).on('keypress',function(e) {
           }
           $("#sat_name").val(data.satname);
           $("#sat_mode").val(data.satmode);
-          if(data.power != 0) {
+          if(data.power == null or data.power != 0) {
             $("#transmit_power").val(data.power);
           }
           $("#selectPropagation").val(data.prop_mode);


### PR DESCRIPTION
### Addresses the following bug:

**Describe the bug**

If CAT control is not providing a value for "Power", then the manually set power in the QSO window will be overwritten with a blank value in live QSO view.

**To Reproduce**

Open live QSO windows
Change value under "Station -> Power"
Enter a value in "Power"
Wait a second

--> Power value disappears

**Expected behaviour**

Either the power value should be correctly set from CAT control (which is not the case at least with CloudlogCAT and my Elecraft KX2), or the value you have entered should not be overwritten by CAT control.

**Additional context**

There is already code in application\views\interface_assets\footer.php which should do this:

```
if(data.power != 0) {
            $("#transmit_power").val(data.power);
          }
```
However this does not work here, as the value is not "0" but "NULL".

