### PR TITLE
Also export QSO where MY_SOTA_REF is set

### DIFF
--- a/application/models/Csv_model.php
+++ b/application/models/Csv_model.php
@@ -23,7 +23,7 @@ class Csv_model extends CI_Model
 		$sql .= "SELECT station_callsign, COL_MY_SOTA_REF, COL_QSO_DATE, COL_TIME_ON, COL_BAND, COL_MODE, COL_CALL, COL_SOTA_REF, COL_COMMENT
 			FROM ".$this->config->item('table_name').
 			" JOIN station_profile on station_profile.station_id = ".$this->config->item('table_name').".station_id".
-			" WHERE COL_SOTA_REF <> ''";
+			" WHERE COL_SOTA_REF <> '' OR COL_MY_SOTA_REF <> ''";
 
 		if ($station_id != "All") {
 			$sql .= ' and ' . $this->config->item('table_name'). '.station_id = ' . $station_id;

--- a/application/views/csv/data/export.php
+++ b/application/views/csv/data/export.php
@@ -35,6 +35,6 @@ $bands = array(
 );
 foreach ($qsos as $qso) {
    $timestamp = strtotime($qso['COL_TIME_ON']);
-   print "V2;".$qso['station_callsign'].";".$qso['COL_MY_SOTA_REF'].";".date('d/m/y', $timestamp).";".date('Hi', $timestamp).";".$bands[$qso['COL_BAND']].";".$qso['COL_MODE'].";".$qso['COL_CALL'].";".$qso['COL_SOTA_REF'].";".$qso['COL_COMMENT']."\n";
+   print "V2,".$qso['station_callsign'].",".$qso['COL_MY_SOTA_REF'].",".date('d/m/y', $timestamp).",".date('Hi', $timestamp).",".$bands[$qso['COL_BAND']].",".$qso['COL_MODE'].",".$qso['COL_CALL'].",".$qso['COL_SOTA_REF'].",".$qso['COL_COMMENT']."\n";
 }
 ?>

--- a/application/views/csv/data/export.php
+++ b/application/views/csv/data/export.php
@@ -27,11 +27,11 @@ $bands = array(
    "6cm"    => "5.6GHz",
    "3cm"    => "10GHz",
    "1.25cm" => "24GHz",
-   "6mm"    => "MICROWAVE",
-   "4mm"    => "MICROWAVE",
-   "2.5mm"  => "MICROWAVE",
-   "2mm"    => "MICROWAVE",
-   "1mm"    => "MICROWAVE"
+   "6mm"    => "MIcROWAVE",
+   "4mm"    => "MIcROWAVE",
+   "2.5mm"  => "MIcROWAVE",
+   "2mm"    => "MIcROWAVE",
+   "1mm"    => "MIcROWAVE"
 );
 foreach ($qsos as $qso) {
    $timestamp = strtotime($qso['COL_TIME_ON']);

--- a/application/views/csv/data/export.php
+++ b/application/views/csv/data/export.php
@@ -35,6 +35,6 @@ $bands = array(
 );
 foreach ($qsos as $qso) {
    $timestamp = strtotime($qso['COL_TIME_ON']);
-   print "V2,".$qso['station_callsign'].",".$qso['COL_MY_SOTA_REF'].",".date('d/m/y', $timestamp).",".date('Hi', $timestamp).",".$bands[$qso['COL_BAND']].",".$qso['COL_MODE'].",".$qso['COL_CALL'].",".$qso['COL_SOTA_REF'].",".$qso['COL_COMMENT']."\n";
+   print "V2;".$qso['station_callsign'].";".$qso['COL_MY_SOTA_REF'].";".date('d/m/y', $timestamp).";".date('Hi', $timestamp).";".$bands[$qso['COL_BAND']].";".$qso['COL_MODE'].";".$qso['COL_CALL'].";".$qso['COL_SOTA_REF'].";".$qso['COL_COMMENT']."\n";
 }
 ?>

--- a/application/views/csv/data/export.php
+++ b/application/views/csv/data/export.php
@@ -27,11 +27,11 @@ $bands = array(
    "6cm"    => "5.6GHz",
    "3cm"    => "10GHz",
    "1.25cm" => "24GHz",
-   "6mm"    => "MIcROWAVE",
-   "4mm"    => "MIcROWAVE",
-   "2.5mm"  => "MIcROWAVE",
-   "2mm"    => "MIcROWAVE",
-   "1mm"    => "MIcROWAVE"
+   "6mm"    => "MICROWAVE",
+   "4mm"    => "MICROWAVE",
+   "2.5mm"  => "MICROWAVE",
+   "2mm"    => "MICROWAVE",
+   "1mm"    => "MICROWAVE"
 );
 foreach ($qsos as $qso) {
    $timestamp = strtotime($qso['COL_TIME_ON']);


### PR DESCRIPTION
This fixes https://github.com/magicbug/Cloudlog/issues/1743 so that also QSOs with COL_MY_SOTA_REF are exported (e.g. my SOTA activcations and S2S QSOs).