### PR TITLE
Fix display of tQSL information

### DIFF
--- a/application/language/bulgarian/qslcard_lang.php
+++ b/application/language/bulgarian/qslcard_lang.php
@@ -9,8 +9,8 @@ $lang['qslcard_string_disk_space'] = 'дисково пространство з
 $lang['qslcard_info'] = 'QSL информация';
 $lang['qslcard_sent_bureau'] = 'QSL картичката е изпратена чрез бюрото';
 $lang['qslcard_sent_direct'] = 'QSL картичката е изпратена директно';
-$lang['qslcard_recv_bureau'] = 'QSL картичката е получена през бюрото';
-$lang['qslcard_recv_direct'] = 'QSL картичката е получена директно';
+$lang['qslcard_rcvd_bureau'] = 'QSL картичката е получена през бюрото';
+$lang['qslcard_rcvd_direct'] = 'QSL картичката е получена директно';
 
 $lang['qslcard_upload_front'] = 'Качване на лице на QSL картичка';
 $lang['qslcard_upload_back'] = 'Качване на гръб на QSL картичка';

--- a/application/language/chinese_simplified/qslcard_lang.php
+++ b/application/language/chinese_simplified/qslcard_lang.php
@@ -9,8 +9,8 @@ $lang['qslcard_string_disk_space'] = '的磁盘空间保存 QSL 卡片资源';
 $lang['qslcard_info'] = 'QSL 信息';
 $lang['qslcard_sent_bureau'] = 'QSL 卡片已由卡片局发出';
 $lang['qslcard_sent_direct'] = 'QSL 卡片已直邮发出';
-$lang['qslcard_recv_bureau'] = 'QSL 卡片已由卡片局接收';
-$lang['qslcard_recv_direct'] = 'QSL 卡片已直邮接收';
+$lang['qslcard_rcvd_bureau'] = 'QSL 卡片已由卡片局接收';
+$lang['qslcard_rcvd_direct'] = 'QSL 卡片已直邮接收';
 
 $lang['qslcard_upload_front'] = '上传 QSL 卡片正面图像';
 $lang['qslcard_upload_back'] = '上传 QSL 卡片背面图像';

--- a/application/language/english/qslcard_lang.php
+++ b/application/language/english/qslcard_lang.php
@@ -7,10 +7,10 @@ $lang['qslcard_string_your_are_using'] = 'You are using';
 $lang['qslcard_string_disk_space'] = 'of disk space to store QSL Card assets';
 
 $lang['qslcard_info'] = 'QSL Info';
-$lang['qslcard_sent_bureau'] = 'QSL Card has been sent via the bureau';
-$lang['qslcard_sent_direct'] = 'QSL Card has been sent via direct';
-$lang['qslcard_recv_bureau'] = 'QSL Card has been received via the bureau';
-$lang['qslcard_recv_direct'] = 'QSL Card has been received via direct';
+$lang['qslcard_sent_bureau'] = 'QSL Card has been sent via the bureau on';
+$lang['qslcard_sent_direct'] = 'QSL Card has been sent via direct on';
+$lang['qslcard_rcvd_bureau'] = 'QSL Card has been received via the bureau on';
+$lang['qslcard_rcvd_direct'] = 'QSL Card has been received via direct on';
 
 $lang['qslcard_upload_front'] = 'Uploaded QSL Card front image';
 $lang['qslcard_upload_back'] = 'Uploaded QSL Card back image';

--- a/application/language/finnish/qslcard_lang.php
+++ b/application/language/finnish/qslcard_lang.php
@@ -9,8 +9,8 @@ $lang['qslcard_string_disk_space'] = 'levytilaa QSL-korteille';
 $lang['qslcard_info'] = 'QSL Info';
 $lang['qslcard_sent_bureau'] = 'QSL kortti on lähetty buron kautta';
 $lang['qslcard_sent_direct'] = 'QSL kortti on lähetetty direktinä';
-$lang['qslcard_recv_bureau'] = 'QSL kortti on vastaanotettu buron kautta';
-$lang['qslcard_recv_direct'] = 'QSL kortti on vastaanotettu direktinä';
+$lang['qslcard_rcvd_bureau'] = 'QSL kortti on vastaanotettu buron kautta';
+$lang['qslcard_rcvd_direct'] = 'QSL kortti on vastaanotettu direktinä';
 
 $lang['qslcard_upload_front'] = 'QSL-kortin ladattu etukuva';
 $lang['qslcard_upload_back'] = 'QSL-kortin ladattu takakuva';

--- a/application/language/french/qslcard_lang.php
+++ b/application/language/french/qslcard_lang.php
@@ -8,8 +8,8 @@ $lang['qslcard_string_disk_space'] = 'd\'espace disque pour stocker les actifs d
 $lang['qslcard_info'] = 'Info QSL';
 $lang['qslcard_sent_bureau'] = 'La carte QSL a été envoyé via le bureau';
 $lang['qslcard_sent_direct'] = 'La carte QSL a été envoyé via direct';
-$lang['qslcard_recv_bureau'] = 'La carte QSL a été reçue via the bureau';
-$lang['qslcard_recv_direct'] = 'La carte QSL a été reçue via direct';
+$lang['qslcard_rcvd_bureau'] = 'La carte QSL a été reçue via the bureau';
+$lang['qslcard_rcvd_direct'] = 'La carte QSL a été reçue via direct';
 
 $lang['qslcard_upload_front'] = 'Image de la face de la carte QSL envoyée';
 $lang['qslcard_upload_back'] = 'Image du dos de la carte QSL envoyée';

--- a/application/language/german/qslcard_lang.php
+++ b/application/language/german/qslcard_lang.php
@@ -6,10 +6,10 @@ defined('BASEPATH') OR exit('Direkter Zugriff auf Skripte ist nicht erlaubt');
 $lang['qslcard_string_your_are_using'] = 'Du benutzt';
 $lang['qslcard_string_disk_space'] = 'an Speicherplatz, um QSL-Karteninformationen zu speichern';
 $lang['qslcard_info'] = 'QSL Info';
-$lang['qslcard_sent_bureau'] = 'QSL Karte wurde via Büro gesendet';
-$lang['qslcard_sent_direct'] = 'QSL Karte wurde direkt gesendet';
-$lang['qslcard_recv_bureau'] = 'QSL Karte wurde via Büro empfangen';
-$lang['qslcard_recv_direct'] = 'QSL Karte wurde direkt empfangen';
+$lang['qslcard_sent_bureau'] = 'QSL Karte wurde via Büro gesendet am';
+$lang['qslcard_sent_direct'] = 'QSL Karte wurde direkt gesendet am';
+$lang['qslcard_rcvd_bureau'] = 'QSL Karte wurde via Büro empfangen am';
+$lang['qslcard_rcvd_direct'] = 'QSL Karte wurde direkt empfangen am';
 
 $lang['qslcard_upload_front'] = 'QSL Kartenfront hochgeladen';
 $lang['qslcard_upload_back'] = 'QSL Kartenrückseite hochgeladen';

--- a/application/language/italian/qslcard_lang.php
+++ b/application/language/italian/qslcard_lang.php
@@ -9,8 +9,8 @@ $lang['qslcard_string_disk_space'] = 'di spazio sul disco per memorizzare le car
 $lang['qslcard_info'] = 'Info QSL';
 $lang['qslcard_sent_bureau'] = 'La cartolina QSL è stata inviata via bureau';
 $lang['qslcard_sent_direct'] = 'La cartolina QSL è stata inviata via diretta';
-$lang['qslcard_recv_bureau'] = 'La cartolina QSL è stata ricevuta via bureau';
-$lang['qslcard_recv_direct'] = 'La cartolina QSL è stata ricevuta via diretta';
+$lang['qslcard_rcvd_bureau'] = 'La cartolina QSL è stata ricevuta via bureau';
+$lang['qslcard_rcvd_direct'] = 'La cartolina QSL è stata ricevuta via diretta';
 
 $lang['qslcard_upload_front'] = 'Carica immagine fronte cartolina QSL';
 $lang['qslcard_upload_back'] = 'Carica immagine retro cartolina QSL';

--- a/application/language/polish/qslcard_lang.php
+++ b/application/language/polish/qslcard_lang.php
@@ -9,8 +9,8 @@ $lang['qslcard_string_disk_space'] = 'żeby przechować dane kart QSL';
 $lang['qslcard_info'] = 'QSL Info';
 $lang['qslcard_sent_bureau'] = 'Karta QSL została wysłana przez biuro';
 $lang['qslcard_sent_direct'] = 'Karta QSL została wysłana bezpośrednio';
-$lang['qslcard_recv_bureau'] = 'Karta QSL została otrzymana przez biuro';
-$lang['qslcard_recv_direct'] = 'Karta QSL została otrzymana bezpośrednio';
+$lang['qslcard_rcvd_bureau'] = 'Karta QSL została otrzymana przez biuro';
+$lang['qslcard_rcvd_direct'] = 'Karta QSL została otrzymana bezpośrednio';
 
 $lang['qslcard_upload_front'] = 'Wyślij awers karty QSL';
 $lang['qslcard_upload_back'] = 'Wyślij rewers karty QSL';

--- a/application/language/spanish/qslcard_lang.php
+++ b/application/language/spanish/qslcard_lang.php
@@ -9,8 +9,8 @@ $lang['qslcard_string_disk_space'] = 'de espacio en disco para almacenar recurso
 $lang['qslcard_info'] = 'QSL info';
 $lang['qslcard_sent_bureau'] = 'La QSL se envió vía buró';
 $lang['qslcard_sent_direct'] = 'La QSL se envió via directa';
-$lang['qslcard_recv_bureau'] = 'La QSL se recibió via buró';
-$lang['qslcard_recv_direct'] = 'La QSL se recibió vía directa';
+$lang['qslcard_rcvd_bureau'] = 'La QSL se recibió via buró';
+$lang['qslcard_rcvd_direct'] = 'La QSL se recibió vía directa';
 
 $lang['qslcard_upload_front'] = 'Imagen delantera de la QSL subida';
 $lang['qslcard_upload_back'] = 'Imagen trasera de la QSL subida';

--- a/application/language/swedish/qslcard_lang.php
+++ b/application/language/swedish/qslcard_lang.php
@@ -9,8 +9,8 @@ $lang['qslcard_string_disk_space'] = 'av diskutrymme för sparade QSL-kort';
 $lang['qslcard_info'] = 'QSL-info';
 $lang['qslcard_sent_bureau'] = 'QSL-kort har skickats via byrå';
 $lang['qslcard_sent_direct'] = 'QSL-kort har skickats direkt';
-$lang['qslcard_recv_bureau'] = 'QSL-kort har mottagits via byrå';
-$lang['qslcard_recv_direct'] = 'QSL-kort har mottagits direkt';
+$lang['qslcard_rcvd_bureau'] = 'QSL-kort har mottagits via byrå';
+$lang['qslcard_rcvd_direct'] = 'QSL-kort har mottagits direkt';
 
 $lang['qslcard_upload_front'] = 'Uppladdat QSL-kort bild framsida';
 $lang['qslcard_upload_back'] = 'Uppladdat QSL-kort bild baksida';

--- a/application/language/turkish/qslcard_lang.php
+++ b/application/language/turkish/qslcard_lang.php
@@ -9,8 +9,8 @@ $lang['qslcard_string_disk_space'] = 'kadar disk alanı kullanıyorsunuz';
 $lang['qslcard_info'] = 'QSL Bilgileri';
 $lang['qslcard_sent_bureau'] = 'QSL kartı büro üzerinden gönderildi';
 $lang['qslcard_sent_direct'] = 'QSL kartı direkt gönderildi';
-$lang['qslcard_recv_bureau'] = 'QSL kartı büro üzerinden alındı';
-$lang['qslcard_recv_direct'] = 'QSL kartı direkt alındı';
+$lang['qslcard_rcvd_bureau'] = 'QSL kartı büro üzerinden alındı';
+$lang['qslcard_rcvd_direct'] = 'QSL kartı direkt alındı';
 
 $lang['qslcard_upload_front'] = 'Yüklenen QSL kartının ön resmi';
 $lang['qslcard_upload_back'] = 'Yüklenen QSL kartının arka resmi';

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -266,17 +266,17 @@
                     <h3><?php echo $this->lang->line('qslcard_info'); ?></h3>
 
                     <?php if($row->COL_QSL_SENT == "Y" && $row->COL_QSL_SENT_VIA == "B") { ?>
-                    <p><?php echo $this->lang->line('qslcard_sent_bureau'); ?></p>
+                    <p><?php echo $this->lang->line('qslcard_sent_bureau'); ?> <?php $timestamp = strtotime($row->COL_QSLSDATE); echo date($custom_date_format, $timestamp); ?>.</p>
                     <?php } ?>
                     <?php if($row->COL_QSL_SENT == "Y" && $row->COL_QSL_SENT_VIA == "D") { ?>
-                    <p><?php echo $this->lang->line('qslcard_sent_direct'); ?></p>
+                    <p><?php echo $this->lang->line('qslcard_sent_direct'); ?> <?php $timestamp = strtotime($row->COL_QSLSDATE); echo date($custom_date_format, $timestamp); ?>.</p>
                     <?php } ?>
 
                     <?php if($row->COL_QSL_RCVD == "Y" && $row->COL_QSL_RCVD_VIA == "B") { ?>
-                    <p><?php echo $this->lang->line('qslcard_recvd_bureau'); ?></p>
+                    <p><?php echo $this->lang->line('qslcard_rcvd_bureau'); ?> <?php $timestamp = strtotime($row->COL_QSLRDATE); echo date($custom_date_format, $timestamp); ?>.</p>
                     <?php } ?>
                     <?php if($row->COL_QSL_RCVD == "Y" && $row->COL_QSL_RCVD_VIA == "D") { ?>
-                    <p><?php echo $this->lang->line('qslcard_recvd_direct'); ?></p>
+                    <p><?php echo $this->lang->line('qslcard_rcvd_direct'); ?> <?php $timestamp = strtotime($row->COL_QSLRDATE); echo date($custom_date_format, $timestamp); ?>.</p>
                     <?php } ?>
                 <?php } ?>
 


### PR DESCRIPTION
This fixes the issue about missing info on paper QSL cards on the QSO popup. See https://github.com/magicbug/Cloudlog/discussions/1751. This also includes display of date of sent/rcvd.