### PR TITLE
Fix error that leads to overwriting QSL R dates

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -622,7 +622,7 @@ class Logbook_model extends CI_Model {
 
     if ($qsl_recv == 'N') {
         $qslrdate = null;
-    } elseif (!$qso->COL_QSLRDATE || $qso->COL_QSL_RECV != $qsl_recv) {
+    } elseif (!$qso->COL_QSLRDATE || $qso->COL_QSL_RCVD != $qsl_recv) {
         $qslrdate = date('Y-m-d H:i:s');
     } else {
         $qslrdate = $qso->COL_QSLRDATE;


### PR DESCRIPTION
It seems that we have a bug in the Logbook model that leads to QSL received date being overwritten with the current date every time a QSO is edited. The reason is falsely named SQL column:

```
application/logs/log-2022-11-08.php:ERROR - 2022-11-08 21:01:21 --> Severity: Notice --> Undefined property: stdClass::$COL_QSL_RECV /var/www/cloudlog/application/models/Logbook_model.php 625
application/logs/log-2022-11-08.php:ERROR - 2022-11-08 21:01:48 --> Severity: Notice --> Undefined property: stdClass::$COL_QSL_RECV /var/www/cloudlog/application/models/Logbook_model.php 625
application/logs/log-2022-11-08.php:ERROR - 2022-11-08 21:03:03 --> Severity: Notice --> Undefined property: stdClass::$COL_QSL_RECV /var/www/cloudlog/application/models/Logbook_model.php 625
application/logs/log-2022-11-08.php:ERROR - 2022-11-08 21:11:38 --> Severity: Notice --> Undefined property: stdClass::$COL_QSL_RECV /var/www/cloudlog/application/models/Logbook_model.php 625
```