### PR TITLE
Accept P12 cert mime type, fix error page for failed LOTW cert uploads

### DIFF
--- a/application/config/mimes.php
+++ b/application/config/mimes.php
@@ -117,7 +117,7 @@ return array(
 	'json'  =>	array('application/json', 'text/json'),
 	'pem'   =>	array('application/x-x509-user-cert', 'application/x-pem-file', 'application/octet-stream'),
 	'p10'   =>	array('application/x-pkcs10', 'application/pkcs10'),
-	'p12'   =>	'application/octet-stream',
+	'p12'   =>	array('application/octet-stream', 'application/x-pkcs12'),
 	'p7a'   =>	'application/x-pkcs7-signature',
 	'p7c'   =>	array('application/pkcs7-mime', 'application/x-pkcs7-mime'),
 	'p7m'   =>	array('application/pkcs7-mime', 'application/x-pkcs7-mime'),

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -121,6 +121,9 @@ class Lotw extends CI_Controller {
         	// Upload of P12 Failed
             $error = array('error' => $this->upload->display_errors());
 
+			// Load DXCC Countrys List
+			$data['dxcc_list'] = $this->dxcc->list();
+
 			// Set Page Title
 			$data['page_title'] = "Logbook of the World";
 


### PR DESCRIPTION
My Cloudlog install failed to accept my LOTW certificate because it had what it viewed as an invalid mime type. The page it displayed to relate this error was also broken. This PR fixes both issues.

I can't be certain, but I'm pretty sure this is the same problem found in #1192.

Tracking this bug down was a wild goose chase. In summary:

 * CodeIgniter's upload library checks a file's mime type against allowed types for the given extension. Cloudlog was previously configured to only accept 'application/octet-stream'.
 * CodeIgniter attempts to learn the mime type in three ways:
   * If the `file` tool is installed, it is run on the file. `file` thinks these certs are 'application/octet-stream'.
   * If the PHP 'fileinfo' module is installed, it runs the `mime_content_type` function, which returns 'application/octet-stream'.
   * If neither of these are installed, it uses the 'Content-Type' header provided by the browser. Both Firefox and Chrome recognize LOTW certs as 'application/x-pkcs12'.

So, if you run Cloudlog with neither `file` nor the PHP 'fileinfo' module, LOTW cert uploads failed. When rendering the error page, the controller doesn't set the 'dxcc_list' variable, and the resulting broken error page looks like a DXCC info problem, even though this is completely unrelated to the actual issue.

I've added the correct mime type to the acceptable list, and along the way, fixed the error page.