### PR TITLE
Disable all other station profiles on activating one

### DIFF
--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -182,7 +182,6 @@ class Stations extends CI_Model {
 			'station_active' => null,
 		);
 		$this->db->where('user_id', $this->session->userdata('user_id'));
-		$this->db->where('station_id', $clean_current);
 		$this->db->update('station_profile', $current_default);
 
 		// Deselect current default	


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/magicbug/Cloudlog/issues/1783 by deactivating all station locations of that specific user before activating another one.