### PR TITLE
Make number of rows "sticky"

### DIFF
--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -490,6 +490,7 @@ function restoreContestSession() {
 				});
 				if (!$.fn.DataTable.isDataTable('.qsotable')) {
 					$('.qsotable').DataTable({
+						"stateSave": true,
 						"pageLength": 25,
 						responsive: false,
 						"scrollY": "400px",

--- a/assets/js/sections/station_locations.js
+++ b/assets/js/sections/station_locations.js
@@ -1,3 +1,5 @@
 $(document).ready( function () {
-    $('#station_locations_table').DataTable();
+    $('#station_locations_table').DataTable({
+        "stateSave": true
+    });
 } );

--- a/assets/js/sections/station_logbooks.js
+++ b/assets/js/sections/station_logbooks.js
@@ -1,7 +1,11 @@
 $(document).ready( function () {
-    $('#station_logbooks_table').DataTable();
+    $('#station_logbooks_table').DataTable({
+        "stateSave": true
+    });
 } );
 
 $(document).ready( function () {
-    $('#station_logbooks_linked_table').DataTable();
+    $('#station_logbooks_linked_table').DataTable({
+        "stateSave": true
+    });
 } );


### PR DESCRIPTION
This add the `stateSave` option to the DataTables so that the number of rows (which can be set from the top of the tables) is "sticky" and does not need to be re-set every time.