### PR TITLE
Make the QSL colors override any other stuff

### DIFF
--- a/assets/css/blue/overrides.css
+++ b/assets/css/blue/overrides.css
@@ -13,46 +13,6 @@ thead>tr>td {
     border-width: 2px;
 }
 
-.eqsl-green {
-    color: #00A000;
-    font-size: 1.1em;
-}
-
-.eqsl-red {
-    color: #F00;
-    font-size: 1.1em;
-}
-
-.qsl-green {
-    color: #00A000;
-    font-size: 1.1em;
-}
-
-.qsl-red {
-    color: #F00;
-    font-size: 1.1em;
-}
-
-.qsl-yellow {
-    color: #d39e00;
-    font-size: 1.1em;
-}
-
-.qsl-grey {
-    color: #dddddd;
-    font-size: 1.1em;
-}
-
-.lotw-green {
-    color: #00A000;
-    font-size: 1.1em;
-}
-
-.lotw-red {
-    color: #F00;
-    font-size: 1.1em;
-}
-
 .settings-nav {
     margin-bottom: 15px;
     list-style: none;

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -146,38 +146,38 @@ TD.eqsl{
 }
 
 .eqsl-green{
-    color: #00A000;
+    color: #00A000 !important;
     font-size: 1.1em;
 }
 .eqsl-red{
-    color: #F00;
+    color: #F00 !important;
     font-size: 1.1em;
 }
 .qsl-green{
-    color: #00A000;
+    color: #00A000 !important;
     font-size: 1.1em;
 }
 .qsl-red{
-    color: #F00;
+    color: #F00 !important;
     font-size: 1.1em;
 }
 .qsl-yellow{
-    color: #d39e00;
+    color: #d39e00 !important;
     font-size: 1.1em;
 }
 .qsl-grey{
-    color: #dddddd;
+    color: #dddddd !important;
     font-size: 1.1em;
 }
 TD.lotw{
     width: 33px;
 }
 .lotw-green{
-    color: #00A000;
+    color: #00A000 !important;
     font-size: 1.1em;
 }
 .lotw-red{
-    color: #F00;
+    color: #F00 !important;
     font-size: 1.1em;
 }
 


### PR DESCRIPTION
Initially reported by @dg9vh. The skins blue and superhero do not cover the QSL icon colors after merging https://github.com/magicbug/Cloudlog/pull/1792:

![Screenshot from 2022-11-21 09-46-46](https://user-images.githubusercontent.com/7112907/203034545-71208c31-79b5-4b10-a64b-9b6de4becf9c.png)

So those are not marked as !important so that external bootstrap css stuff cannot overwrite. 
@dg9vh can you please test?
