### PR TITLE
Fix CSS overrides for cosmo and superhero

### DIFF
--- a/assets/css/blue/overrides.css
+++ b/assets/css/blue/overrides.css
@@ -13,46 +13,6 @@ thead>tr>td {
     border-width: 2px;
 }
 
-.eqsl-green {
-    color: #00A000;
-    font-size: 1.1em;
-}
-
-.eqsl-red {
-    color: #F00;
-    font-size: 1.1em;
-}
-
-.qsl-green {
-    color: #00A000;
-    font-size: 1.1em;
-}
-
-.qsl-red {
-    color: #F00;
-    font-size: 1.1em;
-}
-
-.qsl-yellow {
-    color: #d39e00;
-    font-size: 1.1em;
-}
-
-.qsl-grey {
-    color: #dddddd;
-    font-size: 1.1em;
-}
-
-.lotw-green {
-    color: #00A000;
-    font-size: 1.1em;
-}
-
-.lotw-red {
-    color: #F00;
-    font-size: 1.1em;
-}
-
 .settings-nav {
     margin-bottom: 15px;
     list-style: none;

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -146,38 +146,39 @@ TD.eqsl{
 }
 
 .eqsl-green{
-    color: #00A000;
+    color: #00A000 !important;
     font-size: 1.1em;
+    text-decoration: none !important;
 }
 .eqsl-red{
-    color: #F00;
+    color: #F00 !important;
     font-size: 1.1em;
 }
 .qsl-green{
-    color: #00A000;
+    color: #00A000 !important;
     font-size: 1.1em;
 }
 .qsl-red{
-    color: #F00;
+    color: #F00 !important;
     font-size: 1.1em;
 }
 .qsl-yellow{
-    color: #d39e00;
+    color: #d39e00 !important;
     font-size: 1.1em;
 }
 .qsl-grey{
-    color: #dddddd;
+    color: #dddddd !important;
     font-size: 1.1em;
 }
 TD.lotw{
     width: 33px;
 }
 .lotw-green{
-    color: #00A000;
+    color: #00A000 !important;
     font-size: 1.1em;
 }
 .lotw-red{
-    color: #F00;
+    color: #F00 !important;
     font-size: 1.1em;
 }
 


### PR DESCRIPTION
The two skins cosmo and superhero have a separate CSS for links. This overrides the behaviour for eqsl-green classes so that colors are not overriden (i.e. just being white).