### PR TITLE
Add option to select previous QSL type

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 105;
+$config['migration_version'] = 106;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -533,7 +533,20 @@ class Logbook extends CI_Controller {
 					$html .= "<td>RST (R)</td>";
 					$html .= "<td>Band</td>";
 					$html .= "<td>Mode</td>";
-					$html .= "<td>QSL</td>";
+					switch($this->session->userdata('user_previous_qsl_type')) {
+						case 0:
+							$html .= "<td>".$this->lang->line('gen_hamradio_qsl')."</td>";
+							break;
+						case 1:
+							$html .= "<td>".$this->lang->line('lotw_short')."</td>";
+							break;
+						case 2:
+							$html .= "<td>".$this->lang->line('eqsl_short')."</td>";
+							break;
+						default:
+							$html .= "<td>".$this->lang->line('gen_hamradio_qsl')."</td>";
+							break;
+					}
 					$html .= "<td></td>";
 				$html .= "</tr>";
 
@@ -565,44 +578,88 @@ class Logbook extends CI_Controller {
 						$html .= "<td>".$row->COL_MODE."</td>";
 					else
 						$html .= "<td>".$row->COL_SUBMODE."</td>";
-					$html .= "<td class=\"qsl\">";
-					$html .= "<span class=\"qsl-";
-					switch ($row->COL_QSL_SENT) {
-						case "Y":
-							$html .= "green";
-							break;
-						case "Q":
-							$html .= "yellow";
-							break;
-						case "R":
-							$html .= "yellow";
-							break;
-						case "I":
-							$html .= "grey";
-							break;
-						default:
-						   $html .= "red";
+					if ($this->session->userdata('user_previous_qsl_type') == 1) {
+						$html .= "<td class=\"lotw\">";
+						$html .= "<span class=\"qsl-";
+						switch ($row->COL_LOTW_QSL_SENT) {
+							case "Y":
+								$html .= "green";
+								break;
+							default:
+								$html .= "red";
+						}
+						$html .= "\">&#9650;</span>";
+						$html .= "<span class=\"qsl-";
+						switch ($row->COL_LOTW_QSL_RCVD) {
+							case "Y":
+								$html .= "green";
+								break;
+							default:
+								$html .= "red";
+						}
+						$html .= "\">&#9660;</span>";
+						$html .= "</td>";
+					} else if ($this->session->userdata('user_previous_qsl_type') == 2) {
+						$html .= "<td class=\"eqsl\">";
+						$html .= "<span class=\"qsl-";
+						switch ($row->COL_EQSL_QSL_SENT) {
+							case "Y":
+								$html .= "green";
+								break;
+							default:
+								$html .= "red";
+						}
+						$html .= "\">&#9650;</span>";
+						$html .= "<span class=\"qsl-";
+						switch ($row->COL_EQSL_QSL_RCVD) {
+							case "Y":
+								$html .= "green";
+								break;
+							default:
+								$html .= "red";
+						}
+						$html .= "\">&#9660;</span>";
+						$html .= "</td>";
+					} else {
+						$html .= "<td class=\"qsl\">";
+						$html .= "<span class=\"qsl-";
+						switch ($row->COL_QSL_SENT) {
+							case "Y":
+								$html .= "green";
+								break;
+							case "Q":
+								$html .= "yellow";
+								break;
+							case "R":
+								$html .= "yellow";
+								break;
+							case "I":
+								$html .= "grey";
+								break;
+							default:
+								$html .= "red";
+						}
+						$html .= "\">&#9650;</span>";
+						$html .= "<span class=\"qsl-";
+						switch ($row->COL_QSL_RCVD) {
+							case "Y":
+								$html .= "green";
+								break;
+							case "Q":
+								$html .= "yellow";
+								break;
+							case "R":
+								$html .= "yellow";
+								break;
+							case "I":
+								$html .= "grey";
+								break;
+							default:
+								$html .= "red";
+						}
+						$html .= "\">&#9660;</span>";
+						$html .= "</td>";
 					}
-					$html .= "\">&#9650;</span>";
-					$html .= "<span class=\"qsl-";
-					switch ($row->COL_QSL_RCVD) {
-						case "Y":
-							$html .= "green";
-							break;
-						case "Q":
-							$html .= "yellow";
-							break;
-						case "R":
-							$html .= "yellow";
-							break;
-						case "I":
-							$html .= "grey";
-							break;
-						default:
-						   $html .= "red";
-					}
-					$html .= "\">&#9660;</span>";
-					$html .= "</td>";
 					$html .= "<td><span class=\"badge badge-info\">".$row->station_callsign."</span></td>";
 				$html .= "</tr>";
 			}

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -9,6 +9,8 @@ class User extends CI_Controller {
 		// Load language files
 		$this->lang->load(array(
 			'account',
+			'lotw',
+			'eqsl',
 		));
 	}
 
@@ -78,6 +80,7 @@ class User extends CI_Controller {
 				$data['user_column4'] = $this->input->post('user_column4');
 				$data['user_column5'] = $this->input->post('user_column5');
 				$data['user_show_profile_image'] = $this->input->post('user_show_profile_image');
+				$data['user_previous_qsl_type'] = $this->input->post('user_previous_qsl_type');
 				$this->load->view('user/add', $data);
 			} else {
 				$this->load->view('user/add', $data);
@@ -107,7 +110,8 @@ class User extends CI_Controller {
 				$this->input->post('user_column3'),
 				$this->input->post('user_column4'),
 				$this->input->post('user_column5'),
-				$this->input->post('user_show_profile_image'))) {
+				$this->input->post('user_show_profile_image'),
+				$this->input->post('user_previous_qsl_type'))) {
 				// Check for errors
 				case EUSERNAMEEXISTS:
 					$data['username_error'] = 'Username <b>'.$this->input->post('user_name').'</b> already in use!';
@@ -147,6 +151,7 @@ class User extends CI_Controller {
 			$data['user_column4'] = $this->input->post('user_column4');
 			$data['user_column5'] = $this->input->post('user_column5');
 			$data['user_show_profile_image'] = $this->input->post('user_show_profile_image');
+			$data['user_previous_qsl_type'] = $this->input->post('user_previous_qsl_type');
 			$this->load->view('user/add', $data);
 			$this->load->view('interface_assets/footer');
 		}
@@ -336,6 +341,12 @@ class User extends CI_Controller {
 				$data['user_show_profile_image'] = $q->user_show_profile_image;
 			}
 
+			if($this->input->post('user_previous_qsl_type')) {
+				$data['user_previous_qsl_type'] = $this->input->post('user_previous_qsl_type', false);
+			} else {
+				$data['user_previous_qsl_type'] = $q->user_previous_qsl_type;
+			}
+
 			if($this->input->post('user_column1')) {
 				$data['user_column1'] = $this->input->post('user_column1', true);
 			} else {
@@ -418,6 +429,7 @@ class User extends CI_Controller {
 			$data['user_column4'] = $this->input->post('user_column4');
 			$data['user_column5'] = $this->input->post('user_column5');
 			$data['user_show_profile_image'] = $this->input->post('user_show_profile_image');
+			$data['user_previous_qsl_type'] = $this->input->post('user_previous_qsl_type');
 			$this->load->view('user/edit');
 			$this->load->view('interface_assets/footer');
 		}

--- a/application/language/bulgarian/qso_lang.php
+++ b/application/language/bulgarian/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('Не е разрешен директен дост�
 // Tiles
 $lang['qso_title_qso_map'] = 'Карта на QSO';
 $lang['qso_title_suggestions'] = 'Предложения';
-$lang['qso_title_pervious_contacts'] = 'Предишни контакти';
+$lang['qso_title_previous_contacts'] = 'Предишни контакти';
 
 // Input Help Text on the /QSO Display
 $lang['qso_transmit_power_helptext'] = 'Посочете стойността на мощността във ватове. Въведете само цифри.';

--- a/application/language/chinese_simplified/qso_lang.php
+++ b/application/language/chinese_simplified/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 // Tiles
 $lang['qso_title_qso_map'] = 'QSO 地图';
 $lang['qso_title_suggestions'] = '建议';
-$lang['qso_title_pervious_contacts'] = '先前通联';
+$lang['qso_title_previous_contacts'] = '先前通联';
 
 // Input Help Text on the /QSO Display
 $lang['qso_transmit_power_helptext'] = '以瓦特为单位设置功率值。在输入中仅填写数值。';

--- a/application/language/czech/qso_lang.php
+++ b/application/language/czech/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 // Tiles
 $lang['qso_title_qso_map'] = 'Mapa spojení';
 $lang['qso_title_suggestions'] = 'Návrhy';
-$lang['qso_title_pervious_contacts'] = 'Předchozí spojení';
+$lang['qso_title_previous_contacts'] = 'Předchozí spojení';
 
 // Input Help Text on the /QSO Display
 $lang['qso_transmit_power_helptext'] = 'Zadej výkon ve Wattech. Jsou povolen pouz čísla';

--- a/application/language/dutch/qso_lang.php
+++ b/application/language/dutch/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('Directe toegang tot scripts is niet toegestaan');
 // Tiles
 $lang['qso_title_qso_map'] = 'QSO Kaart';
 $lang['qso_title_suggestions'] = 'Suggesties';
-$lang['qso_title_pervious_contacts'] = 'Eerdere verbindingen';
+$lang['qso_title_previous_contacts'] = 'Eerdere verbindingen';
 
 // Input Help Text on the /QSO Display
 $lang['qso_transmit_power_helptext'] = 'Geef vermogen in Watt. Vermeld alleen cijfers.';

--- a/application/language/english/qso_lang.php
+++ b/application/language/english/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 // Tiles
 $lang['qso_title_qso_map'] = 'QSO Map';
 $lang['qso_title_suggestions'] = 'Suggestions';
-$lang['qso_title_pervious_contacts'] = 'Previous Contacts';
+$lang['qso_title_previous_contacts'] = 'Previous Contacts';
 $lang['qso_title_image'] = 'Profile Picture';
 
 // Input Help Text on the /QSO Display

--- a/application/language/finnish/qso_lang.php
+++ b/application/language/finnish/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 // Tiles
 $lang['qso_title_qso_map'] = 'Vasta-aseman sijainti kartalla';
 $lang['qso_title_suggestions'] = 'Kutsumerkkiehdotukset';
-$lang['qso_title_pervious_contacts'] = 'Edelliset yhteydet';
+$lang['qso_title_previous_contacts'] = 'Edelliset yhteydet';
 
 // Input Help Text on the /QSO Display
 $lang['qso_transmit_power_helptext'] = 'Anna teholukema Watteina käyttäen vain numeroita.';

--- a/application/language/french/qso_lang.php
+++ b/application/language/french/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 // Tiles
 $lang['qso_title_qso_map'] = 'Carte QSO';
 $lang['qso_title_suggestions'] = 'Suggestions';
-$lang['qso_title_pervious_contacts'] = 'Contacts précédents';
+$lang['qso_title_previous_contacts'] = 'Contacts précédents';
 
 // Input Help Text on the /QSO Display
 $lang['qso_transmit_power_helptext'] = 'Saisissez la ouissance en Watts en utilisant uniquement des chiffres.';

--- a/application/language/german/qso_lang.php
+++ b/application/language/german/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('Direkter Zugriff auf Skripte ist nicht erlaubt');
 // Tiles
 $lang['qso_title_qso_map'] = 'QSO-Karte';
 $lang['qso_title_suggestions'] = 'Vorschläge';
-$lang['qso_title_pervious_contacts'] = 'Vorherige Kontakte';
+$lang['qso_title_previous_contacts'] = 'Vorherige Kontakte';
 $lang['qso_title_image'] = 'Profilbild';
 
 // Input Help Text on the /QSO Display

--- a/application/language/italian/qso_lang.php
+++ b/application/language/italian/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('Non è permesso l\'accesso diretto allo script');
 // Tiles
 $lang['qso_title_qso_map'] = 'Mappa QSO';
 $lang['qso_title_suggestions'] = 'Suggerimenti';
-$lang['qso_title_pervious_contacts'] = 'Contatti Precedenti';
+$lang['qso_title_previous_contacts'] = 'Contatti Precedenti';
 $lang['qso_title_image'] = 'Immagine Profilo';
 
 // Input Help Text on the /QSO Display

--- a/application/language/polish/qso_lang.php
+++ b/application/language/polish/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 // Tiles
 $lang['qso_title_qso_map'] = 'Mapa łączności';
 $lang['qso_title_suggestions'] = 'Sugestie';
-$lang['qso_title_pervious_contacts'] = 'Poprzednie łączności';
+$lang['qso_title_previous_contacts'] = 'Poprzednie łączności';
 
 // Input Help Text on the /QSO Display
 $lang['qso_transmit_power_helptext'] = 'Wpisz wartość mocy w watach. W polu podaj same cyfry.';

--- a/application/language/russian/qso_lang.php
+++ b/application/language/russian/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 // Tiles
 $lang['qso_title_qso_map'] = 'Карта QSO';
 $lang['qso_title_suggestions'] = 'Предложения';
-$lang['qso_title_pervious_contacts'] = 'Предыдущие контакты';
+$lang['qso_title_previous_contacts'] = 'Предыдущие контакты';
 $lang['qso_title_image'] = 'Profile Picture';
 
 // Input Help Text on the /QSO Display

--- a/application/language/spanish/qso_lang.php
+++ b/application/language/spanish/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 // Tiles
 $lang['qso_title_qso_map'] = 'Mapa de QSO';
 $lang['qso_title_suggestions'] = 'Sugerencias';
-$lang['qso_title_pervious_contacts'] = 'Contactos previos';
+$lang['qso_title_previous_contacts'] = 'Contactos previos';
 
 // Input Help Text on the /QSO Display
 $lang['qso_transmit_power_helptext'] = 'Especifique el valor de potencia en Watios (W). Incluya solo números.';

--- a/application/language/swedish/qso_lang.php
+++ b/application/language/swedish/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 // Tiles
 $lang['qso_title_qso_map'] = 'QSO-karta';
 $lang['qso_title_suggestions'] = 'Förslag';
-$lang['qso_title_pervious_contacts'] = 'Föregående QSOn';
+$lang['qso_title_previous_contacts'] = 'Föregående QSOn';
 $lang['qso_title_image'] = 'Profilbild';
 
 // Input Help Text on the /QSO Display

--- a/application/language/turkish/qso_lang.php
+++ b/application/language/turkish/qso_lang.php
@@ -5,7 +5,7 @@ defined('BASEPATH') OR exit('Doğrudan komut dosyası erişimine izin verilmez')
 // Tiles
 $lang['qso_title_qso_map'] = 'QSO Haritası';
 $lang['qso_title_suggestions'] = 'Öneriler';
-$lang['qso_title_pervious_contacts'] = 'Önceki Görüşmeler';
+$lang['qso_title_previous_contacts'] = 'Önceki Görüşmeler';
 $lang['qso_title_image'] = 'Profil Resmi';
 
 // Input Help Text on the /QSO Display

--- a/application/migrations/106_add_user_previous_qsl_type.php
+++ b/application/migrations/106_add_user_previous_qsl_type.php
@@ -1,0 +1,28 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/*
+ *   This adds an option to select the QSL type for previous QSOs
+*/
+
+class Migration_add_user_previous_qsl_type extends CI_Migration {
+
+	public function up()
+	{
+		if (!$this->db->field_exists('user_previous_qsl_type', 'users')) {
+			$fields = array(
+				'user_previous_qsl_type integer DEFAULT 0',
+			);
+
+			$this->dbforge->add_column('users', $fields);
+		}
+	}
+
+	public function down()
+	{
+		if ($this->db->field_exists('user_previous_qsl_type', 'users')) {
+			$this->dbforge->drop_column('users', 'user_previous_qsl_type');
+		}
+	}
+}

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -114,7 +114,7 @@ class User_Model extends CI_Model {
 	function add($username, $password, $email, $type, $firstname, $lastname, $callsign, $locator, $timezone,
 		$measurement, $user_date_format, $user_stylesheet, $user_qth_lookup, $user_sota_lookup, $user_wwff_lookup,
 		$user_show_notes, $user_column1, $user_column2, $user_column3, $user_column4, $user_column5,
-	  	$user_show_profile_image) {
+		$user_show_profile_image, $user_previous_qsl_type) {
 		// Check that the user isn't already used
 		if(!$this->exists($username)) {
 			$data = array(
@@ -140,6 +140,7 @@ class User_Model extends CI_Model {
 				'user_column4' => xss_clean($user_column4),
 				'user_column5' => xss_clean($user_column5),
 				'user_show_profile_image' => xss_clean($user_show_profile_image),
+				'user_previous_qsl_type' => xss_clean($user_previous_qsl_type),
 			);
 
 			// Check the password is valid
@@ -193,6 +194,7 @@ class User_Model extends CI_Model {
 					'user_column4' => xss_clean($fields['user_column4']),
 					'user_column5' => xss_clean($fields['user_column5']),
 					'user_show_profile_image' => xss_clean($fields['user_show_profile_image']),
+					'user_previous_qsl_type' => xss_clean($fields['user_previous_qsl_type']),
 				);
 
 				// Check to see if the user is allowed to change user levels
@@ -310,6 +312,7 @@ class User_Model extends CI_Model {
 			'user_column3' => isset($u->row()->user_column3) ? $u->row()->user_column3: 'RSTR',
 			'user_column4' => isset($u->row()->user_column4) ? $u->row()->user_column4: 'Band',
 			'user_column5' => isset($u->row()->user_column5) ? $u->row()->user_column5: 'Country',
+			'user_previous_qsl_type' => isset($u->row()->user_previous_qsl_type) ? $u->row()->user_previous_qsl_type: 0,
 			'active_station_logbook' => $u->row()->active_station_logbook,
 		);
 

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -503,7 +503,7 @@
     <?php } ?>
 
     <div class="card previous-qsos">
-      <div class="card-header"><h4 class="card-title" style="font-size: 16px; font-weight: bold;"><?php echo $this->lang->line('qso_title_pervious_contacts'); ?></h4></div>
+      <div class="card-header"><h4 class="card-title" style="font-size: 16px; font-weight: bold;"><?php echo $this->lang->line('qso_title_previous_contacts'); ?></h4></div>
 
         <div id="partial_view" style="font-size: 0.95rem;"></div>
 

--- a/application/views/user/add.php
+++ b/application/views/user/add.php
@@ -248,6 +248,15 @@
 		</div>
 
 		<div class="form-group">
+			<label for="previousqsltype">Select the type of QSL to show in the previous QSOs section.</label>
+			<select class="custom-select" id="previousqsltype" name="user_previous_qsl_type">
+				<option value="0"><?php echo $this->lang->line('gen_hamradio_qsl'); ?></option>
+				<option value="1"><?php echo $this->lang->line('lotw_short'); ?></option>
+				<option value="2"><?php echo $this->lang->line('eqsl_short'); ?></option>
+			</select>
+		</div>
+
+		<div class="form-group">
 			<label for="profileimages">Show profile picture of QSO partner from qrz.com/hamqth.com profile in the log QSO section.</label>
 			<select class="custom-select" id="profileimages" name="user_show_profile_image">
 				<option value="0"><?php echo $this->lang->line('general_word_no'); ?></option>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -441,6 +441,29 @@
 			<div class="col-md">
 				<div class="card">
 					<div class="card-header">
+						Previous QSL Type
+					</div>
+					<div class="card-body">
+						<div class="form-group">
+							<label for="profileimages">Select the type of QSL to show in the previous QSOs section.</label>
+							<select class="custom-select" id="previousqsltype" name="user_previous_qsl_type">
+								<option value="0" <?php if ($user_previous_qsl_type == 0) { echo " selected =\"selected\""; } ?>><?php echo $this->lang->line('gen_hamradio_qsl'); ?></option>
+								<option value="1" <?php if ($user_previous_qsl_type == 1) { echo " selected =\"selected\""; } ?>><?php echo $this->lang->line('lotw_short'); ?></option>
+								<option value="2" <?php if ($user_previous_qsl_type == 2) { echo " selected =\"selected\""; } ?>><?php echo $this->lang->line('eqsl_short'); ?></option>
+							</select>
+						</div>
+
+					</div>
+				</div>
+			</div>
+
+		</div>
+		<br>
+		<div class="row">
+			<!-- qrz.com Images -->
+			<div class="col-md">
+				<div class="card">
+					<div class="card-header">
 						qrz.com/hamqth.com Images
 					</div>
 					<div class="card-body">

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -437,7 +437,6 @@
 		</div>
 		<br>
 		<div class="row">
-			<!-- qrz.com Images -->
 			<div class="col-md">
 				<div class="card">
 					<div class="card-header">


### PR DESCRIPTION
This addresses https://github.com/magicbug/Cloudlog/discussions/1806 by adding a config option to the user profile to select QSL type to be of QSL, LotW or eQSL for the QSOs being show in the previous QSOs section while logging a QSO:

![Screenshot from 2022-11-25 00-12-19](https://user-images.githubusercontent.com/7112907/203873812-6c044c16-894e-45df-8d47-fd31de628cc5.png)

![Screenshot from 2022-11-25 00-12-55](https://user-images.githubusercontent.com/7112907/203873833-233b2d9b-4c54-4fb7-b0fb-870f00717345.png)
