### PR TITLE
Also reset callsign image display

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -749,4 +749,6 @@ function resetDefaultQSOFields() {
 	$('#callsign_info').removeClass("badge-success");
 	$('#callsign_info').removeClass("badge-danger");
 	$('#input_usa_state').val("");
+	$('#callsign-image').attr('style', 'display: none;');
+	$('#callsign-image-content').text("");
 }


### PR DESCRIPTION
This also hides/resets the callsign image content. Otherwise wrong image is shown after one changed the call to log.