### PR TITLE
Add "Electronic" as QSL selection

### DIFF
--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -167,8 +167,10 @@
 		<button type="button" class="btn btn-sm btn-primary" id="btnUpdateFromCallbook">Update from Callbook</button>
 		<button type="button" class="btn btn-sm btn-primary" id="queueBureau">Queue Bureau</button>
 		<button type="button" class="btn btn-sm btn-primary" id="queueDirect">Queue Direct</button>
+        <button type="button" class="btn btn-sm btn-primary" id="queueElectronic">Queue Electronic</button>
 		<button type="button" class="btn btn-sm btn-success" id="sentBureau">Sent Bureau</button>
 		<button type="button" class="btn btn-sm btn-success" id="sentDirect">Sent Direct</button>
+        <button type="button" class="btn btn-sm btn-success" id="sentElectronic">Sent Electronic</button>
 		<button type="button" class="btn btn-sm btn-warning" id="dontSend">Don't Send</button>
 		<button type="button" class="btn btn-sm btn-info" id="exportAdif">Create ADIF</button>
         <button type="button" class="btn btn-sm btn-danger" id="deleteQsos">Delete</button>

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -295,12 +295,20 @@ $(document).ready(function () {
 		handleQsl('Q','D', 'queueDirect');
 	});
 
+    $('#queueElectronic').click(function (event) {
+		handleQsl('Q','E', 'queueElectronic');
+	});
+
 	$('#sentBureau').click(function (event) {
 		handleQsl('Y','B', 'sentBureau');
 	});
 
 	$('#sentDirect').click(function (event) {
 		handleQsl('Y','D', 'sentDirect');
+	});
+
+    $('#sentElectronic').click(function (event) {
+		handleQsl('Y','E', 'sentElectronic');
 	});
 
 	$('#dontSend').click(function (event) {


### PR DESCRIPTION
In the new advanced view, I am missing a possibility to mark QSOs for "Electronic QSLs". I use this e.g. if someone sends me a mail with a QSL card as attachment. I normally will then return my QSL card by the same way.

This pull requests adds this functionality.