### PR TITLE
Fix date validation on ADIF export

### DIFF
--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -82,12 +82,12 @@ class adif_data extends CI_Model {
         $this->db->where($this->config->item('table_name').'.station_id', $station_id);
 
         // If date is set, we format the date and add it to the where-statement
-        if ($from != 0) {
+        if ($from) {
             $from = DateTime::createFromFormat('d/m/Y', $from);
             $from = $from->format('Y-m-d');
             $this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) >= '".$from."'");
         }
-        if ($to != 0) {
+        if ($to) {
             $to = DateTime::createFromFormat('d/m/Y', $to);
             $to = $to->format('Y-m-d');
             $this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) <= '".$to."'");


### PR DESCRIPTION
#1862, #1863

If date fields are not set when ADIF export form is submitted, the dates are submitted as empty strings.

E.g. under Firefox on my system:

```
-----------------------------258695364640644243403098313945
Content-Disposition: form-data; name="station_profile"

2
-----------------------------258695364640644243403098313945
Content-Disposition: form-data; name="from"


-----------------------------258695364640644243403098313945
Content-Disposition: form-data; name="to"


-----------------------------258695364640644243403098313945--
```

`Adif_data->export_custom` was previously checking if `$from, $to != 0` which in this case is true, but then the blank string is passed through to `DateTime::createFormat` and interpreted as a truthy value, which causes the error referenced above.

This now works for me when exporting all QSOs to ADIF under PHP8.