### PR TITLE
adapt mode in advanced logbook

### DIFF
--- a/application/controllers/Logbookadvanced.php
+++ b/application/controllers/Logbookadvanced.php
@@ -39,9 +39,9 @@ class Logbookadvanced extends CI_Controller {
 		$modes = [];
 		if ($stationIds !== []) {
 			foreach ($this->logbookadvanced_model->get_worked_modes($stationIds) as $mode) {
-				$key = $mode['mode'];
+				$key = $mode['mode'] . "|";
 				if ($mode['submode'] !== null) {
-					$key .= "|" . $mode['submode'];
+					$key .= $mode['submode'];
 				}
 				if ($mode['submode'] == null) {
 					$modes[$key] = $mode['mode'];


### PR DESCRIPTION
In my environment I noticed that I have both mode "FM" and "FM|" (and "CW" and "CW|") in my advanced logbook mode filter. Of these only the ones with | work as the ones without | lead to a server side error in the search. Therefore I adapted the modes to always contain | as the search implementation seems to require the | anyways. This seems to work fine (at least with my data).