### PR TITLE
Use QSO ID to delete QSL rather than QSL ID

### DIFF
--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -60,7 +60,11 @@ class Qsl_model extends CI_Model {
         // be sure that QSO belongs to user
         $CI =& get_instance();
         $CI->load->model('logbook_model');
-        if (!$CI->logbook_model->check_qso_is_accessible($clean_id)) {
+        $this->db->select('qsoid');
+        $this->db->from('qsl_images');
+        $this->db->where('id', $clean_id);
+        $qsoid = $this->db->get()->row()->qsoid;
+        if (!$CI->logbook_model->check_qso_is_accessible($qsoid)) {
             return;
         }
 
@@ -75,7 +79,11 @@ class Qsl_model extends CI_Model {
         // be sure that QSO belongs to user
         $CI =& get_instance();
         $CI->load->model('logbook_model');
-        if (!$CI->logbook_model->check_qso_is_accessible($clean_id)) {
+        $this->db->select('qsoid');
+        $this->db->from('qsl_images');
+        $this->db->where('id', $clean_id);
+        $qsoid = $this->db->get()->row()->qsoid;
+        if (!$CI->logbook_model->check_qso_is_accessible($qsoid)) {
             return;
         }
 


### PR DESCRIPTION
This addresses https://github.com/magicbug/Cloudlog/issues/1878.

The deleteQsl and getFilename functions used the QSL id to determine if the QSO is accessible. This does not work because check_qso_is_accessible needs a QSO ID. So we have to look this up in order to check if the QSO is accessible.