### PR TITLE
Show public OQRS link if at least one callsign has OQRS activated

### DIFF
--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -431,5 +431,15 @@ class Visitor extends CI_Controller {
 		$this->load->view('gridsquares/index');
 		$this->load->view('visitor/layout/footer');
 	}
-	
+
+	public function oqrs_enabled($slug) {
+		$this->load->model('oqrs_model');
+		$this->load->model('Logbooks_model');
+		$logbook_id = $this->Logbooks_model->public_slug_exists_logbook_id($slug);
+		if (!empty($this->oqrs_model->getOqrsStationsFromSlug($logbook_id))) {
+			return true;
+		} else {
+			return false;
+		}
+	}
 }

--- a/application/models/Oqrs_model.php
+++ b/application/models/Oqrs_model.php
@@ -249,4 +249,16 @@ class Oqrs_model extends CI_Model {
 
 		return '';
 	}
+
+	function getOqrsStationsFromSlug($logbook_id) {
+		$sql = 'SELECT station_callsign FROM `station_logbooks_relationship` JOIN `station_profile` ON station_logbooks_relationship.station_location_id = station_profile.station_id WHERE station_profile.oqrs = 1 AND station_logbook_id = '.$logbook_id.';';
+
+		$query = $this->db->query($sql);
+
+		if ($query->num_rows() > 0) {
+			return true;
+		} else {
+			return false;
+		}
+	}
 }

--- a/application/views/visitor/layout/header.php
+++ b/application/views/visitor/layout/header.php
@@ -49,6 +49,14 @@
 		<li class="nav-item">
 			<a class="nav-link" href="<?php echo site_url('visitor/satellites/'.$slug);?>">Gridsquares</a>
 		</li>
+		<?php
+		$this->CI =& get_instance();
+		if ($this->CI->oqrs_enabled($slug)) {
+		?>
+		<li class="nav-item">
+			<a class="nav-link" href="<?php echo site_url('oqrs');?>">OQRS</a>
+		</li>
+		<?php } ?>
 		<li class="nav-item">
 			 <a class="btn btn-outline-primary" href="<?php echo site_url('user/login');?>">Login</a>
 		</li>


### PR DESCRIPTION
This adds a link to the OQRS section to the public pages (with public slugs). The link is only shown if at least one callsign of the logbook (which belongs to the public slug) has OQRS enabled. In all other cases the link is not shown. This was based on a discussion with @AndreasK79. So keen to read his opinion on this solution here :)