### PR TITLE
Fix oqrs flaws

### DIFF
--- a/application/controllers/Oqrs.php
+++ b/application/controllers/Oqrs.php
@@ -9,6 +9,8 @@ class Oqrs extends CI_Controller {
 
 	function __construct() {
 		parent::__construct();
+		$this->lang->load('lotw');
+		$this->lang->load('eqsl');
 		// Commented out to get public access
 		// $this->load->model('user_model');
 		// if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }

--- a/application/models/Oqrs_model.php
+++ b/application/models/Oqrs_model.php
@@ -145,6 +145,7 @@ class Oqrs_model extends CI_Model {
 				'email' 			=> xss_clean($postdata['email']),
 				'qslroute' 			=> '',
 				'status' 			=> '1',
+				'qsoid' 			=> '0',
 			);
 
 			$this->db->insert('oqrs', $data);

--- a/application/views/oqrs/notinlogform.php
+++ b/application/views/oqrs/notinlogform.php
@@ -27,7 +27,7 @@ checked.<br />
 <form>
     <div class="form-group">
         <label for="message">Message</label>
-        <textarea name="message" class="form-control" id="exampleFormControlTextarea1" rows="3" aria-describedby="messageHelp"></textarea>
+        <textarea name="message" class="form-control" id="messageInput" rows="3" aria-describedby="messageHelp"></textarea>
         <small id="messageHelp" class="form-text text-muted">Any extra information we need to know about?</small>
     </div>
 


### PR DESCRIPTION
This fixes 3 errors with OQRS:
1. Set qsoid to 0 in case someone makes a not-in-log request. Otherwise the request will not be saved as qsoid has no default value in SQL table
2. Corrects ID of message input text field so that it is stored to DB (currently silently ignored)
3. Loads eQSL and LotW lang for OQRS to fix display errors (and missing lang tags in logs)

@AndreasK79 pls verify and approve.