### PR TITLE
Add check for null values to QSL timestamps

### DIFF
--- a/application/views/oqrs/qsolist.php
+++ b/application/views/oqrs/qsolist.php
@@ -40,19 +40,23 @@ if ($qsos->result() != NULL) {
 		echo '<td style=\'text-align: center\' class="qsl">';
 		echo '<span ';
 		if ($qsl->COL_QSL_SENT != "N") {
-			$timestamp = strtotime($qsl->COL_QSLSDATE);
+			if ($qsl->COL_QSLSDATE != null) {
+				$timestamp = ' '.date($custom_date_format, strtotime($qsl->COL_QSLSDATE));
+			} else {
+				$timestamp = '';
+			}
 			switch ($qsl->COL_QSL_SENT) {
 			case "Y":
-				echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_sent')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_sent').$timestamp;
 				break;
 			case "Q":
-				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued').$timestamp;
 				break;
 			case "R":
-				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested').$timestamp;
 				break;
 			case "I":
-				echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore').$timestamp;
 				break;
 			default:
 				echo "class=\"qsl-red";
@@ -78,19 +82,23 @@ if ($qsos->result() != NULL) {
 		echo '">&#9650;</span>';
 		echo '<span ';
 		if ($qsl->COL_QSL_RCVD != "N") {
-			$timestamp = strtotime($qsl->COL_QSLRDATE);
+			if ($qsl->COL_QSLRDATE != null) {
+				$timestamp = ' '.date($custom_date_format, strtotime($qsl->COL_QSLRDATE));
+			} else {
+				$timestamp = '';
+			}
 			switch ($qsl->COL_QSL_RCVD) {
 			case "Y":
-				echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_received')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_received').$timestamp;
 				break;
 			case "Q":
-				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued').$timestamp;
 				break;
 			case "R":
-				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested').$timestamp;
 				break;
 			case "I":
-				echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore').$timestamp;
 				break;
 			default:
 				echo "class=\"qsl-red";
@@ -119,8 +127,12 @@ if ($qsos->result() != NULL) {
 			echo '<td style=\'text-align: center\' class="eqsl">';
 			echo '<span ';
 			if ($qsl->COL_EQSL_QSL_SENT == "Y") {
-				$timestamp = strtotime($qsl->COL_EQSL_QSLSDATE);
-				echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_sent')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+				echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_sent');
+				if ($qsl->COL_EQSL_QSLSDATE != null) {
+					$timestamp = strtotime($qsl->COL_EQSL_QSLSDATE);
+					echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+				}
+				echo "\" data-toggle=\"tooltip\"";
 			}
 			echo ' class="eqsl-';
 			echo ($qsl->COL_EQSL_QSL_SENT=='Y')?'green':'red';
@@ -128,8 +140,12 @@ if ($qsos->result() != NULL) {
 
 			echo '<span ';
 			if ($qsl->COL_EQSL_QSL_RCVD == "Y") {
-				$timestamp = strtotime($qsl->COL_EQSL_QSLRDATE);
-				echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_received')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+				echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_received');
+				if ($qsl->COL_EQSL_QSLRDATE != null) {
+					$timestamp = strtotime($qsl->COL_EQSL_QSLRDATE);
+					echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+				}
+				echo "\" data-toggle=\"tooltip\"";
 			}
 			echo ' class="eqsl-';
 			echo ($qsl->COL_EQSL_QSL_RCVD=='Y')?'green':'red';
@@ -140,8 +156,12 @@ if ($qsos->result() != NULL) {
 			echo '<td style=\'text-align: center\' class="lotw">';
 			echo '<span ';
 			if ($qsl->COL_LOTW_QSL_SENT == "Y") {
-				$timestamp = strtotime($qsl->COL_LOTW_QSLSDATE);
-				echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_sent')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+				echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_sent');
+				if ($qsl->COL_LOTW_QSLSDATE != null) {
+					$timestamp = strtotime($qsl->COL_LOTW_QSLSDATE);
+					echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+				}
+				echo "\" data-toggle=\"tooltip\"";
 			}
 			echo ' class="lotw-';
 			echo ($qsl->COL_LOTW_QSL_SENT=='Y')?'green':'red';
@@ -149,8 +169,12 @@ if ($qsos->result() != NULL) {
 
 			echo '<span ';
 			if ($qsl->COL_LOTW_QSL_RCVD == "Y") {
-				$timestamp = strtotime($qsl->COL_LOTW_QSLRDATE);
-				echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_received')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+				echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_received');
+				if ($qsl->COL_LOTW_QSLRDATE != null) {
+					$timestamp = strtotime($qsl->COL_LOTW_QSLRDATE);
+					echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+				}
+				echo "\" data-toggle=\"tooltip\"";
 			}
 			echo ' class="lotw-';
 			echo ($qsl->COL_LOTW_QSL_RCVD=='Y')?'green':'red';

--- a/application/views/qslprint/qsolist.php
+++ b/application/views/qslprint/qsolist.php
@@ -40,19 +40,23 @@ if ($qsos->result() != NULL) {
 		echo '<td style=\'text-align: center\' class="qsl">';
 		echo '<span ';
 		if ($qsl->COL_QSL_SENT != "N") {
-			$timestamp = strtotime($qsl->COL_QSLSDATE);
+			if ($qsl->COL_QSLSDATE != null) {
+				$timestamp = ' '.date($custom_date_format, strtotime($qsl->COL_QSLSDATE));
+			} else {
+				$timestamp = '';
+			}
 			switch ($qsl->COL_QSL_SENT) {
 			case "Y":
-				echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_sent')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_sent').$timestamp;
 				break;
 			case "Q":
-				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued').$timestamp;
 				break;
 			case "R":
-				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested').$timestamp;
 				break;
 			case "I":
-				echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore').$timestamp;
 				break;
 			default:
 				echo "class=\"qsl-red";
@@ -78,19 +82,23 @@ if ($qsos->result() != NULL) {
 		echo '">&#9650;</span>';
 		echo '<span ';
 		if ($qsl->COL_QSL_RCVD != "N") {
-			$timestamp = strtotime($qsl->COL_QSLRDATE);
+			if ($qsl->COL_QSLRDATE != null) {
+				$timestamp = ' '.date($custom_date_format, strtotime($qsl->COL_QSLRDATE));
+			} else {
+				$timestamp = '';
+			}
 			switch ($qsl->COL_QSL_RCVD) {
 			case "Y":
-				echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_received')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_received').$timestamp;
 				break;
 			case "Q":
-				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued').$timestamp;
 				break;
 			case "R":
-				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested').$timestamp;
 				break;
 			case "I":
-				echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore')." ".date($custom_date_format,$timestamp);
+				echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore').$timestamp;
 				break;
 			default:
 				echo "class=\"qsl-red";
@@ -119,8 +127,12 @@ if ($qsos->result() != NULL) {
 			echo '<td style=\'text-align: center\' class="eqsl">';
 			echo '<span ';
 			if ($qsl->COL_EQSL_QSL_SENT == "Y") {
-				$timestamp = strtotime($qsl->COL_EQSL_QSLSDATE);
-				echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_sent')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+				echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_sent');
+				if ($qsl->COL_EQSL_QSLSDATE != null) {
+					$timestamp = strtotime($qsl->COL_EQSL_QSLSDATE);
+					echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+				}
+				echo "\" data-toggle=\"tooltip\"";
 			}
 			echo ' class="eqsl-';
 			echo ($qsl->COL_EQSL_QSL_SENT=='Y')?'green':'red';
@@ -128,8 +140,12 @@ if ($qsos->result() != NULL) {
 
 			echo '<span ';
 			if ($qsl->COL_EQSL_QSL_RCVD == "Y") {
-				$timestamp = strtotime($qsl->COL_EQSL_QSLRDATE);
-				echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_received')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+				echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_received');
+				if ($qsl->COL_EQSL_QSLRDATE != null) {
+					$timestamp = strtotime($qsl->COL_EQSL_QSLRDATE);
+					echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+				}
+				echo "\" data-toggle=\"tooltip\"";
 			}
 			echo ' class="eqsl-';
 			echo ($qsl->COL_EQSL_QSL_RCVD=='Y')?'green':'red';
@@ -140,8 +156,12 @@ if ($qsos->result() != NULL) {
 			echo '<td style=\'text-align: center\' class="lotw">';
 			echo '<span ';
 			if ($qsl->COL_LOTW_QSL_SENT == "Y") {
-				$timestamp = strtotime($qsl->COL_LOTW_QSLSDATE);
-				echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_sent')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+				echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_sent');
+				if ($qsl->COL_LOTW_QSLSDATE != null) {
+					$timestamp = strtotime($qsl->COL_LOTW_QSLSDATE);
+					echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+				}
+				echo "\" data-toggle=\"tooltip\"";
 			}
 			echo ' class="lotw-';
 			echo ($qsl->COL_LOTW_QSL_SENT=='Y')?'green':'red';
@@ -149,8 +169,12 @@ if ($qsos->result() != NULL) {
 
 			echo '<span ';
 			if ($qsl->COL_LOTW_QSL_RCVD == "Y") {
-				$timestamp = strtotime($qsl->COL_LOTW_QSLRDATE);
-				echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_received')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+				echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_received');
+				if ($qsl->COL_LOTW_QSLRDATE) {
+					$timestamp = strtotime($qsl->COL_LOTW_QSLRDATE);
+					echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+				}
+				echo "\" data-toggle=\"tooltip\"";
 			}
 			echo ' class="lotw-';
 			echo ($qsl->COL_LOTW_QSL_RCVD=='Y')?'green':'red';

--- a/application/views/search/search_result_ajax.php
+++ b/application/views/search/search_result_ajax.php
@@ -210,19 +210,23 @@ $ci =& get_instance();
                   echo '<td style=\'text-align: center\' class="qsl">';
                   echo '<span ';
                   if ($row->COL_QSL_SENT != "N") {
-                     $timestamp = strtotime($row->COL_QSLSDATE);
+                     if ($row->COL_QSLSDATE != null) {
+                        $timestamp = ' '.date($custom_date_format, strtotime($row->COL_QSLSDATE));
+                     } else {
+                        $timestamp = '';
+                     }
                      switch ($row->COL_QSL_SENT) {
                      case "Y":
-                        echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_sent')." ".date($custom_date_format,$timestamp);
+                        echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_sent').$timestamp;
                         break;
                      case "Q":
-                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued')." ".date($custom_date_format,$timestamp);
+                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued').$timestamp;
                         break;
                      case "R":
-                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested')." ".date($custom_date_format,$timestamp);
+                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested').$timestamp;
                         break;
                      case "I":
-                        echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore')." ".date($custom_date_format,$timestamp);
+                        echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore').$timestamp;
                         break;
                      default:
                         echo "class=\"qsl-red";
@@ -248,19 +252,23 @@ $ci =& get_instance();
                   echo '">&#9650;</span>';
                   echo '<span ';
                   if ($row->COL_QSL_RCVD != "N") {
-                     $timestamp = strtotime($row->COL_QSLRDATE);
+                     if ($row->COL_QSLRDATE != null) {
+                        $timestamp = ' '.date($custom_date_format, strtotime($row->COL_QSLRDATE));
+                     } else {
+                        $timestamp = '';
+                     }
                      switch ($row->COL_QSL_RCVD) {
                      case "Y":
-                        echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_received')." ".date($custom_date_format,$timestamp);
+                        echo "class=\"qsl-green\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_received').$timestamp;
                         break;
                      case "Q":
-                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued')." ".date($custom_date_format,$timestamp);
+                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_queued').$timestamp;
                         break;
                      case "R":
-                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested')." ".date($custom_date_format,$timestamp);
+                        echo "class=\"qsl-yellow\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_requested').$timestamp;
                         break;
                      case "I":
-                        echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore')." ".date($custom_date_format,$timestamp);
+                        echo "class=\"qsl-grey\" data-toggle=\"tooltip\" data-original-title=\"".$this->lang->line('general_word_invalid_ignore').$timestamp;
                         break;
                      default:
                         echo "class=\"qsl-red";
@@ -289,8 +297,12 @@ $ci =& get_instance();
                   echo '<td style=\'text-align: center\' class="eqsl">';
                   echo '<span ';
                   if ($row->COL_EQSL_QSL_SENT == "Y") {
-                     $timestamp = strtotime($row->COL_EQSL_QSLSDATE);
-                     echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_sent')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+                     echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_sent');
+                     if ($row->COL_EQSL_QSLSDATE != null) {
+                        $timestamp = strtotime($row->COL_EQSL_QSLSDATE);
+                        echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+                     }
+                     echo "\" data-toggle=\"tooltip\"";
                   }
                   echo ' class="eqsl-';
                   echo ($row->COL_EQSL_QSL_SENT=='Y')?'green':'red';
@@ -298,8 +310,12 @@ $ci =& get_instance();
 
                   echo '<span ';
                   if ($row->COL_EQSL_QSL_RCVD == "Y") {
-                     $timestamp = strtotime($row->COL_EQSL_QSLRDATE);
-                     echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_received')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+                     echo "data-original-title=\"".$this->lang->line('eqsl_short')." ".$this->lang->line('general_word_received');
+                     if ($row->COL_EQSL_QSLRDATE != null) {
+                        $timestamp = strtotime($row->COL_EQSL_QSLRDATE);
+                        echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+                     }
+                     echo "\" data-toggle=\"tooltip\"";
                   }
                   echo ' class="eqsl-';
                   echo ($row->COL_EQSL_QSL_RCVD=='Y')?'green':'red';
@@ -319,8 +335,12 @@ $ci =& get_instance();
                 echo '<td style=\'text-align: center\' class="lotw">';
                 echo '<span ';
                 if ($row->COL_LOTW_QSL_SENT == "Y") {
-                   $timestamp = strtotime($row->COL_LOTW_QSLSDATE);
-                   echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_sent')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+                   echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_sent');
+                   if ($row->COL_LOTW_QSLSDATE != null) {
+                     $timestamp = strtotime($row->COL_LOTW_QSLSDATE);
+                     echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+                   }
+                   echo "\" data-toggle=\"tooltip\"";
                 }
                 echo ' class="lotw-';
                 echo ($row->COL_LOTW_QSL_SENT=='Y')?'green':'red';
@@ -328,8 +348,12 @@ $ci =& get_instance();
 
                 echo '<span ';
                 if ($row->COL_LOTW_QSL_RCVD == "Y") {
-                   $timestamp = strtotime($row->COL_LOTW_QSLRDATE);
-                   echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_received')." ".($timestamp!=''?date($custom_date_format, $timestamp):'')."\" data-toggle=\"tooltip\"";
+                   echo "data-original-title=\"".$this->lang->line('lotw_short')." ".$this->lang->line('general_word_received');
+                   if ($row->COL_LOTW_QSLRDATE != null) {
+                      $timestamp = strtotime($row->COL_LOTW_QSLRDATE);
+                      echo " ".($timestamp != '' ? date($custom_date_format, $timestamp) : '');
+                   }
+                   echo "\" data-toggle=\"tooltip\"";
                 }
                 echo ' class="lotw-';
                 echo ($row->COL_LOTW_QSL_RCVD=='Y')?'green':'red';


### PR DESCRIPTION
Check QSL dates for null to prevent PHP 8.1 errors.