### PR TITLE
Sort QSOs for QSLprint DESC as in other places

### DIFF
--- a/application/models/Qslprint_model.php
+++ b/application/models/Qslprint_model.php
@@ -53,7 +53,7 @@ class Qslprint_model extends CI_Model {
 		// always filter user. this ensures that even if the station_id is from another user no inaccesible QSOs will be returned
 		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
 		$this->db->where_in('COL_QSL_SENT', array('R', 'Q'));
-		$this->db->order_by("COL_TIME_ON", "ASC");
+		$this->db->order_by("COL_TIME_ON", "DESC");
 		$query = $this->db->get($this->config->item('table_name'));
 
 		return $query;
@@ -107,7 +107,7 @@ class Qslprint_model extends CI_Model {
 		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
 		$this->db->where('COL_CALL like "%'.$callsign.'%"');
 		$this->db->where('coalesce(COL_QSL_SENT, "") not in ("R", "Q")');
-		$this->db->order_by("COL_TIME_ON", "ASC");
+		$this->db->order_by("COL_TIME_ON", "DESC");
 		$query = $this->db->get($this->config->item('table_name'));
 
 		return $query;


### PR DESCRIPTION
I think it makes sense if the QSOs were listed in DESC order here as in other places within Cloudlog.