### PR TITLE
Order by primary key as second criterion

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1113,6 +1113,7 @@ class Logbook_model extends CI_Model {
     $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
     $this->db->where_in('station_profile.station_id', $logbooks_locations_array);
     $this->db->order_by(''.$this->config->item('table_name').'.COL_TIME_ON', "desc");
+    $this->db->order_by(''.$this->config->item('table_name').'.COL_PRIMARY_KEY', "desc");
 
     $this->db->limit($num);
     $this->db->offset($offset);
@@ -1179,7 +1180,7 @@ class Logbook_model extends CI_Model {
       
       $sql = "SELECT * FROM ( select * from " . $this->config->item('table_name'). "
         WHERE station_id IN(". $location_list .")
-        order by col_time_on desc
+        order by col_time_on desc, col_primary_key desc
         limit " . $num .
         ") hrd
         JOIN station_profile ON station_profile.station_id = hrd.station_id

--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -91,7 +91,7 @@ class Logbookadvanced_model extends CI_Model {
 			INNER JOIN station_profile ON qsos.station_id=station_profile.station_id
 			WHERE station_profile.user_id =  ?
 			$where
-			ORDER BY qsos.COL_TIME_ON desc
+			ORDER BY qsos.COL_TIME_ON desc, qsos.COL_PRIMARY_KEY desc
 			LIMIT $limit
 		";
 


### PR DESCRIPTION
If I enter post QSOs after SAT contacts sometimes there is a QSO with exactly the same time (with accuracy of a minute). The logbook shows contacts sorted by `COL_TIME_ON`. But when this value is identical for more than one QSOs these QSOs get sorted by `COL_PRIMARY_KEY` in ascending order it seems. I guess it would make more sense to have it in descending order so that if you log one QSO after another they get displayed in the same order as logged.
Example: I logged M5JFS before DL2GRC but the logbook shows:

![Screenshot from 2023-01-26 01-01-02](https://user-images.githubusercontent.com/7112907/214721240-f2e82eb7-9ff0-4b9a-8e3b-42182712bf6c.png)

With this patch it would be sorted correctly:

![Screenshot from 2023-01-26 01-00-49](https://user-images.githubusercontent.com/7112907/214721286-60633fff-1670-40df-8b1f-dde4557bcd7b.png)
