### PR TITLE
[QSO Entry] Added dxcc summary to spawn when dxcc is identified

### DIFF
--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -1,6 +1,6 @@
 <div class="container qso_panel">
 
-<div class="row">
+<div class="row qsopane">
 
   <div class="col-sm-5">
     <div class="card">

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -431,3 +431,20 @@ function getLookupResult() {
 		}
 	});
 }
+
+// This function executes the call to the backend for fetching dxcc summary and inserted table below qso entry
+function getDxccResult(dxcc) {
+	$.ajax({
+		url: base_url + 'index.php/lookup/search',
+		type: 'post',
+		data: {
+			type: 'dxcc',
+			dxcc: dxcc,
+		},
+		success: function (html) {
+            $('.dxccsummary').remove();
+            $('.qsopane').append('<div class="dxccsummary col-sm-12"><br><div class="card"><div class="card-header">DXCC Summary</div><div class="card-body dxccsummarybody"></div></div></div>');
+            $('.dxccsummarybody').append(html);
+		}
+	});
+}

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -443,7 +443,7 @@ function getDxccResult(dxcc, name) {
 		},
 		success: function (html) {
             $('.dxccsummary').remove();
-            $('.qsopane').append('<div class="dxccsummary col-sm-12"><br><div class="card"><div class="card-header">DXCC Summary for '+name+'</div><div class="card-body dxccsummarybody"></div></div></div>');
+            $('.qsopane').append('<div class="dxccsummary col-sm-12"><br><div class="card"><div class="card-header" data-toggle="collapse" data-target=".dxccsummarybody">DXCC Summary for '+name+'</div><div class="card-body collapse dxccsummarybody"></div></div></div>');
             $('.dxccsummarybody').append(html);
 		}
 	});

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -433,7 +433,7 @@ function getLookupResult() {
 }
 
 // This function executes the call to the backend for fetching dxcc summary and inserted table below qso entry
-function getDxccResult(dxcc) {
+function getDxccResult(dxcc, name) {
 	$.ajax({
 		url: base_url + 'index.php/lookup/search',
 		type: 'post',
@@ -443,7 +443,7 @@ function getDxccResult(dxcc) {
 		},
 		success: function (html) {
             $('.dxccsummary').remove();
-            $('.qsopane').append('<div class="dxccsummary col-sm-12"><br><div class="card"><div class="card-header">DXCC Summary</div><div class="card-body dxccsummarybody"></div></div></div>');
+            $('.qsopane').append('<div class="dxccsummary col-sm-12"><br><div class="card"><div class="card-header">DXCC Summary for '+name+'</div><div class="card-body dxccsummarybody"></div></div></div>');
             $('.dxccsummarybody').append(html);
 		}
 	});

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -407,7 +407,7 @@ $("#callsign").focusout(function() {
 				if(result.dxcc.entity != undefined) {
 					$('#country').val(convert_case(result.dxcc.entity));
 					$('#callsign_info').text(convert_case(result.dxcc.entity));
-					getDxccResult(result.dxcc.adif);
+					getDxccResult(result.dxcc.adif, convert_case(result.dxcc.entity));
 
 					if($("#sat_name" ).val() != "") {
 						//logbook/jsonlookupgrid/io77/SAT/0/0

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -406,7 +406,7 @@ $("#callsign").focusout(function() {
 				if(result.dxcc.entity != undefined) {
 					$('#country').val(convert_case(result.dxcc.entity));
 					$('#callsign_info').text(convert_case(result.dxcc.entity));
-					getDxccResult(convert_case(result.dxcc.adif));
+					getDxccResult(result.dxcc.adif);
 
 					if($("#sat_name" ).val() != "") {
 						//logbook/jsonlookupgrid/io77/SAT/0/0

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -368,6 +368,7 @@ function reset_fields() {
 	mymap.setView(pos, 12);
 	mymap.removeLayer(markers);
 	$('.callsign-suggest').hide();
+	$('.dxccsummary').remove();
 }
 
 $("#callsign").focusout(function() {
@@ -788,4 +789,5 @@ function resetDefaultQSOFields() {
 	$('#input_usa_state').val("");
 	$('#callsign-image').attr('style', 'display: none;');
 	$('#callsign-image-content').text("");
+	$('.dxccsummary').remove();
 }

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -406,6 +406,7 @@ $("#callsign").focusout(function() {
 				if(result.dxcc.entity != undefined) {
 					$('#country').val(convert_case(result.dxcc.entity));
 					$('#callsign_info').text(convert_case(result.dxcc.entity));
+					getDxccResult(convert_case(result.dxcc.adif));
 
 					if($("#sat_name" ).val() != "") {
 						//logbook/jsonlookupgrid/io77/SAT/0/0


### PR DESCRIPTION
After entering a callsign, the dxcc will be determined. When that is done, a dxcc summary will be added at the bottom of the qso entry.

Example:
![image](https://user-images.githubusercontent.com/6977712/214784273-cd66d937-630c-4179-b919-7ee86305e2eb.png)


