### PR TITLE
Re-make URL copy-able (lost on previous commit)

### DIFF
--- a/application/views/debug/main.php
+++ b/application/views/debug/main.php
@@ -15,11 +15,11 @@
                     </tr>
                     <tr>
                         <td>Language</td>
-                        <td><?php echo $this->config->item('language')."\n"; ?></td>
+                        <td><?php echo ucfirst($this->config->item('language'))."\n"; ?></td>
                     </tr>
                     <tr>
                         <td>Base URL</td>
-                        <td><?php echo $this->config->item('base_url')."\n"; ?></td>
+                        <td><span id="baseUrl"><a href="<?php echo $this->config->item('base_url')?>" target="_blank"><?php echo $this->config->item('base_url'); ?></a></span> <span data-toggle="tooltip" data-original-title="<?php echo $this->lang->line('copy_to_clipboard'); ?>" onclick='copyURL("<?php echo $this->config->item('base_url'); ?>")'><i class="copy-icon fas fa-copy"></span></td>
                     </tr>
                 </table>
             </div>


### PR DESCRIPTION
Accidentally reverted in my commit https://github.com/magicbug/Cloudlog/commit/f897ec2db3270ddd54ee2a583217306c3d708b9f.