### PR TITLE
Fix: KML export also no longer working if Cloudlog configured to remove index.php

### DIFF
--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -4,7 +4,7 @@
 
 RewriteEngine On
 
-RewriteCond %{REQUEST_URI} ^/backup/$
+RewriteCond %{REQUEST_URI} ^/(backup|kml)/$
 RewriteRule ^(.*)$ /index.php?/$1 [L]
 
 RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
Similar issue as with the backup menu option described in https://github.com/magicbug/Cloudlog/issues/2036