### PR TITLE
Mark QSOs as uploaded in batch to improve performance

### DIFF
--- a/application/controllers/Webadif.php
+++ b/application/controllers/Webadif.php
@@ -61,7 +61,7 @@ class Webadif extends CI_Controller {
 				$result = $this->logbook_model->push_qso_to_webadif($webadif_api_url, $webadif_api_key, $adif);
 
 				if ($result) {
-					$this->logbook_model->mark_webadif_qsos_sent($qso->COL_PRIMARY_KEY);
+					$this->logbook_model->mark_webadif_qsos_sent([$qso->COL_PRIMARY_KEY]);
 					$i++;
 				} else {
 					$errorMessage = 'QO-100 Dx Club upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
@@ -149,8 +149,15 @@ class Webadif extends CI_Controller {
 		);
 
 		if ($data['qsos']!==null) {
+			$qsoIDs=[];
 			foreach ($data['qsos']->result() as $qso) {
-				$this->logbook_model->mark_webadif_qsos_sent($qso->COL_PRIMARY_KEY);
+				$qsoIDs[]=$qso->COL_PRIMARY_KEY;
+			}
+			$batchSize = 500;
+			while ($qsoIDs !== []) {
+				$slice = array_slice($qsoIDs, 0, $batchSize);
+				$qsoIDs = array_slice($qsoIDs, $batchSize);
+				$this->logbook_model->mark_webadif_qsos_sent($slice);
 			}
 		}
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -497,7 +497,7 @@ class Logbook_model extends CI_Model {
 			);
 
 			if ($result) {
-				$this->mark_webadif_qsos_sent($last_id);
+				$this->mark_webadif_qsos_sent([$last_id]);
 			}
 		}
 	}
@@ -632,17 +632,19 @@ class Logbook_model extends CI_Model {
 
 	/*
 	* Function marks QSOs as uploaded to WebADIF.
-	* $primarykey is the unique id for that QSO in the logbook
+	* $qsoIDs is an arroy of unique id for the QSOs in the logbook
 	*/
-	function mark_webadif_qsos_sent($primarykey)
+	function mark_webadif_qsos_sent(array $qsoIDs)
 	{
-		$data = array(
-			'upload_date' => date("Y-m-d H:i:s", strtotime("now")),
-			'qso_id' => $primarykey,
-		);
-
-		$this->db->insert('webadif', $data);
-
+		$data = [];
+		$now = date("Y-m-d H:i:s", strtotime("now"));
+		foreach ($qsoIDs as $qsoID) {
+			$data[] = [
+				'upload_date' => $now,
+				'qso_id' => $qsoID,
+			];
+		}
+		$this->db->insert_batch('webadif', $data);
 		return true;
 	}
 
@@ -1278,7 +1280,7 @@ class Logbook_model extends CI_Model {
 	/*
      * Function returns the QSOs from the logbook, which have not been either marked as uploaded to webADIF
      */
-	function get_webadif_qsos($station_id,$from, $to){
+	function get_webadif_qsos($station_id,$from = null, $to = null){
 		$sql = "
 			SELECT qsos.*, station_profile.*
 			FROM %s qsos


### PR DESCRIPTION
Instead of running QSOs one by one, build a batch of 500 and do a multiple insert, as it should be faster.
@phl0 can you test it on you excellent dataset?