### PR TITLE
Show Notes tab in "QSO data" view if a note exists

### DIFF
--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -9,6 +9,12 @@
             <a id="station-tab" class="nav-link" data-toggle="tab" href="#stationdetails" role="tab" aria-controls="table" aria-selected="true"><?php echo $this->lang->line('cloudlog_station_profile'); ?></a>
         </li>
         <?php
+        if ($row->COL_NOTES != null) {?>
+        <li class="nav-item">
+            <a id="notes-tab" class="nav-link" data-toggle="tab" href="#notesdetails" role="tab" aria-controls="table" aria-selected="true"><?php echo "Notes"; ?></a>
+        </li>
+        <?php }?>
+        <?php
         if (($this->config->item('use_auth')) && ($this->session->userdata('user_type') >= 2)) {
 
             echo '<li ';
@@ -437,6 +443,11 @@
                     </tr>
                     <?php } ?>
             </table>
+        </div>
+
+        <div class="tab-pane fade" id="notesdetails" role="tabpanel" aria-labelledby="table-tab">
+            <h3>Notes</h3>
+            <?php echo nl2br($row->COL_NOTES); ?>
         </div>
 
         <?php


### PR DESCRIPTION
If Notes exists for a certain QSO, an additional tab "Notes" is displayed in the "QSO data" view so that you are aware of the Notes and can check them directly from that view:

![image](https://user-images.githubusercontent.com/2588362/226547020-f9bbed15-c57d-44c6-bb27-2144a7d00aaf.png)
![image](https://user-images.githubusercontent.com/2588362/226563505-ad48cb26-6d77-4ef2-a187-de02f94e3503.png)


