### PR TITLE
Add a column to API keys to show last usage timestamp

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 115;
+$config['migration_version'] = 116;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -221,6 +221,8 @@ class API extends CI_Controller {
             $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard');
         }
 
+		$this->api_model->update_last_used($obj['key']);
+
 		// Retrieve the arguments from the query string
         $data['data']['format'] = $arguments['format'];
 
@@ -294,6 +296,8 @@ class API extends CI_Controller {
 		if((!$this->user_model->authorize(3)) && ($this->api_model->authorize($arguments['key']) == 0)) {
             $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard');
         }
+
+		$this->api_model->update_last_used($obj['key']);
 
 		// Retrieve the arguments from the query string
         $data['data']['format'] = $arguments['format'];
@@ -432,6 +436,7 @@ class API extends CI_Controller {
 		   die();
 		}
 
+		$this->api_model->update_last_used($obj['key']);
 
 		if($obj['type'] == "adif" && $obj['string'] != "") {
 			// Load the logbook model for adding QSO records
@@ -499,6 +504,8 @@ class API extends CI_Controller {
 		   echo json_encode(['status' => 'failed', 'reason' => "missing api key"]);
 		   die();
 		}
+
+		$this->api_model->update_last_used($obj['key']);
 
 		$user_id = $this->api_model->key_userid($obj['key']);
 

--- a/application/migrations/116_add_timestamp_to_api.php
+++ b/application/migrations/116_add_timestamp_to_api.php
@@ -1,0 +1,21 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_add_timestamp_to_api extends CI_Migration
+{
+	public function up()
+	{
+		$fields = array(
+			'last_used TIMESTAMP DEFAULT NOW() NOT NULL AFTER `last_change`',
+		);
+
+		if (!$this->db->field_exists('last_used', 'api')) {
+			$this->dbforge->add_column('api', $fields);
+		}
+	}
+
+	public function down()
+	{
+		$this->dbforge->drop_column('api', 'last_used');
+	}
+}

--- a/application/models/Api_model.php
+++ b/application/models/Api_model.php
@@ -179,7 +179,6 @@ class API_Model extends CI_Model {
     $this->db->set('last_used', 'NOW()', FALSE);
     $this->db->where('key', xss_clean($key));
     $this->db->update('api');
-    //$query = $this->db->query('UPDATE `api` SET `last_used` = NOW() WHERE `key` = "'.xss_clean($key).'";');
   }
 
 	// FUNCTION: string name(string $column)

--- a/application/models/Api_model.php
+++ b/application/models/Api_model.php
@@ -175,6 +175,13 @@ class API_Model extends CI_Model {
     }
   }
 
+  function update_last_used($key) {
+    $this->db->set('last_used', 'NOW()', FALSE);
+    $this->db->where('key', xss_clean($key));
+    $this->db->update('api');
+    //$query = $this->db->query('UPDATE `api` SET `last_used` = NOW() WHERE `key` = "'.xss_clean($key).'";');
+  }
+
 	// FUNCTION: string name(string $column)
 	// Converts a MySQL column name to a more friendly name
 	function name($col)

--- a/application/views/api/help.php
+++ b/application/views/api/help.php
@@ -26,6 +26,7 @@
 		    <tr>
 		      <th scope="col">API Key</th>
 		      <th scope="col">Description</th>
+		      <th scope="col">Last Used</th>
 		      <th scope="col">Rights</th>
 		      <th scope="col">Status</th>
 		    </tr>
@@ -35,6 +36,7 @@
 				<tr>
 					<td><i class="fas fa-key"></i> <span class="api-key" id="<?php echo $row->key; ?>"><?php echo $row->key; ?></span> <span data-toggle="tooltip" data-original-title="<?php echo $this->lang->line('copy_to_clipboard'); ?>" onclick='copyApiKey("<?php echo $row->key; ?>")'><i class="copy-icon fas fa-copy"></span></td>
 					<td><?php echo $row->description; ?></td>
+					<td><?php echo $row->last_used; ?></td>
 					<td>
 						<?php
 							


### PR DESCRIPTION
Squashed commit of the following:

commit 83f12cc945fa717945062a841854498368d8cb10
Author: phl0
Date:   Tue Mar 21 12:24:53 2023 +0100

    Change default value to current date/time

commit e1cb72f3fc80f581ee30d927772efe0ffe155059
Author: phl0
Date:   Tue Mar 21 12:05:46 2023 +0100

    Add functions to update timestamps

commit d303f629a0b2d200e49da36766cf72ed37c3fe92
Merge: 01a9606a 7dd76923
Author: phl0
Date:   Tue Mar 21 11:13:21 2023 +0100

    Merge remote-tracking branch 'origin/dev' into apiKeyLastUsed

commit 01a9606afde6aad6be0f07f34f8584e540c50e8c
Author: phl0
Date:   Tue Mar 21 11:11:51 2023 +0100

    Reorder DB migration due to previous commits

commit ec5cd743b96dc1ed0f2740f7b2051f88549f4248
Author: phl0
Date:   Fri Mar 17 16:23:34 2023 +0100

    Basics for API key last used