### PR TITLE
Make LotW interactions a little more verbose (and less error prone)

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -359,7 +359,6 @@ class Lotw extends CI_Controller {
 			|	Download QSO Matches from LoTW
 			*/
 			echo "<br><br>";
-			echo "LoTW Matches<br>";
 			echo $this->lotw_download();
 
 	}
@@ -580,6 +579,7 @@ class Lotw extends CI_Controller {
 		unlink($filepath);
 
 		if(isset($data['lotw_table_headers'])) {
+			echo "LoTW Matches<br>";
 			if($display_view == TRUE) {
 				$data['page_title'] = "LoTW ADIF Information";
 				$this->load->view('interface_assets/header', $data);
@@ -589,7 +589,7 @@ class Lotw extends CI_Controller {
 				return $tableheaders.$table;
 			}
 		} else {
-			echo "LoTW Downloading failed either due to it being down or incorrect logins.";
+			echo "Downloaded LotW report contains no matches.";
 		}
 	}
 

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -650,6 +650,9 @@ class Lotw extends CI_Controller {
 					return "Temporary download directory ".dirname($file)." is not writable. Aborting!";
 				}
 				file_put_contents($file, file_get_contents($lotw_url));
+				if (file_get_contents($file, false, null, 0, 39) != "ARRL Logbook of the World Status Report") {
+					return "LotW downloading failed either due to it being down or incorrect logins.";
+				}
 
 				ini_set('memory_limit', '-1');
 				$results = $this->loadFromFile($file, false);

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -615,6 +615,9 @@ class Lotw extends CI_Controller {
 
 				$config['upload_path'] = './uploads/';
 				$file = $config['upload_path'] . 'lotwreport_download.adi';
+				if (file_exists($file) && ! is_writable($file)) {
+					return "Temporary download file ".$file." is not writable. Aborting!";
+				}
 
 				// Get credentials for LoTW
 		    	$data['user_lotw_name'] = urlencode($user->user_lotw_name);
@@ -643,6 +646,9 @@ class Lotw extends CI_Controller {
 				$lotw_url .= "&qso_qslsince=";
 				$lotw_url .= "$lotw_last_qsl_date";
 
+				if (! is_writable(dirname($file))) {
+					return "Temporary download directory ".dirname($file)." is not writable. Aborting!";
+				}
 				file_put_contents($file, file_get_contents($lotw_url));
 
 				ini_set('memory_limit', '-1');


### PR DESCRIPTION
This addresses issues with LotW downloads as for example mentioned in https://github.com/magicbug/Cloudlog/discussions/1948.
The code now checks whether a file already exists and is writable and if not reports accordingly. If the file does not exists it checks whether the directory is writable and aborts if not. 
And last but not least error messages were improved. The code now checks the file contents for a valid LotW report before importing it and failing. Also error messages for simply empty list of matches has been refactored.
This is for @AndreasK79 for his kind review before merge. Tests and reports more than welcome even before this gets merged.