### PR TITLE
Use DXCC ID pulled from LotW cert

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 117;
+$config['migration_version'] = 118;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -153,20 +153,20 @@ class Lotw extends CI_Controller {
 			}
 
 			// Check to see if certificate is already in the system
-			$new_certificate = $this->LotwCert->find_cert($info['issued_callsign'], $dxcc, $this->session->userdata('user_id'));
+			$new_certificate = $this->LotwCert->find_cert($info['issued_callsign'], $info['dxcc-id'], $this->session->userdata('user_id'));
 
         	if($new_certificate == 0) {
         		// New Certificate Store in Database
 
         		// Store Certificate Data into MySQL
-        		$this->LotwCert->store_certificate($this->session->userdata('user_id'), $info['issued_callsign'], $dxcc, $info['validFrom'], $info['validTo_Date'], $info['qso-first-date'], $info['qso-end-date'], $info['pem_key'], $info['general_cert']);
+        		$this->LotwCert->store_certificate($this->session->userdata('user_id'), $info['issued_callsign'], $info['dxcc-id'], $info['validFrom'], $info['validTo_Date'], $info['qso-first-date'], $info['qso-end-date'], $info['pem_key'], $info['general_cert']);
 
         		// Cert success flash message
         		$this->session->set_flashdata('Success', $info['issued_callsign'].' Certificate Imported.');
         	} else {
         		// Certificate is in the system time to update
 
-				$this->LotwCert->update_certificate($this->session->userdata('user_id'), $info['issued_callsign'], $dxcc, $info['validFrom'], $info['validTo_Date'], $info['pem_key'], $info['general_cert']);
+				$this->LotwCert->update_certificate($this->session->userdata('user_id'), $info['issued_callsign'], $info['dxcc-id'], $info['validFrom'], $info['validTo_Date'], $info['pem_key'], $info['general_cert']);
 
         		// Cert success flash message
         		$this->session->set_flashdata('Success', $info['issued_callsign'].' Certificate Updated.');
@@ -443,6 +443,7 @@ class Lotw extends CI_Controller {
 		// https://oidref.com/1.3.6.1.4.1.12348.1
 		$data['qso-first-date'] = $certdata['extensions']['1.3.6.1.4.1.12348.1.2'];
 		$data['qso-end-date'] = $certdata['extensions']['1.3.6.1.4.1.12348.1.3'];
+		$data['dxcc-id'] = $certdata['extensions']['1.3.6.1.4.1.12348.1.4'];
 
 		return $data;
 	}

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -142,16 +142,6 @@ class Lotw extends CI_Controller {
 
         	$info = $this->decrypt_key($data['upload_data']['full_path']);
 
-        	// Check DXCC & Store Country Name
-			$this->load->model('Logbook_model');
-
-			if($this->input->post('dxcc') != "") {
-				$dxcc = $this->input->post('dxcc');
-			} else{
-				$dxcc_check = $this->Logbook_model->check_dxcc_table($info['issued_callsign'], $info['validFrom']);
-				$dxcc = $dxcc_check[1];
-			}
-
 			// Check to see if certificate is already in the system
 			$new_certificate = $this->LotwCert->find_cert($info['issued_callsign'], $info['dxcc-id'], $this->session->userdata('user_id'));
 

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -225,10 +225,10 @@ class Lotw extends CI_Controller {
 					// Get Certificate Data
 					$this->load->model('LotwCert');
 					$data['station_profile'] = $station_profile;
-					$data['lotw_cert_info'] = $this->LotwCert->lotw_cert_details($station_profile->station_callsign, $station_profile->station_country);
+					$data['lotw_cert_info'] = $this->LotwCert->lotw_cert_details($station_profile->station_callsign, $station_profile->station_dxcc);
 
 					// If Station Profile has no LOTW Cert continue on.
-					if(!isset($data['lotw_cert_info']->cert_dxcc)) {
+					if(!isset($data['lotw_cert_info']->cert_dxcc_id)) {
 						continue;
 					}
 
@@ -243,9 +243,6 @@ class Lotw extends CI_Controller {
 						echo $data['lotw_cert_info']->callsign.": LotW certificate expired!";
 						continue;
 					}
-
-					$this->load->model('Dxcc');
-					$data['station_profile_dxcc'] = $this->Dxcc->lookup_country($data['lotw_cert_info']->cert_dxcc);
 
 					// Get QSOs
 

--- a/application/migrations/118_make_lotw_use_dxcc_id.php
+++ b/application/migrations/118_make_lotw_use_dxcc_id.php
@@ -1,0 +1,37 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_make_lotw_use_dxcc_id extends CI_Migration
+{
+	public function up()
+	{
+		$fields = array(
+			'cert_dxcc_id SMALLINT(6) NOT NULL AFTER `cert_dxcc`',
+		);
+
+		if (!$this->db->field_exists('cert_dxcc_id', 'lotw_certs')) {
+			$this->dbforge->add_column('lotw_certs', $fields);
+		}
+
+		$sql = 'UPDATE `lotw_certs` JOIN `dxcc_entities` ON `lotw_certs`.`cert_dxcc` = `dxcc_entities`.`name` SET `lotw_certs`.`cert_dxcc_id` = `dxcc_entities`.`adif`;';
+		$this->db->query($sql);
+
+		$this->dbforge->drop_column('lotw_certs', 'cert_dxcc');
+	}
+
+	public function down()
+	{
+		$fields = array(
+			'cert_dxcc VARCHAR(255) NOT NULL AFTER `callsign`',
+		);
+
+		if (!$this->db->field_exists('cert_dxcc', 'lotw_certs')) {
+			$this->dbforge->add_column('lotw_certs', $fields);
+		}
+
+		$sql = 'UPDATE `lotw_certs` JOIN `dxcc_entities` ON `lotw_certs`.`cert_dxcc_id` = `dxcc_entities`.`adif` SET `lotw_certs`.`cert_dxcc` = `dxcc_entities`.`name`;';
+		$this->db->query($sql);
+
+		$this->dbforge->drop_column('lotw_certs', 'cert_dxcc_id');
+	}
+}

--- a/application/migrations/118_make_lotw_use_dxcc_id.php
+++ b/application/migrations/118_make_lotw_use_dxcc_id.php
@@ -6,7 +6,7 @@ class Migration_make_lotw_use_dxcc_id extends CI_Migration
 	public function up()
 	{
 		$fields = array(
-			'cert_dxcc_id SMALLINT(6) NOT NULL AFTER `cert_dxcc`',
+			'cert_dxcc_id SMALLINT(6) DEFAULT 0 NOT NULL AFTER `cert_dxcc`',
 		);
 
 		if (!$this->db->field_exists('cert_dxcc_id', 'lotw_certs')) {

--- a/application/models/LotwCert.php
+++ b/application/models/LotwCert.php
@@ -12,7 +12,9 @@ class LotwCert extends CI_Model {
 	*/
 	function lotw_certs($user_id) {
 
+		$this->db->select('lotw_certs.lotw_cert_id as lotw_cert_id, lotw_certs.callsign as callsign, dxcc_entities.name as cert_dxcc, lotw_certs.qso_start_date as qso_start_date, lotw_certs.qso_end_date as qso_end_date, lotw_certs.date_created as date_created, lotw_certs.date_expires as date_expires, lotw_certs.last_upload as last_upload');
 		$this->db->where('user_id', $user_id);
+		$this->db->join('dxcc_entities','lotw_certs.cert_dxcc_id = dxcc_entities.adif','left');
 		$this->db->order_by('cert_dxcc', 'ASC');
 		$query = $this->db->get('lotw_certs');
 			
@@ -29,7 +31,7 @@ class LotwCert extends CI_Model {
 
 	function find_cert($callsign, $dxcc, $user_id) {
 		$this->db->where('user_id', $user_id);
-		$this->db->where('cert_dxcc', $dxcc);
+		$this->db->where('cert_dxcc_id', $dxcc);
 		$this->db->where('callsign', $callsign);
 		$query = $this->db->get('lotw_certs');
 
@@ -40,7 +42,7 @@ class LotwCert extends CI_Model {
 		$data = array(
 		    'user_id' => $user_id,
 		    'callsign' => $callsign,
-		    'cert_dxcc' => $dxcc,
+		    'cert_dxcc_id' => $dxcc,
 		    'date_created' => $date_created,
 		    'date_expires' => $date_expires,
 		    'qso_start_date' => $qso_start_date,
@@ -54,7 +56,7 @@ class LotwCert extends CI_Model {
 
 	function update_certificate($user_id, $callsign, $dxcc, $date_created, $date_expires, $cert_key, $general_cert) {
 		$data = array(
-		    'cert_dxcc' => $dxcc,
+		    'cert_dxcc_id' => $dxcc,
 		    'date_created' => $date_created,
 		    'date_expires' => $date_expires,
 		    'cert_key' => $cert_key,
@@ -63,7 +65,7 @@ class LotwCert extends CI_Model {
 
 		$this->db->where('user_id', $user_id);
 		$this->db->where('callsign', $callsign);
-		$this->db->where('cert_dxcc', $dxcc);
+		$this->db->where('cert_dxcc_id', $dxcc);
 		$this->db->update('lotw_certs', $data);
 	}
 

--- a/application/models/LotwCert.php
+++ b/application/models/LotwCert.php
@@ -22,7 +22,7 @@ class LotwCert extends CI_Model {
 	}
 
 	function lotw_cert_details($callsign, $dxcc) {
-		$this->db->where('cert_dxcc', $dxcc);
+		$this->db->where('cert_dxcc_id', $dxcc);
 		$this->db->where('callsign', $callsign);
 		$query = $this->db->get('lotw_certs');
 

--- a/application/views/lotw_views/adif_views/adif_export.php
+++ b/application/views/lotw_views/adif_views/adif_export.php
@@ -17,7 +17,7 @@ $cert2 = str_replace("-----END CERTIFICATE-----", "", $cert1);
 <CERT_UID:1>1
 <CALL:<?php echo strlen($lotw_cert_info->callsign); ?>><?php echo $lotw_cert_info->callsign; ?>
 
-<DXCC:<?php echo strlen($lotw_cert_info->cert_dxcc_id); ?>><?php echo $lotw_cert_info->cert_dxcc_d; ?>
+<DXCC:<?php echo strlen($lotw_cert_info->cert_dxcc_id); ?>><?php echo $lotw_cert_info->cert_dxcc_id; ?>
 
 <?php if(isset($station_profile->station_gridsquare)) { ?><GRIDSQUARE:<?php echo strlen($station_profile->station_gridsquare); ?>><?php echo $station_profile->station_gridsquare; ?><?php } ?>
 

--- a/application/views/lotw_views/adif_views/adif_export.php
+++ b/application/views/lotw_views/adif_views/adif_export.php
@@ -17,7 +17,7 @@ $cert2 = str_replace("-----END CERTIFICATE-----", "", $cert1);
 <CERT_UID:1>1
 <CALL:<?php echo strlen($lotw_cert_info->callsign); ?>><?php echo $lotw_cert_info->callsign; ?>
 
-<DXCC:<?php echo strlen($station_profile_dxcc->adif); ?>><?php echo $station_profile_dxcc->adif; ?>
+<DXCC:<?php echo strlen($lotw_cert_info->cert_dxcc_id); ?>><?php echo $lotw_cert_info->cert_dxcc_d; ?>
 
 <?php if(isset($station_profile->station_gridsquare)) { ?><GRIDSQUARE:<?php echo strlen($station_profile->station_gridsquare); ?>><?php echo $station_profile->station_gridsquare; ?><?php } ?>
 

--- a/application/views/lotw_views/index.php
+++ b/application/views/lotw_views/index.php
@@ -44,7 +44,7 @@
 						<?php foreach ($lotw_cert_results->result() as $row) { ?>
 							<tr>
 					      		<td><?php echo $row->callsign; ?></td>
-					      		<td><?php echo ucfirst($row->cert_dxcc); ?></td>
+					      		<td><?php echo $row->cert_dxcc == '' ? '- NONE -' : ucfirst($row->cert_dxcc); ?></td>
 								<td><?php
 									if (isset($row->qso_start_date)) {
 										$valid_qso_start = strtotime( $row->qso_start_date );

--- a/application/views/lotw_views/index.php
+++ b/application/views/lotw_views/index.php
@@ -86,8 +86,9 @@
 										<span class="badge badge-success"><?php echo $this->lang->line('lotw_valid'); ?></span>
 									<?php } ?>
 
-									<?php if ($row->last_upload) { ?>
-										<span class="badge badge-success"><?php echo $row->last_upload; ?></span>
+									<?php if ($row->last_upload) {
+										$last_upload = date($this->config->item('qso_date_format').' H:i:s', strtotime( $row->last_upload )); ?>
+										<span class="badge badge-success"><?php echo $last_upload; ?></span>
 									<?php } else { ?>
 										<span class="badge badge-warning"><?php echo $this->lang->line('lotw_not_synced'); ?></span>
 									<?php } ?>

--- a/application/views/lotw_views/upload_cert.php
+++ b/application/views/lotw_views/upload_cert.php
@@ -32,19 +32,6 @@
 				    <input type="file" name="userfile" class="form-control-file" id="exampleFormControlFile1">
 				 </div>
 
-				<div class="form-group">
-					<label for="stationDXCCInput"><?php echo $this->lang->line('lotw_certificate_dxcc'); ?></label>
-						<?php if ($dxcc_list->num_rows() > 0) { ?>
-						<select class="form-control" id="dxcc_select" name="dxcc" aria-describedby="stationCallsignInputHelp">
-						<option value=""></option>
-						<?php foreach ($dxcc_list->result() as $dxcc) { ?>
-						<option value="<?php echo $dxcc->name; ?>"><?php echo $dxcc->name; ?></option>
-						<?php } ?>
-						</select>
-						<?php } ?>
-					<small id="stationDXCCInputHelp" class="form-text text-muted"><?php echo $this->lang->line('lotw_certificate_dxcc_help_text'); ?></small>
-				</div>
-
 				<button type="submit" value="upload" class="btn btn-primary"><?php echo $this->lang->line('lotw_btn_upload_file'); ?></button>
 			</form>
 


### PR DESCRIPTION
We have various issues like https://github.com/magicbug/Cloudlog/discussions/2065 where people seem to set the DXCC for their LotW certs wrong and upload fails. Luckily there is a simple solution for that: We should use the DXCC id that is contained in the LotW cert instead of asking the user to choose the (wrong) DXCC during cert upload.

![Screenshot from 2023-04-19 10-44-01](https://user-images.githubusercontent.com/7112907/233193586-72feffc1-f1d5-483f-ba20-e43ef29698e9.png)

The DXCC/ADIF ID can be found in the additional attributes (OID 1.3.6.1.4.1.12348.1.4). So we go ahead and use that instead of deriving it from dxcc_entities. Special case with ID 0 (i.e. no DXCC as /mm for example) is also handled and displayed accordingly.

Keen to hear your feedback @AndreasK79 and @magicbug. 