### PR TITLE
Fix SQL statement to check for empty LotW dates

### DIFF
--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -58,7 +58,7 @@ class adif_data extends CI_Model {
         $this->db->where($this->config->item('table_name').'.station_id', $active_station_id);
         $this->db->where($this->config->item('table_name').'.COL_PROP_MODE', 'SAT');
 
-        $where = $this->config->item('table_name').".COL_LOTW_QSLRDATE != ''";
+        $where = $this->config->item('table_name').".COL_LOTW_QSLRDATE IS NOT NULL";
         $this->db->where($where);
 
         $this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");


### PR DESCRIPTION
The `Export All Satellite QSOs Confirmed on LoTW` function is b0rken because SQL statement to check for empty dates is wrong:

![Screenshot from 2023-04-21 00-01-49](https://user-images.githubusercontent.com/7112907/233497272-e20d2991-3198-476c-bd47-dfee71a26d0f.png)

This was introduced with https://github.com/magicbug/Cloudlog/commit/d9ec5ec514c3b867b4a7e78d646e5a09032f46bc