### PR TITLE
Remove redundant country colum in station_profile

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 118;
+$config['migration_version'] = 119;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/migrations/119_remove_dxcc_name_from_station_profile.php
+++ b/application/migrations/119_remove_dxcc_name_from_station_profile.php
@@ -1,0 +1,26 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_remove_dxcc_name_from_station_profile extends CI_Migration
+{
+	public function up()
+	{
+		if ($this->db->field_exists('station_country', 'station_profile')) {
+			$this->dbforge->drop_column('station_profile', 'station_country');
+		}	
+	}
+
+	public function down()
+	{
+		$fields = array(
+			'station_country VARCHAR(255) NULL DEFAULT NULL AFTER `station_dxcc`',
+		);
+
+		if (!$this->db->field_exists('station_country', 'station_profile')) {
+			$this->dbforge->add_column('station_profile', $fields);
+		}
+
+		$sql = 'UPDATE `station_profile` JOIN `dxcc_entities` ON `station_profile`.`station_dxcc` = `dxcc_entities`.`adif` SET `station_profile`.`station_country` = `dxcc_entities`.`name`;';
+		$this->db->query($sql);
+	}
+}

--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -5,9 +5,11 @@ class adif_data extends CI_Model {
     function export_all() {
         $this->load->model('stations');
         $active_station_id = $this->stations->find_active();
+        $this->db->select($this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
         $this->db->where($this->config->item('table_name').'.station_id', $active_station_id);
         $this->db->order_by("COL_TIME_ON", "ASC");
         $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+        $this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif');
         $query = $this->db->get($this->config->item('table_name'));
 
         return $query;

--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -17,6 +17,8 @@ class adif_data extends CI_Model {
         $this->load->model('stations');
         $active_station_id = $this->stations->find_active();
 
+        $this->db->select($this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
+
 		if ($station_id == NULL) {
 			$this->db->where($this->config->item('table_name').'.station_id', $active_station_id);
 		} else if ($station_id != 'All') {
@@ -24,6 +26,7 @@ class adif_data extends CI_Model {
 		}
 
         $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+        $this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif');
         // always filter user. this ensures that even if the station_id is from another user no inaccesible QSOs will be returned
         $this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
         $this->db->where_in('COL_QSL_SENT', array('R', 'Q'));
@@ -37,7 +40,7 @@ class adif_data extends CI_Model {
         $this->load->model('stations');
         $active_station_id = $this->stations->find_active();
 
-        $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*');
+        $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
         $this->db->from($this->config->item('table_name'));
         $this->db->where($this->config->item('table_name').'.station_id', $active_station_id);
         $this->db->where($this->config->item('table_name').'.COL_PROP_MODE', 'SAT');
@@ -45,6 +48,7 @@ class adif_data extends CI_Model {
         $this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");
 
         $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+        $this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif');
 
         return $this->db->get();
     }
@@ -53,7 +57,7 @@ class adif_data extends CI_Model {
         $this->load->model('stations');
         $active_station_id = $this->stations->find_active();
 
-        $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*');
+        $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
         $this->db->from($this->config->item('table_name'));
         $this->db->where($this->config->item('table_name').'.station_id', $active_station_id);
         $this->db->where($this->config->item('table_name').'.COL_PROP_MODE', 'SAT');
@@ -65,6 +69,7 @@ class adif_data extends CI_Model {
 
 
         $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+        $this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif');
 
         return $this->db->get();
     }
@@ -77,7 +82,7 @@ class adif_data extends CI_Model {
             return;
         }
 
-        $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*');
+        $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
         $this->db->from($this->config->item('table_name'));
         $this->db->where($this->config->item('table_name').'.station_id', $station_id);
 
@@ -102,6 +107,7 @@ class adif_data extends CI_Model {
         $this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");
 
         $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+        $this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif');
 
         return $this->db->get();
     }
@@ -111,7 +117,7 @@ class adif_data extends CI_Model {
         $active_station_id = $this->stations->find_active();
 
 
-        $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*');
+        $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
         $this->db->from($this->config->item('table_name'));
         $this->db->where($this->config->item('table_name').'.station_id', $active_station_id);
         $this->db->group_start();
@@ -122,6 +128,7 @@ class adif_data extends CI_Model {
         $this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");
 
         $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+        $this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif');
 
         return $this->db->get();
     }
@@ -141,7 +148,7 @@ class adif_data extends CI_Model {
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		$this->db->select(''.$this->config->item('table_name').'.*, station_profile.*');
+		$this->db->select(''.$this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
 		$this->db->from($this->config->item('table_name'));
 		$this->db->where_in($this->config->item('table_name').'.station_id', $logbooks_locations_array);
 		$this->db->where($this->config->item('table_name').'.COL_SIG', $type);
@@ -149,6 +156,7 @@ class adif_data extends CI_Model {
 		$this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");
 
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+		$this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif');
 
 		return $this->db->get();
 	}

--- a/application/models/Clublog_model.php
+++ b/application/models/Clublog_model.php
@@ -63,7 +63,9 @@ class Clublog_model extends CI_Model {
 	}
 
 	function get_clublog_qsos($station_id){
+		$this->db->select('*, dxcc_entities.name as station_country');
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+		$this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif', 'left');
 		$this->db->where($this->config->item('table_name').'.station_id', $station_id);
 		$this->db->group_start();
 		$this->db->where("COL_CLUBLOG_QSO_UPLOAD_STATUS", null);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1303,8 +1303,9 @@ class Logbook_model extends CI_Model {
      * Function returns the QSOs from the logbook, which have not been either marked as uploaded to qrz, or has been modified with an edit
      */
     function get_qrz_qsos($station_id){
-        $sql = 'select * from ' . $this->config->item('table_name') . ' thcv ' .
-            ' join station_profile on thcv.station_id = station_profile.station_id' .
+        $sql = 'select *, dxcc_entities.name as station_country from ' . $this->config->item('table_name') . ' thcv ' .
+            ' left join station_profile on thcv.station_id = station_profile.station_id' .
+            ' left join dxcc_entities on thcv.col_my_dxcc = dxcc_entities.adif' .
             ' where thcv.station_id = ' . $station_id .
             ' and (COL_QRZCOM_QSO_UPLOAD_STATUS is NULL
             or COL_QRZCOM_QSO_UPLOAD_STATUS = ""
@@ -1320,9 +1321,10 @@ class Logbook_model extends CI_Model {
      */
 	function get_webadif_qsos($station_id,$from = null, $to = null){
 		$sql = "
-			SELECT qsos.*, station_profile.*
+			SELECT qsos.*, station_profile.*, dxcc_entities.name as station_country
 			FROM %s qsos
 			INNER JOIN station_profile ON qsos.station_id = station_profile.station_id
+			LEFT JOIN dxcc_entities on qsos.col_my_dxcc = dxcc_entities.adif
 			LEFT JOIN webadif ON qsos.COL_PRIMARY_KEY = webadif.qso_id
 			WHERE qsos.station_id = %d
         AND qsos.COL_SAT_NAME = 'QO-100'

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -294,6 +294,8 @@ class Logbook_model extends CI_Model {
 
   public function check_station($id){
 
+    $this->db->select('station_profile.*, dxcc_entities.name as station_country');
+    $this->db->join('dxcc_entities','station_profile.station_dxcc = dxcc_entities.adif','left');
     $this->db->where('station_id', $id);
     $query = $this->db->get('station_profile');
 
@@ -1287,9 +1289,11 @@ class Logbook_model extends CI_Model {
   }
 
   function get_qso($id) {
+    $this->db->select($this->config->item('table_name').'.*, station_profile.*, dxcc_entities.*, dxcc_entities_2.name as station_country');
     $this->db->from($this->config->item('table_name'));
     $this->db->join('dxcc_entities', $this->config->item('table_name').'.col_dxcc = dxcc_entities.adif', 'left');
-    $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+    $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id', 'left');
+    $this->db->join('dxcc_entities as dxcc_entities_2', 'station_profile.station_dxcc = dxcc_entities_2.adif');
     $this->db->where('COL_PRIMARY_KEY', $id);
 
     return $this->db->get();
@@ -3121,8 +3125,10 @@ class Logbook_model extends CI_Model {
 
             // Collect field information from the station profile table thats required for the QSO.
             if($station_id != "0") {
-              $station_result = $this->db->where('station_id', $station_id)
-                                ->get('station_profile');
+              $this->db->select('station_profile.*, dxcc_entities.name as station_country');
+              $this->db->where('station_id', $station_id);
+              $this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif');
+              $station_result = $this->db->get('station_profile');
 
                 if ($station_result->num_rows() > 0){
                     $data['station_id'] = $station_id;

--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -118,9 +118,10 @@ class Logbookadvanced_model extends CI_Model {
 		}
 
         $sql = "
-            SELECT *
+            SELECT *, dxcc_entities.name AS station_country
 			FROM " . $this->config->item('table_name') . " qsos
 			INNER JOIN station_profile ON qsos.station_id = station_profile.station_id
+			INNER JOIN dxcc_entities ON qsos.COL_MY_DXCC = dxcc_entities.adif
 			WHERE station_profile.user_id =  ?
 			$where
 			ORDER BY qsos.COL_TIME_ON desc

--- a/application/models/Logbooks_model.php
+++ b/application/models/Logbooks_model.php
@@ -262,7 +262,9 @@ class Logbooks_model extends CI_Model {
 				array_push($relationships_array, $row->station_location_id);
 			}
 
+			$this->db->select('station_profile.*, dxcc_entities.name as station_country');
 			$this->db->where_in('station_id', $relationships_array);
+			$this->db->join('dxcc_entities','station_profile.station_dxcc = dxcc_entities.adif','left');
 			$query = $this->db->get('station_profile');
 			
 			return $query;

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -4,9 +4,10 @@ class Stations extends CI_Model {
 
     function all_with_count() {
 
-		$this->db->select('station_profile.*, count('.$this->config->item('table_name').'.station_id) as qso_total');
+		$this->db->select('station_profile.*, dxcc_entities.name as station_country, count('.$this->config->item('table_name').'.station_id) as qso_total');
         $this->db->from('station_profile');
         $this->db->join($this->config->item('table_name'),'station_profile.station_id = '.$this->config->item('table_name').'.station_id','left');
+        $this->db->join('dxcc_entities','station_profile.station_dxcc = dxcc_entities.adif','left');
        	$this->db->group_by('station_profile.station_id');
 		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
 		$this->db->or_where('station_profile.user_id =', NULL);
@@ -20,7 +21,9 @@ class Stations extends CI_Model {
 	}
 
 	function all_of_user() {
+		$this->db->select('station_profile.*, dxcc_entities.name as station_country');
 		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->join('dxcc_entities','station_profile.station_dxcc = dxcc_entities.adif','left');
 		return $this->db->get('station_profile');
 	}
 
@@ -70,7 +73,6 @@ class Stations extends CI_Model {
 			'station_sig_info' =>  xss_clean(strtoupper($this->input->post('sig_info', true))),
 			'station_callsign' =>  xss_clean($this->input->post('station_callsign', true)),
 			'station_dxcc' =>  xss_clean($this->input->post('dxcc', true)),
-			'station_country' =>  xss_clean($this->input->post('station_country', true)),
 			'station_cnty' =>  xss_clean($this->input->post('station_cnty', true)),
 			'station_cq' =>  xss_clean($this->input->post('station_cq', true)),
 			'station_itu' =>  xss_clean($this->input->post('station_itu', true)),
@@ -103,7 +105,6 @@ class Stations extends CI_Model {
 			'station_sig_info' => xss_clean($this->input->post('sig_info', true)),
 			'station_callsign' => xss_clean($this->input->post('station_callsign', true)),
 			'station_dxcc' => xss_clean($this->input->post('dxcc', true)),
-			'station_country' => xss_clean($this->input->post('station_country', true)),
 			'station_cnty' => xss_clean($this->input->post('station_cnty', true)),
 			'station_cq' => xss_clean($this->input->post('station_cq', true)),
 			'station_itu' => xss_clean($this->input->post('station_itu', true)),
@@ -256,7 +257,9 @@ class Stations extends CI_Model {
 		// Clean ID
 		$clean_id = $this->security->xss_clean($id);
 
-    	$this->db->where('station_id', $clean_id);
+		$this->db->select('station_profile.*, dxcc_entities.name as station_country');
+		$this->db->where('station_id', $clean_id);
+		$this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif');
 		$query = $this->db->get('station_profile');
 
 		$row = $query->row();

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -17,7 +17,10 @@ class Stations extends CI_Model {
 	// Returns ALL station profiles regardless of user logged in
 	// This is also used by LoTW sync so must not be changed.
 	function all() {
-		return $this->db->get('station_profile');
+		$this->db->select('station_profile.*, dxcc_entities.name as station_country');
+		$this->db->from('station_profile');
+		$this->db->join('dxcc_entities','station_profile.station_dxcc = dxcc_entities.adif','left');
+		return $this->db->get();
 	}
 
 	function all_of_user() {

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -50,7 +50,6 @@
 				<?php } ?>
 				</select>
 				<?php } ?>
-				<input type="hidden" id="country" name="station_country" value="" required />
 		    <small id="stationDXCCInputHelp" class="form-text text-muted">Station DXCC entity. For example: Scotland</small>
 		  </div>
 

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -69,7 +69,6 @@
 							<?php } ?>
 							</select>
 							<?php } ?>
-						<input type="hidden" id="country" name="station_country" value="<?php if(set_value('station_country') != "") { echo set_value('station_country'); } else { echo $my_station_profile->station_country; } ?>" required />
 						<small id="stationDXCCInputHelp" class="form-text text-muted">Station DXCC entity. For example: Scotland</small>
 					</div>
 

--- a/application/views/station_profile/index.php
+++ b/application/views/station_profile/index.php
@@ -59,7 +59,7 @@
 						<?php echo $row->station_profile_name;?><br>
 					</td>
 					<td><?php echo $row->station_callsign;?></td>
-					<td><?php echo $row->station_country;?></td>
+					<td><?php echo $row->station_country == '' ? '- NONE -' : $row->station_country;?></td>
 					<td><?php echo $row->station_gridsquare;?></td>
 					<td style="text-align: center" data-order="<?php echo $row->station_id;?>">
 						<?php if($row->station_active != 1) { ?>


### PR DESCRIPTION
After working several days with @AndreasK79 it came clear that station_country is a multi-redundant column in station_profile table. This has several implications (besides redundant data) and for example breaks marking deleted DXCC as such. From my extensive tests it seems that I pinched all functions relying on station_country and replaced them with proper SQL joins to get DXCC name from dxcc_entities. But still I would like @AndreasK79 and @magicbug to confirm before merging this to dev.

Squashed commit of the following:

commit 29e5f5118a1c3f8deb623e5948c3b7602241792d
Merge: 566b390d e0a04cbe
Author: phl0 <github@florian-wolters.de>
Date:   Mon Apr 24 23:28:31 2023 +0200

    Merge remote-tracking branch 'upstream/dev' into removeRedundantDxccNames

commit 566b390d8b0322b32f4438994354ce902010c0d4
Author: phl0 <github@florian-wolters.de>
Date:   Mon Apr 24 23:18:28 2023 +0200

    Refactor reassign function to use DXCC name from dxcc_entities

commit 2e50b34c1bdb9bb087e0e0d16f13c340c15588fb
Author: phl0 <github@florian-wolters.de>
Date:   Mon Apr 24 22:05:12 2023 +0200

    Use DXCC name from DXCC entities upon import

commit d2b1d895818777747db593848b855819f53ffe6d
Author: phl0 <github@florian-wolters.de>
Date:   Mon Apr 24 21:18:53 2023 +0200

    Add DB migration script

commit 0ecf4b8d9cf0253c1f818a252f7ae83722254544
Author: phl0 <github@florian-wolters.de>
Date:   Mon Apr 24 18:16:55 2023 +0200

    Fix export function for requests QSLs

commit 51d2c5c6175a8e8c69b9edd57d6f1e95c4a03600
Author: phl0 <github@florian-wolters.de>
Date:   Mon Apr 24 17:53:50 2023 +0200

    Fix webadif/qrz upload

commit 45039a6b1284d1a23f610fc70a39ef25ce720cab
Author: phl0 <github@florian-wolters.de>
Date:   Mon Apr 24 17:32:40 2023 +0200

    Fix lotw_export function

commit 1306225d027cacbe70e510fd0fc5d3ca5040c35e
Author: phl0 <github@florian-wolters.de>
Date:   Mon Apr 24 17:21:37 2023 +0200

    Fix SIG export function

commit 082798a80d8bb446500dcbadfa4912c510e4a458
Author: phl0 <github@florian-wolters.de>
Date:   Mon Apr 24 17:01:42 2023 +0200

    Fix SAT export functions

commit 2f035afaa3d3c74ca811c96c66f7bf9726b31a78
Merge: 87555f20 d6139439
Author: phl0 <github@florian-wolters.de>
Date:   Mon Apr 24 16:52:43 2023 +0200

    Merge remote-tracking branch 'upstream/dev' into removeRedundantDxccNames

commit 87555f201817fb963be117ab193d42bc03889972
Author: phl0 <github@florian-wolters.de>
Date:   Thu Apr 20 23:54:14 2023 +0200

    Use DXCC entity name from dxcc_entities in ADIF export

commit e2fd1c5eb9b7e3257ed016814719bc7f9b913587
Author: phl0 <github@florian-wolters.de>
Date:   Thu Apr 20 23:36:16 2023 +0200

    Make logbooks use DXCC name from entities table

commit 463057523dacbc34a545f0d9f720f2c29c9883a7
Author: phl0 <github@florian-wolters.de>
Date:   Thu Apr 20 23:01:58 2023 +0200

    Use DXCC name from separate table in QSO view

commit 62b8f7aed8c1dca426b055eb7af6360106fc022b
Author: phl0 <github@florian-wolters.de>
Date:   Thu Apr 20 18:21:57 2023 +0200

    Add table join to station profile lookup

commit 0afe155f46f1fcd227446166b215a98729494dc8
Author: phl0 <github@florian-wolters.de>
Date:   Thu Apr 20 18:13:35 2023 +0200

    Remove country name from edit functions

commit ecb3689a0a73f0cc9c5ca7eba5dec7df5f9fbcd1
Author: phl0 <github@florian-wolters.de>
Date:   Thu Apr 20 18:07:58 2023 +0200

    Remove station_country parameter

commit 22c350a585a3ff95d1d0b1f49dbe8ca310bdaf85
Author: phl0 <github@florian-wolters.de>
Date:   Thu Apr 20 17:59:24 2023 +0200

    Use DXCC name from dxcc_entitites table