### PR TITLE
Make stats publicly usable with API key

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -672,14 +672,14 @@ class API extends CI_Controller {
 	*
 	*/
 
-	function statistics() {
+	function statistics($key = null) {
 		header('Content-type: application/json');
 		$this->load->model('logbook_model');
 
-		$data['todays_qsos'] = $this->logbook_model->todays_qsos();
-		$data['total_qsos'] = $this->logbook_model->total_qsos();
-		$data['month_qsos'] = $this->logbook_model->month_qsos();
-		$data['year_qsos'] = $this->logbook_model->year_qsos();
+		$data['todays_qsos'] = $this->logbook_model->todays_qsos(null, $key);
+		$data['total_qsos'] = $this->logbook_model->total_qsos(null, $key);
+		$data['month_qsos'] = $this->logbook_model->month_qsos(null, $key);
+		$data['year_qsos'] = $this->logbook_model->year_qsos(null, $key);
 
 		http_response_code(201);
 		echo json_encode(['Today' => $data['todays_qsos'], 'total_qsos' => $data['total_qsos'], 'month_qsos' => $data['month_qsos'], 'year_qsos' => $data['year_qsos']]);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1583,11 +1583,23 @@ class Logbook_model extends CI_Model {
   }
 
     /* Return total number of qsos */
-    function total_qsos($StationLocationsArray = null) {
+    function total_qsos($StationLocationsArray = null, $api_key = null) {
       if($StationLocationsArray == null) {
         $CI =& get_instance();
         $CI->load->model('logbooks_model');
-        $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+        if ($api_key != null) {
+          $CI->load->model('api_model');
+          if (strpos($this->api_model->access($api_key), 'r') !== false) {
+            $this->api_model->update_last_used($api_key);
+            $user_id = $this->api_model->key_userid($api_key);
+            $active_station_logbook = $CI->logbooks_model->find_active_station_logbook_from_userid($user_id);
+            $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($active_station_logbook);
+          } else {
+            $logbooks_locations_array = [];
+          }
+        } else {
+          $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+        }
       } else {
         $logbooks_locations_array = $StationLocationsArray;
       }
@@ -1610,11 +1622,23 @@ class Logbook_model extends CI_Model {
     }
 
     /* Return number of QSOs had today */
-    function todays_qsos($StationLocationsArray = null) {
+    function todays_qsos($StationLocationsArray = null, $api_key = null) {
       if($StationLocationsArray == null) {
         $CI =& get_instance();
         $CI->load->model('logbooks_model');
-        $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+        if ($api_key != null) {
+          $CI->load->model('api_model');
+          if (strpos($this->api_model->access($api_key), 'r') !== false) {
+            $this->api_model->update_last_used($api_key);
+            $user_id = $this->api_model->key_userid($api_key);
+            $active_station_logbook = $CI->logbooks_model->find_active_station_logbook_from_userid($user_id);
+            $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($active_station_logbook);
+          } else {
+            $logbooks_locations_array = [];
+          }
+        } else {
+          $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+        }
       } else {
         $logbooks_locations_array = $StationLocationsArray;
       }
@@ -1713,11 +1737,23 @@ class Logbook_model extends CI_Model {
     }
 
     // Return QSOs made during the current month
-    function month_qsos($StationLocationsArray = null) {
+    function month_qsos($StationLocationsArray = null, $api_key = null) {
       if($StationLocationsArray == null) {
         $CI =& get_instance();
         $CI->load->model('logbooks_model');
-        $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+        if ($api_key != null) {
+          $CI->load->model('api_model');
+          if (strpos($this->api_model->access($api_key), 'r') !== false) {
+            $this->api_model->update_last_used($api_key);
+            $user_id = $this->api_model->key_userid($api_key);
+            $active_station_logbook = $CI->logbooks_model->find_active_station_logbook_from_userid($user_id);
+            $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($active_station_logbook);
+          } else {
+            $logbooks_locations_array = [];
+          }
+        } else {
+          $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+        }
       } else {
         $logbooks_locations_array = $StationLocationsArray;
       }
@@ -1764,12 +1800,24 @@ class Logbook_model extends CI_Model {
 
 
     /* Return QSOs made during the current Year */
-    function year_qsos($StationLocationsArray = null) {
+    function year_qsos($StationLocationsArray = null, $api_key = null) {
 
       if($StationLocationsArray == null) {
         $CI =& get_instance();
         $CI->load->model('logbooks_model');
-        $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+        if ($api_key != null) {
+          $CI->load->model('api_model');
+          if (strpos($this->api_model->access($api_key), 'r') !== false) {
+            $this->api_model->update_last_used($api_key);
+            $user_id = $this->api_model->key_userid($api_key);
+            $active_station_logbook = $CI->logbooks_model->find_active_station_logbook_from_userid($user_id);
+            $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($active_station_logbook);
+          } else {
+             $logbooks_locations_array = [];
+          }
+        } else {
+          $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+        }
       } else {
         $logbooks_locations_array = $StationLocationsArray;
       }

--- a/application/models/Logbooks_model.php
+++ b/application/models/Logbooks_model.php
@@ -308,5 +308,19 @@ class Logbooks_model extends CI_Model {
 		}
 		return false;
 	}
+
+	public function find_active_station_logbook_from_userid($userid) {
+		$this->db->select('active_station_logbook');
+		$this->db->where('user_id', $userid);
+		$query = $this->db->get('users');
+		if ($query->num_rows() > 0){
+			foreach ($query->result() as $row)
+			{
+				return $row->active_station_logbook;
+			}
+		} else {
+			return 0;
+		}
+	}
 }
 ?>

--- a/application/views/api/help.php
+++ b/application/views/api/help.php
@@ -27,8 +27,9 @@
 		      <th scope="col">API Key</th>
 		      <th scope="col">Description</th>
 		      <th scope="col">Last Used</th>
-		      <th scope="col">Rights</th>
+		      <th scope="col">Permissions</th>
 		      <th scope="col">Status</th>
+		      <th scope="col">Actions</th>
 		    </tr>
 		  </thead>
 		  <tbody>
@@ -41,18 +42,18 @@
 						<?php
 							
 							if($row->rights == "rw") {
-								echo "Read & Write";
+								echo "<span class=\"badge badge-warning\">Read & Write</span>";
 							} elseif($row->rights == "r") {
-								echo "Read Only";
+								echo "<span class=\"badge badge-success\">Read-Only</span>";
 							} else {
-								echo "Unknown";
+								echo "<span class=\"badge badge-dark\">Unknown</span>";
 							}
 			
 						?>
 
 					</td>
-					<td><span class="badge badge-pill badge-light"><?php echo ucfirst($row->status); ?></span>
-
+					<td><span class="badge badge-pill badge-success"><?php echo ucfirst($row->status); ?></span></td>
+					<td>
 						<a href="<?php echo site_url('api/edit'); ?>/<?php echo $row->key; ?>" class="btn btn-outline-primary btn-sm">Edit</a>
 
 						<a href="<?php echo site_url('api/auth/'.$row->key); ?>" target="_blank" class="btn btn-primary btn-sm">Test</a>


### PR DESCRIPTION
Tuned the statistics function so that it allows for public usage (i.e. not logged-in) with an API key that is at least read-only.

Was requested in https://github.com/magicbug/Cloudlog/discussions/1697. So I kindly ask @M0TZO for a test and feedback here.