### PR TITLE
Add option for default station power

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 119;
+$config['migration_version'] = 120;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -483,6 +483,15 @@ class QSO extends CI_Controller {
       echo $this->wwff->info($wwff);
    }
 
+   public function get_station_power() {
+      $this->load->model('stations');
+      $stationProfile = xss_clean($this->input->post('stationProfile'));
+      $data = array('station_power' => $this->stations->get_station_power($stationProfile));
+
+      header('Content-Type: application/json');
+      echo json_encode($data);
+   }
+
    function check_locator($grid) {
       $grid = $this->input->post('locator');
       // Allow empty locator

--- a/application/migrations/120_add_station_power.php
+++ b/application/migrations/120_add_station_power.php
@@ -1,0 +1,24 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_add_station_power extends CI_Migration
+{
+	public function up()
+	{
+		$fields = array(
+			'station_power SMALLINT NULL DEFAULT NULL AFTER `station_callsign`',
+		);
+
+		if (!$this->db->field_exists('station_power', 'station_profile')) {
+			$this->dbforge->add_column('station_profile', $fields);
+		}
+	}
+
+	public function down()
+	{
+
+		if ($this->db->field_exists('station_power', 'station_profile')) {
+			$this->dbforge->drop_column('station_profile', 'station_power');
+		}	
+	}
+}

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -75,6 +75,7 @@ class Stations extends CI_Model {
 			'station_sig' =>  xss_clean(strtoupper($this->input->post('sig', true))),
 			'station_sig_info' =>  xss_clean(strtoupper($this->input->post('sig_info', true))),
 			'station_callsign' =>  xss_clean($this->input->post('station_callsign', true)),
+			'station_power' =>  xss_clean($this->input->post('station_power', true)),
 			'station_dxcc' =>  xss_clean($this->input->post('dxcc', true)),
 			'station_cnty' =>  xss_clean($this->input->post('station_cnty', true)),
 			'station_cq' =>  xss_clean($this->input->post('station_cq', true)),
@@ -107,6 +108,7 @@ class Stations extends CI_Model {
 			'station_sig' => xss_clean($this->input->post('sig', true)),
 			'station_sig_info' => xss_clean($this->input->post('sig_info', true)),
 			'station_callsign' => xss_clean($this->input->post('station_callsign', true)),
+			'station_power' => xss_clean($this->input->post('station_power', true)),
 			'station_dxcc' => xss_clean($this->input->post('dxcc', true)),
 			'station_cnty' => xss_clean($this->input->post('station_cnty', true)),
 			'station_cq' => xss_clean($this->input->post('station_cq', true)),
@@ -417,6 +419,21 @@ class Stations extends CI_Model {
 			return true;
 		}
 		return false;
+	}
+
+	public function get_station_power($id) {
+		$this->db->select('station_power');
+		$this->db->where('user_id', $this->session->userdata('user_id'));
+		$this->db->where('station_id', $id);
+		$query = $this->db->get('station_profile');
+		if($query->num_rows() >= 1) {
+			foreach ($query->result() as $row)
+			{
+				return $row->station_power;
+			}
+		} else {
+			return null;
+		}
 	}
 }
 

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1086,7 +1086,6 @@ $(document).on('keypress',function(e) {
 
 	$('#stationProfile').change(function() {
 		var stationProfile = $('#stationProfile').val();
-      console.log("TEST "+stationProfile);
 		$.ajax({
 			url: base_url+'index.php/qso/get_station_power',
 			type: 'post',

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1084,6 +1084,22 @@ $(document).on('keypress',function(e) {
 	});
 <?php } ?>
 
+	$('#stationProfile').change(function() {
+		var stationProfile = $('#stationProfile').val();
+      console.log("TEST "+stationProfile);
+		$.ajax({
+			url: base_url+'index.php/qso/get_station_power',
+			type: 'post',
+			data: {'stationProfile': stationProfile},
+			success: function(res) {
+				$('#transmit_power').val(res.station_power);
+			},
+			error: function() {
+				$('#transmit_power').val('');
+			},
+		});
+	});
+
 <?php if ($this->session->userdata('user_qth_lookup') == 1) { ?>
     $('#qth').focusout(function() {
     	if ($('#locator').val() === '') {

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -156,8 +156,11 @@
             <div class="form-group">
               <label for="stationProfile"><?php echo $this->lang->line('cloudlog_station_profile'); ?></label>
               <select id="stationProfile" class="custom-select" name="station_profile">
-                <?php foreach ($stations->result() as $stationrow) { ?>
-                <option value="<?php echo $stationrow->station_id; ?>" <?php if($active_station_profile == $stationrow->station_id) { echo "selected=\"selected\""; } ?>><?php echo $stationrow->station_profile_name; ?></option>
+                <?php
+                   $power = '';
+                      foreach ($stations->result() as $stationrow) {
+                ?>
+                <option value="<?php echo $stationrow->station_id; ?>" <?php if($active_station_profile == $stationrow->station_id) { echo "selected=\"selected\""; $power = $stationrow->station_power; } ?>><?php echo $stationrow->station_profile_name; ?></option>
                 <?php } ?>
               </select>
             </div>
@@ -203,7 +206,7 @@
 
             <div class="form-group">
               <label for="transmit_power"><?php echo $this->lang->line('gen_hamradio_transmit_power'); ?></label>
-              <input type="number" step="0.001" class="form-control" id="transmit_power" name="transmit_power" value="<?php echo $this->session->userdata('transmit_power'); ?>" />
+              <input type="number" step="0.001" class="form-control" id="transmit_power" name="transmit_power" value="<?php if ($this->session->userdata('transmit_power')) { echo $this->session->userdata('transmit_power'); } else { echo $power; } ?>" />
               <small id="powerHelp" class="form-text text-muted"><?php echo $this->lang->line('qso_transmit_power_helptext'); ?></small>
             </div>
           </div>

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -40,6 +40,12 @@
 		    <small id="stationCallsignInputHelp" class="form-text text-muted">Station callsign. For example: 2M0SQL/P</small>
 		  </div>
 
+			<div class="form-group">
+		    <label for="stationPowerInput">Station Power</label>
+		    <input type="number" class="form-control" name="station_power" id="stationPowerInput" step="1" aria-describedby="stationPowerInputHelp" placeholder="10" required>
+		    <small id="stationPowerInputHelp" class="form-text text-muted">Default station power. Overwritten by CAT.</small>
+		  </div>
+
 		  <div class="form-group">
 		    <label for="stationDXCCInput">Station DXCC</label>
 				<?php if ($dxcc_list->num_rows() > 0) { ?>

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -47,6 +47,12 @@
 						<input type="text" class="form-control" name="station_callsign" id="stationCallsignInput" aria-describedby="stationCallsignInputHelp" value="<?php if(set_value('station_callsign') != "") { echo set_value('station_callsign'); } else { echo $my_station_profile->station_callsign; } ?>" required>
 						<small id="stationCallsignInputHelp" class="form-text text-muted">Station callsign. For example: 2M0SQL/P</small>
 					</div>
+
+					<div class="form-group">
+						<label for="stationPowerInput">Station Power</label>
+						<input type="number" class="form-control" name="station_power" step="1" id="stationPowerInput" aria-describedby="stationPowerInputHelp" value="<?php if(set_value('station_power') != "") { echo set_value('station_power'); } else { echo $my_station_profile->station_power; } ?>">
+						<small id="stationPowerInputHelp" class="form-text text-muted">Default station power. Overwritten by CAT.</small>
+					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This addresses https://github.com/magicbug/Cloudlog/issues/2055 by adding a parameter to station_locations that holds a value for a default power. This is of course overwritten by CAT or user entered values. Please test and report.