### PR TITLE
Remove useless file writing

### DIFF
--- a/application/controllers/Kmlexport.php
+++ b/application/controllers/Kmlexport.php
@@ -90,17 +90,8 @@ class Kmlexport extends CI_Controller {
 		$output .= "</Document>";
 		$output .= "</kml>";
 
-        if (!file_exists('kml')) {
-            mkdir('kml', 0755, true);
-        }
-
-		if ( ! write_file('kml/qsos.kml', $output)) {
-		     echo 'Unable to write the file. Make sure the folder KML has write permissions.';
-		}
-		else {
-		    header("Content-Disposition: attachment; filename=\"qsos.kml\"");
-			echo $output;
-		}
+		header("Content-Disposition: attachment; filename=\"qsos.kml\"");
+		echo $output;
 
 	}
 }


### PR DESCRIPTION
This addresses https://github.com/magicbug/Cloudlog/discussions/2123.
The file is written for no purpose. The content is saved to a variable which is then send downstream to the client. The file is written in parallel but not used anywhere. So imho we can remove that part of the code. Opinions @magicbug @AndreasK79?