### PR TITLE
Deleted badge dxcc award

### DIFF
--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -87,7 +87,7 @@ class DXCC extends CI_Model {
 				$dxccMatrix[$dxcc->adif]['name'] = ucwords(strtolower($dxcc->name), "- (/");
 				$dxccMatrix[$dxcc->adif]['Dxccprefix'] = $dxcc->prefix;
 				if ($postdata['includedeleted'])
-					$dxccMatrix[$dxcc->adif]['Deleted'] = isset($dxcc->Enddate) ? "<div class='alert-danger'>Y</div>" : '';
+					$dxccMatrix[$dxcc->adif]['Deleted'] = isset($dxcc->Enddate) ? 1 : 0;
 				$dxccMatrix[$dxcc->adif][$band] = '-';
 			}
 

--- a/application/views/awards/dxcc/index.php
+++ b/application/views/awards/dxcc/index.php
@@ -209,7 +209,7 @@
                         <td>'. $i++ .'</td>';
             foreach ($value as $name => $key) {
                 if (isset($value['Deleted']) && $value['Deleted'] == 1 && $name == "name") {
-                   echo '<td style="text-align: center">' . $key . ' <span class="badge badge-danger">'.$this->lang->line('gen_hamradio_deleted_dxcc').'</span></td>';
+                   echo '<td style="text-align: center">' . $key . ' <span class="badge badge-danger">'.lang('gen_hamradio_deleted_dxcc').'</span></td>';
                 } else if ($name == "Deleted") {
                    continue;
                 } else {

--- a/application/views/awards/dxcc/index.php
+++ b/application/views/awards/dxcc/index.php
@@ -198,9 +198,6 @@
                         <td>#</td>
                         <td>DXCC Name</td>
                         <td>Prefix</td>';
-        if ($this->input->post('includedeleted'))
-            echo '
-                        <td>Deleted</td>';
         foreach($bands as $band) {
             echo '<td>' . $band . '</td>';
         }
@@ -210,8 +207,14 @@
         foreach ($dxcc_array as $dxcc => $value) {      // Fills the table with the data
             echo '<tr>
                         <td>'. $i++ .'</td>';
-            foreach ($value  as $key) {
-                echo '<td style="text-align: center">' . $key . '</td>';
+            foreach ($value as $name => $key) {
+                if (isset($value['Deleted']) && $value['Deleted'] == 1 && $name == "name") {
+                   echo '<td style="text-align: center">' . $key . ' <span class="badge badge-danger">'.$this->lang->line('gen_hamradio_deleted_dxcc').'</span></td>';
+                } else if ($name == "Deleted") {
+                   continue;
+                } else {
+                   echo '<td style="text-align: center">' . $key . '</td>';
+                }
             }
             echo '</tr>';
         }


### PR DESCRIPTION
Changes table layout for DXCC awards to align with display of deleted DXCCs in all other locations. 
View before:

![Screenshot from 2023-05-14 16-01-04](https://github.com/magicbug/Cloudlog/assets/7112907/318b4ef1-568b-43be-a795-d0c0413cd5c9)

View after:

![Screenshot from 2023-05-14 16-00-53](https://github.com/magicbug/Cloudlog/assets/7112907/3c59ac22-092a-481e-9565-e5f6f53688ca)

This presumes https://github.com/magicbug/Cloudlog/pull/2138 to be merged beforehand.
