### PR TITLE
[Visual decorations] Small decoration for header of the log overview …

### DIFF
--- a/application/views/view_log/index.php
+++ b/application/views/view_log/index.php
@@ -2,7 +2,7 @@
 
 	<h2><?php echo lang('gen_hamradio_logbook'); ?></h2>
 	<?php if ($results) { ?>
-		<h6><?php echo lang('gen_hamradio_logbook').": ".$this->logbooks_model->find_name($this->session->userdata('active_station_logbook')); ?> <?php echo lang('general_word_location').": ".$this->stations->find_name(); ?></h6>
+		<h6><?php echo lang('gen_hamradio_logbook').": <b>".$this->logbooks_model->find_name($this->session->userdata('active_station_logbook')); ?></b> <?php echo lang('general_word_location').": <b>".$this->stations->find_name(); ?></b></h6>
 	<?php } ?>
 
 

--- a/application/views/view_log/index.php
+++ b/application/views/view_log/index.php
@@ -2,7 +2,7 @@
 
 	<h2><?php echo lang('gen_hamradio_logbook'); ?></h2>
 	<?php if ($results) { ?>
-		<h6><?php echo lang('gen_hamradio_logbook').": <span class='value_decorated'>".$this->logbooks_model->find_name($this->session->userdata('active_station_logbook')); ?></span> <?php echo lang('general_word_location').": <span class='value_decorated'>".$this->stations->find_name(); ?></span></h6>
+		<h6><?php echo lang('gen_hamradio_logbook').": <span class='station_logbook_decoration'>".$this->logbooks_model->find_name($this->session->userdata('active_station_logbook')); ?></span> <?php echo lang('general_word_location').": <span class='station_location_decoration'>".$this->stations->find_name(); ?></span></h6>
 	<?php } ?>
 
 

--- a/application/views/view_log/index.php
+++ b/application/views/view_log/index.php
@@ -2,7 +2,7 @@
 
 	<h2><?php echo lang('gen_hamradio_logbook'); ?></h2>
 	<?php if ($results) { ?>
-		<h6><?php echo lang('gen_hamradio_logbook').": <b>".$this->logbooks_model->find_name($this->session->userdata('active_station_logbook')); ?></b> <?php echo lang('general_word_location').": <b>".$this->stations->find_name(); ?></b></h6>
+		<h6><?php echo lang('gen_hamradio_logbook').": <span class='value_decorated'>".$this->logbooks_model->find_name($this->session->userdata('active_station_logbook')); ?></span> <?php echo lang('general_word_location').": <span class='value_decorated'>".$this->stations->find_name(); ?></span></h6>
 	<?php } ?>
 
 

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -439,7 +439,12 @@ div#station_logbooks_linked_table_paginate {
 }
 
 
-.value_decorated{
+.station_logbook_decoration{
+    font-weight: bold;
+    font-size: larger;
+}
+
+.station_location_decoration{
     font-weight: bold;
     font-size: larger;
 }

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -437,3 +437,9 @@ div#station_logbooks_linked_table_paginate {
     max-height: calc(100vh - 270px);
 	overflow-y: auto;
 }
+
+
+.value_decorated{
+    font-weight: bold;
+    font-size: larger;
+}


### PR DESCRIPTION
Added bold font decoration to the station logbook and station location names in the header. This makes the names more visible than before.
Before:
![2023-05-16_21-27-03](https://github.com/magicbug/Cloudlog/assets/16667173/2bffb229-4311-4794-8066-1d9730866b03)
After:
![2023-05-16_21-27-41](https://github.com/magicbug/Cloudlog/assets/16667173/2c28dd7f-37c3-44cd-9ba3-fb01584c95d0)
