### PR TITLE
Update Distances_model : change "round" to "ceil"

### DIFF
--- a/application/models/Distances_model.php
+++ b/application/models/Distances_model.php
@@ -256,13 +256,13 @@ class Distances_model extends CI_Model
 
         switch ($measurement_base) {
             case 'M':
-                return round(6371*$ca/1.609344);
+                return ceil(6371*$ca/1.609344);
             case 'K':
-                return round(6371*$ca);
+                return ceil(6371*$ca);
             case 'N':
-                return round(6371*$ca/1.852);
+                return ceil(6371*$ca/1.852);
             default:
-                return round(6371*$ca);
+                return ceil(6371*$ca);
         }
     }
 }


### PR DESCRIPTION
I propose change "round" to "ceil" (Round fractions up).

Because I work on an export plugin in EDI file (IARU REGTEST1), the rounding is systematically higher: "For the amateur bands up to 10 GHz inclusive, points will be scored on the basis of one point per kilometer, i.e. the calculated distance in kilometers will be truncated to an integer value and 1 km will be added. " (excerpt from VHF_Handbook_V9.01)