### PR TITLE
Make contest table use padding for SRX and STX

### DIFF
--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -528,7 +528,21 @@ function restoreContestSession(data) {
 							"scrollCollapse": true,
 							"paging": false,
 							"scrollX": true,
-							order: [0, 'desc']
+							order: [0, 'desc'],
+							"columnDefs": [
+								{
+									"render": function ( data, type, row ) {
+										return pad(row[8],3);
+									},
+									"targets" : 8
+								},
+								{
+									"render": function ( data, type, row ) {
+										return pad(row[9],3);
+									},
+									"targets" : 9
+								}
+							]
 						});
 					}
 				}
@@ -537,4 +551,9 @@ function restoreContestSession(data) {
 	} else {
 		$("#exch_serial_s").val("1");
 	}
+}
+
+function pad (str, max) {
+	str = str.toString();
+	return str.length < max ? pad("0" + str, max) : str;
 }


### PR DESCRIPTION
Use a little padding for SRX and STX.

![Screenshot from 2023-05-27 14-32-06](https://github.com/magicbug/Cloudlog/assets/7112907/c1a05b7e-1ce0-4f71-9d08-0f42e1170387)
