### PR TITLE
Create and publish Docker image of Cloudlog

### DIFF
--- a/.github/workflows/push-hub.yml
+++ b/.github/workflows/push-hub.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: 'Get Previous tag'
+      - name: Get latest tag
         id: latesttag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
-        with:
-          fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Print latest tag
+        run: echo ${{ env.RELEASE_VERSION }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -33,4 +33,4 @@ jobs:
           context: ./docker
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{ steps.latesttag.outputs.tag }}
+          tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/push-hub.yml
+++ b/.github/workflows/push-hub.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Get latest tag
-        id: latesttag
-        run: |
-         echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
-         echo "Tag name from github.ref_name: ${{  github.ref_name }}"
+      - uses: oprypin/find-latest-tag@v1
+        id: findtag  # The step ID to refer to later.
+        with:
+          #repository: octokit/rest.js  # The repository to scan.
+          releases-only: true  # We know that all relevant tags have a GitHub release for them.
       - name: Print latest tag
-        run: echo ${{  github.ref_name }}
+        run: echo ${{ steps.findtag.outputs.tag }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -35,4 +35,4 @@ jobs:
           context: ./docker
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{  github.ref_name }}
+          tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{ steps.findtag.outputs.tag }}

--- a/.github/workflows/push-hub.yml
+++ b/.github/workflows/push-hub.yml
@@ -34,4 +34,4 @@ jobs:
           file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{ steps.get-latest-tag.outputs.tag }}
+          tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{ steps.get-latest-tag.outputs.tag }},${{ secrets.DOCKERHUB_IMAGENAME }}:latest

--- a/.github/workflows/push-hub.yml
+++ b/.github/workflows/push-hub.yml
@@ -1,4 +1,4 @@
-name: ci
+name: Push Docker image to the Hub
 
 on:
   push:

--- a/.github/workflows/push-hub.yml
+++ b/.github/workflows/push-hub.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
-          context: ./docker
+          context: ./
+          file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{ steps.get-latest-tag.outputs.tag }}

--- a/.github/workflows/push-hub.yml
+++ b/.github/workflows/push-hub.yml
@@ -1,0 +1,36 @@
+name: ci
+
+#on:
+#  push:
+#    branches:
+#      - "main"
+
+on: workflow_dispatch
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: 'Get Previous tag'
+        id: latesttag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        with:
+          fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: ./docker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{ steps.latesttag.outputs.tag }}

--- a/.github/workflows/push-hub.yml
+++ b/.github/workflows/push-hub.yml
@@ -13,13 +13,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: oprypin/find-latest-tag@v1
-        id: findtag  # The step ID to refer to later.
-        with:
-          #repository: octokit/rest.js  # The repository to scan.
-          releases-only: true  # We know that all relevant tags have a GitHub release for them.
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
       - name: Print latest tag
-        run: echo ${{ steps.findtag.outputs.tag }}
+        run: echo ${{ steps.get-latest-tag.outputs.tag }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -35,4 +32,4 @@ jobs:
           context: ./docker
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{ steps.findtag.outputs.tag }}
+          tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{ steps.get-latest-tag.outputs.tag }}

--- a/.github/workflows/push-hub.yml
+++ b/.github/workflows/push-hub.yml
@@ -1,11 +1,12 @@
 name: ci
 
-#on:
-#  push:
-#    branches:
-#      - "main"
+on:
+  push:
+    # Pattern matched against refs/tags
+    tags:        
+      - '*'           # Push events to every tag not containing
 
-on: workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   docker:

--- a/.github/workflows/push-hub.yml
+++ b/.github/workflows/push-hub.yml
@@ -15,9 +15,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Get latest tag
         id: latesttag
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: |
+         echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
+         echo "Tag name from github.ref_name: ${{  github.ref_name }}"
       - name: Print latest tag
-        run: echo ${{ env.RELEASE_VERSION }}
+        run: echo ${{  github.ref_name }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -33,4 +35,4 @@ jobs:
           context: ./docker
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{ env.RELEASE_VERSION }}
+          tags: ${{ secrets.DOCKERHUB_IMAGENAME }}:${{  github.ref_name }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,8 @@ RUN docker-php-ext-install mbstring
 RUN docker-php-ext-install xml
 #RUN docker-php-ext-install openssl
 WORKDIR /var/www/html
-COPY ../ /var/www/html
-RUN rm -rf /var/www/html/docker/ \ 
+COPY ../* /var/www/html/
+RUN ls && rm -rf /var/www/html/docker/ \ 
 && chown -R root:www-data ./application/config/ \
 && chown -R root:www-data ./application/logs/ \
 && chown -R root:www-data ./assets/qslcard/ \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM php:7.4-apache
+RUN touch /usr/local/etc/php/conf.d/uploads.ini \
+&& echo “file_uploads = On” >> /usr/local/etc/php/conf.d/uploads.ini \
+&& echo “memory_limit = 64M” >> /usr/local/etc/php/conf.d/uploads.ini \
+&& echo “upload_max_filesize = 64M” >> /usr/local/etc/php/conf.d/uploads.ini \
+&& echo “post_max_size = 64M” >> /usr/local/etc/php/conf.d/uploads.ini \
+&& echo “max_execution_time = 60” >> /usr/local/etc/php/conf.d/uploads.ini
+RUN apt-get update \
+&& apt-get install -y git curl libxml2-dev libonig-dev
+RUN docker-php-ext-install mysqli
+#RUN docker-php-ext-install curl
+RUN docker-php-ext-install mbstring
+RUN docker-php-ext-install xml
+#RUN docker-php-ext-install openssl
+WORKDIR /var/www/html
+COPY ../ /var/www/html
+RUN rm -rf /var/www/html/docker/ \ 
+&& chown -R root:www-data ./application/config/ \
+&& chown -R root:www-data ./application/logs/ \
+&& chown -R root:www-data ./assets/qslcard/ \
+&& chown -R root:www-data ./backup/ \
+&& chown -R root:www-data ./updates/ \
+&& chown -R root:www-data ./uploads/ \
+&& chown -R root:www-data ./images/eqsl_card_images/ \
+&& chown -R root:www-data ./assets/json/ \
+&& chmod -R g+rw ./application/config/ \
+&& chmod -R g+rw ./application/logs/ \
+&& chmod -R g+rw ./assets/qslcard/ \
+&& chmod -R g+rw ./backup/ \
+&& chmod -R g+rw ./updates/ \
+&& chmod -R g+rw ./uploads/ \
+&& chmod -R g+rw ./images/eqsl_card_images/ \
+&& chmod -R g+rw ./assets/json/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM php:7.4-apache
-RUN touch /usr/local/etc/php/conf.d/uploads.ini \
+FROM php:7.4-apache                                                                                                                                         
+RUN touch /usr/local/etc/php/conf.d/uploads.ini \                                                                                                           
 && echo “file_uploads = On” >> /usr/local/etc/php/conf.d/uploads.ini \
 && echo “memory_limit = 64M” >> /usr/local/etc/php/conf.d/uploads.ini \
 && echo “upload_max_filesize = 64M” >> /usr/local/etc/php/conf.d/uploads.ini \
@@ -13,7 +13,7 @@ RUN docker-php-ext-install mbstring
 RUN docker-php-ext-install xml
 #RUN docker-php-ext-install openssl
 WORKDIR /var/www/html
-COPY ../* /var/www/html/
+COPY ./ /var/www/html/
 RUN ls && rm -rf /var/www/html/docker/ \ 
 && chown -R root:www-data ./application/config/ \
 && chown -R root:www-data ./application/logs/ \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,18 @@
+version: ‘3.4’
+
+services:
+  cloudlog:
+    image: cloudlog
+    container_name: cloudlog
+    volumes:
+      - cloudlog-config:/var/www/html/application/config
+      - cloudlog-backup:/var/www/html/application/backup
+      - cloudlog-uploads:/var/www/html/application/uploads
+    ports:
+      - 8086:80
+    restart: unless-stopped
+
+volumes:
+  cloudlog-config:
+  cloudlog-backup:
+  cloudlog-uploads:


### PR DESCRIPTION
I created a Dockerfile to automatically build and push images to Docker Hub at every new Release that is published.

# Docker Hub preparation
## Docker Hub account
1. Create a free Docker Hub account [here](https://hub.docker.com/)
2. Once the account is confirmed, go to "Account Settings" and then "Security"
3. Generate a new "Access Token" and copy the provided key

## Create Image repository
1. In the top bar select "Repositories"
2. Create a new "Repository" following the steps

# GitHub Preparation
## GitHub Settings
1. Go in the repo Settings, select "Secrets and Variables"
3. Select "Actions"
4. Create a new Repository Secret called "DOCKERHUB_IMAGENAME" and set paste the image name, should look like "username/imagename"
5. Create a new Repository Secret called "DOCKERHUB_TOKEN" and paste the Docker Hub token
6. Create a new Repository Secret called "DOCKERHUB_USERNAME" and enter your Docker Hub username

# Publishing new image
Image is automatically published every time a new release is created, no need to manually operate.

# Final-user required steps
Once the image is published to Docker Hub, final users will only need to pull it from the Hub and execute it on their machine, no coding skills needed.

This procedure is equivalent to what is explained [here in the help](https://github.com/magicbug/Cloudlog/wiki/Installation-on-a-Docker-Container), only difference is that the image is already done and final user will only need to pull it an run it. I will create a dedicated Wiki page if needed.

The wiki page i just pasted will be updated accordingly to point to the newly created images

Sample result: [https://hub.docker.com/r/iu2frl/cloudlog](https://hub.docker.com/r/iu2frl/cloudlog)