### PR TITLE
Fix QSL marking functions

### DIFF
--- a/application/views/search/search_result_ajax.php
+++ b/application/views/search/search_result_ajax.php
@@ -113,7 +113,7 @@ $ci =& get_instance();
                     $custom_date_format = $this->config->item('qso_date_format');
                 }
             ?>
-            <?php  echo '<tr class="tr'.($i & 1).'" id ="qso_'. $row->COL_PRIMARY_KEY .'">'; ?>
+            <?php  echo '<tr class="tr'.($i & 1).'" id="qso_'. $row->COL_PRIMARY_KEY .'">'; ?>
             <td><?php $timestamp = strtotime($row->COL_TIME_ON); echo date($custom_date_format, $timestamp); ?></td>
             <?php if(($this->config->item('use_auth') && ($this->session->userdata('user_type') >= 2)) || $this->config->item('use_auth') === FALSE || ($this->config->item('show_time'))) { ?>
                 <td><?php $timestamp = strtotime($row->COL_TIME_ON); echo date('H:i', $timestamp); ?></td>
@@ -207,7 +207,7 @@ $ci =& get_instance();
 				if(($this->config->item('use_auth')) && ($this->session->userdata('user_type') >= 2)) { ?>
 
                 <?php
-                  echo '<td style=\'text-align: center\' class="qsl">';
+                  echo '<td id="qsl_'.$row->COL_PRIMARY_KEY.'" style=\'text-align: center\' class="qsl">';
                   echo '<span ';
                   if ($row->COL_QSL_SENT != "N") {
                      if ($row->COL_QSLSDATE != null) {

--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -92,7 +92,7 @@ function echoQrbCalcLink($mygrid, $grid, $vucc) {
                     // Get Default date format from /config/cloudlog.php
                     $custom_date_format = $this->config->item('qso_date_format');
                 }
-                echo '<tr class="tr'.($i & 1).'" id ="qso_'. $row->COL_PRIMARY_KEY .'">'; ?>
+                echo '<tr class="tr'.($i & 1).'" id="qso_'. $row->COL_PRIMARY_KEY .'">'; ?>
             <td><?php $timestamp = strtotime($row->COL_TIME_ON); echo date($custom_date_format, $timestamp); ?></td>
             <?php if(($this->config->item('use_auth') && ($this->session->userdata('user_type') >= 2)) || $this->config->item('use_auth') === FALSE || ($this->config->item('show_time'))) { ?>
                 <td><?php $timestamp = strtotime($row->COL_TIME_ON); echo date('H:i', $timestamp); ?></td>
@@ -109,7 +109,7 @@ function echoQrbCalcLink($mygrid, $grid, $vucc) {
                 echo_table_col($row, $this->session->userdata('user_column5'));
 			
 				if(($this->config->item('use_auth')) && ($this->session->userdata('user_type') >= 2)) { ?>
-                <td class="qsl">
+                <td id="qsl_<?php echo $row->COL_PRIMARY_KEY; ?>" class="qsl">
                 <span <?php if ($row->COL_QSL_SENT != "N") {
                        switch ($row->COL_QSL_SENT) {
                        case "Y":

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -7,7 +7,7 @@ function qsl_rcvd(id, method) {
         },
         success: function(data) {
             if (data.message == 'OK') {
-                $("#qso_" + id).find("td:eq(8)").find("span:eq(1)").attr('class', 'qsl-green'); // Paints arrow green
+                $("#qsl_" + id).find("span:eq(1)").attr('class', 'qsl-green'); // Paints arrow green
                 $(".qsl_rcvd_" + id).remove(); // removes choice from menu
             }
             else {
@@ -26,7 +26,7 @@ function qsl_sent(id, method) {
         },
         success: function(data) {
             if (data.message == 'OK') {
-                $("#qso_" + id).find("td:eq(8)").find("span:eq(0)").attr('class', 'qsl-green'); // Paints arrow green
+                $("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-green'); // Paints arrow green
                 $(".qsl_sent_" + id).remove(); // removes choice from menu
             }
             else {
@@ -47,7 +47,7 @@ function qsl_requested(id, method) {
         },
         success: function(data) {
             if (data.message == 'OK') {
-                $("#qso_" + id).find("td:eq(8)").find("span:eq(0)").attr('class', 'qsl-yellow'); // Paints arrow green
+                $("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-yellow'); // Paints arrow yellow
             }
             else {
                 $(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');
@@ -67,7 +67,7 @@ function qsl_ignore(id, method) {
         },
         success: function(data) {
             if (data.message == 'OK') {
-                $("#qso_" + id).find("td:eq(8)").find("span:eq(0)").attr('class', 'qsl-grey'); // Paints arrow grey
+                $("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-grey'); // Paints arrow grey
             }
             else {
                 $(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');


### PR DESCRIPTION
Using the mark QSL function in Logbook -> Overview does mark eQSL as received using JS. 

https://github.com/magicbug/Cloudlog/assets/7112907/e81ff78b-192d-4116-adb0-b4bd6cab4a53

That is because the code does rely on counting columns which does not make sense as the number can vary (i.e. works correct if eQSL is disabled). We fix this by using a fixed ID.
