### PR TITLE
Correct eQSL images folder name

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -12,7 +12,7 @@ class eqsl extends CI_Controller {
     public function index() {
 
         $this->lang->load('qslcard');
-        $folder_name = "assets/qslcard";
+        $folder_name = "images/eqsl_card_images";
         $data['storage_used'] = $this->sizeFormat($this->folderSize($folder_name));
 
         // Render Page


### PR DESCRIPTION
We should use the correct folder here. Currently shows the size of assets/qslcard whereas eQSL images are stored in images/eqsl_card_images.