### PR TITLE
Add error message for no outstanding QO-100 QSOs

### DIFF
--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -372,14 +372,14 @@ class Stations extends CI_Model {
 		$sql="
 			SELECT station_profile.station_id, station_profile.station_profile_name, station_profile.station_callsign, notc.c notcount, totc.c totcount
 			FROM station_profile
-			INNER JOIN (
+			LEFT OUTER JOIN (
 				SELECT qsos.station_id, COUNT(qsos.COL_PRIMARY_KEY) c
 				FROM %s qsos
 				LEFT JOIN webadif ON qsos.COL_PRIMARY_KEY = webadif.qso_id
 				WHERE webadif.qso_id IS NULL AND qsos.COL_SAT_NAME = 'QO-100'
 				GROUP BY qsos.station_id
 			) notc ON station_profile.station_id = notc.station_id
-			INNER JOIN (
+			LEFT JOIN (
 				SELECT qsos.station_id, COUNT(qsos.COL_PRIMARY_KEY) c
 				FROM %s qsos
 				WHERE qsos.COL_SAT_NAME = 'QO-100'

--- a/application/views/webadif/export.php
+++ b/application/views/webadif/export.php
@@ -24,6 +24,11 @@
 
 <?php
             if ($station_profile->result()) {
+               $queuedqsos = 0;
+               foreach ($station_profile->result() as $count) {      // Fills the table with the data
+                   $queuedqsos += $count->notcount;
+               }
+               if ($queuedqsos > 0) {
 				?>
 				<p>You need to set a QO-100 Dx Club API key in your station profile. Only station profiles with an API Key are displayed.</p>
 				<p><span class="badge badge-warning">Warning</span> This might take a while as QSO uploads are processed sequentially.</p>
@@ -41,15 +46,25 @@
                 </thead>
                 <tbody>';
                 foreach ($station_profile->result() as $station) {      // Fills the table with the data
-                echo '<tr>';
-                    echo '<td>' . $station->station_profile_name . '</td>';
-                    echo '<td>' . $station->station_callsign . '</td>';
-                    echo '<td id ="notcount'.$station->station_id.'">' . $station->notcount . '</td>';
-                    echo '<td id ="totcount'.$station->station_id.'">' . $station->totcount . '</td>';
-                    echo '<td><button id="webadifUpload" type="button" name="webadifUpload" class="btn btn-primary btn-sm ld-ext-right" onclick="ExportWebADIF('. $station->station_id .')"><i class="fas fa-cloud-upload-alt"></i> Upload<div class="ld ld-ring ld-spin"></div></button></td>';
-                    echo '</tr>';
+                   if ($station->notcount != null) {
+                       echo '<tr>';
+                           echo '<td>' . $station->station_profile_name . '</td>';
+                           echo '<td>' . $station->station_callsign . '</td>';
+                           echo '<td id ="notcount'.$station->station_id.'">' . $station->notcount . '</td>';
+                           echo '<td id ="totcount'.$station->station_id.'">' . $station->totcount . '</td>';
+                           echo '<td><button id="webadifUpload" type="button" name="webadifUpload" class="btn btn-primary btn-sm ld-ext-right" onclick="ExportWebADIF('. $station->station_id .')"><i class="fas fa-cloud-upload-alt"></i> Upload<div class="ld ld-ring ld-spin"></div></button></td>';
+                       echo '</tr>';
+                   }
                 }
                 echo '</tfoot></table>';
+               } else {
+                  ?>
+                  <div class="alert alert-success">
+                  There are currently no outstanding QSOs that need to be uploaded to the QO-100 Dx Club's API.<br />
+                  Go ahead and turn on your QO-100 station!
+                  </div>
+                  <?php
+               }
 
         }
         else {


### PR DESCRIPTION
Adjusted the webadif / QO-100 Dx-Club API code a little so that the error message does not confuse the user as in https://github.com/magicbug/Cloudlog/issues/2230. It can now distinguish between no station locations with webadif API key and all QSOs uploaded. The latter case now shows this message:

![Screenshot from 2023-06-29 22-04-52](https://github.com/magicbug/Cloudlog/assets/7112907/4a23faba-719b-4d51-b62a-81c814009673)

@hugosilvaparagramanet @do4bmw: Looking forward to your opinion here! Oh and @AndreasK79 as well of course :)