### PR TITLE
LOTW QSO end date issue

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 124;
+$config['migration_version'] = 125;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/migrations/125_lotw_enddates.php
+++ b/application/migrations/125_lotw_enddates.php
@@ -1,0 +1,21 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_lotw_enddates extends CI_Migration
+{
+	public function up()
+	{
+		if ($this->db->table_exists('lotw_certs')) {
+			$sql = 'UPDATE lotw_certs SET qso_end_date = DATE_ADD(qso_end_date, INTERVAL 24*60*60 -1 SECOND) WHERE TIME(qso_end_date) = "00:00:00";';
+			$this->db->query($sql);
+		}
+	}
+
+	public function down()
+	{
+		if ($this->db->table_exists('lotw_certs')) {
+			$sql = 'UPDATE lotw_certs SET qso_end_date = DATE_SUB(qso_end_date, INTERVAL 24*60*60 -1 SECOND) WHERE TIME(qso_end_date) = "23:59:59";';
+			$this->db->query($sql);
+		}
+	}
+}

--- a/application/models/LotwCert.php
+++ b/application/models/LotwCert.php
@@ -6,7 +6,7 @@ class LotwCert extends CI_Model {
 	|--------------------------------------------------------------------------
 	| Function: lotw_certs
 	|--------------------------------------------------------------------------
-	| 
+	|
 	| Returns all lotw_certs for a selected user via the $user_id parameter
 	|
 	*/
@@ -17,7 +17,7 @@ class LotwCert extends CI_Model {
 		$this->db->join('dxcc_entities','lotw_certs.cert_dxcc_id = dxcc_entities.adif','left');
 		$this->db->order_by('cert_dxcc', 'ASC');
 		$query = $this->db->get('lotw_certs');
-			
+
 		return $query;
 	}
 
@@ -46,7 +46,7 @@ class LotwCert extends CI_Model {
 		    'date_created' => $date_created,
 		    'date_expires' => $date_expires,
 		    'qso_start_date' => $qso_start_date,
-		    'qso_end_date' => $qso_end_date,
+		    'qso_end_date' => $qso_end_date . ' 23:59:59',
 		    'cert_key' => $cert_key,
 		    'cert' => $general_cert,
 		);
@@ -60,7 +60,7 @@ class LotwCert extends CI_Model {
 		    'date_created' => $date_created,
 		    'date_expires' => $date_expires,
 		    'qso_start_date' => $qso_start_date,
-		    'qso_end_date' => $qso_end_date,
+		    'qso_end_date' => $qso_end_date . ' 23:59:59',
 		    'cert_key' => $cert_key,
 		    'cert' => $general_cert
 		);
@@ -90,9 +90,9 @@ class LotwCert extends CI_Model {
 
     return "Updated";
   }
-	
+
 	function empty_table($table) {
-		$this->db->empty_table($table); 
+		$this->db->empty_table($table);
 	}
 
    function lotw_cert_expired($user_id, $date) {


### PR DESCRIPTION
When importing a LOTW certificate the "QSO End Date" was being stored in the database with time ```00:00:00```, but in fact the validity is a date so it should work until ```23:59:59```. This causes QSOs made in the last day that the certificate covers to not be uploaded to LOTW.
The fix is simply to add ```23:59:59``` to the data when importing the certificate.
I have not created a fix to the existing data since this is very close to an edge case and only people that ask for certificates with very tight date limits should be affected.