### PR TITLE
Fixed #2244

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,21 +13,10 @@ RUN docker-php-ext-install mysqli mbstring xml
 RUN rm -rf /var/www/html/docker/
 COPY ./ /var/www/html/
 WORKDIR /var/www/html
-RUN cd /var/www/html && ls \ 
-&& chown -R root:root ./application/config/ \
-&& chown -R root:root ./application/logs/ \
-&& chown -R root:root ./assets/qslcard/ \
-&& chown -R root:root ./backup/ \
-&& chown -R root:root ./updates/ \
-&& chown -R root:root ./uploads/ \
-&& chown -R root:root ./images/eqsl_card_images/ \
-&& chown -R root:root ./assets/json/ \
-&& chmod -R g+rw ./application/config/ \
-&& chmod -R g+rw ./application/logs/ \
-&& chmod -R g+rw ./assets/qslcard/ \
-&& chmod -R g+rw ./backup/ \
-&& chmod -R g+rw ./updates/ \
-&& chmod -R g+rw ./uploads/ \
-&& chmod -R g+rw ./images/eqsl_card_images/ \
-&& chmod -R g+rw ./assets/json/ \
-&& chmod 777 /var/www/html/install
+RUN cd /var/www/html \
+&& echo "Setting root as owner of the folder..." \
+&& chown -R root:root /var/www/html \
+&& echo "Setting permissions to the install folder" \
+&& chmod 777 /var/www/html/install \
+&& echo "Make sure everything is fine" \
+&& dir -ls

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,14 @@ RUN cd /var/www/html \
 && echo "Setting root as owner of the folder..." \
 && chown -R root:root /var/www/html \
 && echo "Setting permissions to the install folder" \
+&& chown -R root:root ./application/config/ \
+&& chown -R root:root ./application/logs/ \
+&& chown -R root:root ./assets/qslcard/ \
+&& chown -R root:root ./backup/ \
+&& chown -R root:root ./updates/ \
+&& chown -R root:root ./uploads/ \
+&& chown -R root:root ./images/eqsl_card_images/ \
+&& chown -R root:root ./assets/json/ \
 && chmod -R g+rw ./application/config/ \
 && chmod -R g+rw ./application/logs/ \
 && chmod -R g+rw ./assets/qslcard/ \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,4 +29,5 @@ RUN cd /var/www/html && ls \
 && chmod -R g+rw ./updates/ \
 && chmod -R g+rw ./uploads/ \
 && chmod -R g+rw ./images/eqsl_card_images/ \
-&& chmod -R g+rw ./assets/json/
+&& chmod -R g+rw ./assets/json/ \
+&& chmod 777 /var/www/html/install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,14 +14,14 @@ RUN rm -rf /var/www/html/docker/
 COPY ./ /var/www/html/
 WORKDIR /var/www/html
 RUN cd /var/www/html && ls \ 
-&& chown -R root:www-data ./application/config/ \
-&& chown -R root:www-data ./application/logs/ \
-&& chown -R root:www-data ./assets/qslcard/ \
-&& chown -R root:www-data ./backup/ \
-&& chown -R root:www-data ./updates/ \
-&& chown -R root:www-data ./uploads/ \
-&& chown -R root:www-data ./images/eqsl_card_images/ \
-&& chown -R root:www-data ./assets/json/ \
+&& chown -R root:root ./application/config/ \
+&& chown -R root:root ./application/logs/ \
+&& chown -R root:root ./assets/qslcard/ \
+&& chown -R root:root ./backup/ \
+&& chown -R root:root ./updates/ \
+&& chown -R root:root ./uploads/ \
+&& chown -R root:root ./images/eqsl_card_images/ \
+&& chown -R root:root ./assets/json/ \
 && chmod -R g+rw ./application/config/ \
 && chmod -R g+rw ./application/logs/ \
 && chmod -R g+rw ./assets/qslcard/ \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,14 @@ RUN cd /var/www/html \
 && echo "Setting root as owner of the folder..." \
 && chown -R root:root /var/www/html \
 && echo "Setting permissions to the install folder" \
+&& chmod -R g+rw ./application/config/ \
+&& chmod -R g+rw ./application/logs/ \
+&& chmod -R g+rw ./assets/qslcard/ \
+&& chmod -R g+rw ./backup/ \
+&& chmod -R g+rw ./updates/ \
+&& chmod -R g+rw ./uploads/ \
+&& chmod -R g+rw ./images/eqsl_card_images/ \
+&& chmod -R g+rw ./assets/json/ \
 && chmod 777 /var/www/html/install \
 && echo "Make sure everything is fine" \
 && dir -ls

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,14 +17,14 @@ RUN cd /var/www/html \
 && echo "Setting root as owner of the folder..." \
 && chown -R root:root /var/www/html \
 && echo "Setting permissions to the install folder" \
-&& chown -R root:root ./application/config/ \
-&& chown -R root:root ./application/logs/ \
-&& chown -R root:root ./assets/qslcard/ \
-&& chown -R root:root ./backup/ \
-&& chown -R root:root ./updates/ \
-&& chown -R root:root ./uploads/ \
-&& chown -R root:root ./images/eqsl_card_images/ \
-&& chown -R root:root ./assets/json/ \
+&& chown -R root:www-data ./application/config/ \
+&& chown -R root:www-data ./application/logs/ \
+&& chown -R root:www-data ./assets/qslcard/ \
+&& chown -R root:www-data ./backup/ \
+&& chown -R root:www-data ./updates/ \
+&& chown -R root:www-data ./uploads/ \
+&& chown -R root:www-data ./images/eqsl_card_images/ \
+&& chown -R root:www-data ./assets/json/ \
 && chmod -R g+rw ./application/config/ \
 && chmod -R g+rw ./application/logs/ \
 && chmod -R g+rw ./assets/qslcard/ \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,14 +7,13 @@ RUN touch /usr/local/etc/php/conf.d/uploads.ini \
 && echo "max_execution_time = 60" >> /usr/local/etc/php/conf.d/uploads.ini
 RUN apt-get update \
 && apt-get install -y git curl libxml2-dev libonig-dev
-RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install mysqli mbstring xml
 #RUN docker-php-ext-install curl
-RUN docker-php-ext-install mbstring
-RUN docker-php-ext-install xml
 #RUN docker-php-ext-install openssl
-WORKDIR /var/www/html
+RUN rm -rf /var/www/html/docker/
 COPY ./ /var/www/html/
-RUN ls && rm -rf /var/www/html/docker/ \ 
+WORKDIR /var/www/html
+RUN cd /var/www/html && ls \ 
 && chown -R root:www-data ./application/config/ \
 && chown -R root:www-data ./application/logs/ \
 && chown -R root:www-data ./assets/qslcard/ \


### PR DESCRIPTION
The issue reported in https://github.com/magicbug/Cloudlog/issues/2244 should be fixed, i tried them on a arm64 machine.

I also created a new guide at: https://github.com/magicbug/Cloudlog/wiki/Executing-the-full-standalone-Cloudlog-stack

To update the images on Docker Hub without tagging a new release, you need to:
1. Copy the updated Dockerfile in the main branch
2. Move to the Actions tab
3. Select `Push Docker image to the Hub`
4. Click on `Run Workflow` in the upper right corner and make sure to choose the main branch