### PR TITLE
Removing index.php in directory and URL in case of configuration error

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -131,8 +131,8 @@ if($_POST) {
 
 		  <fieldset>
 		  	<legend>Configuration Settings</legend>
-		  	<label for="directory">Directory</label><input type="text" id="directory" value="<?php echo str_replace("/install/", "", $_SERVER['REQUEST_URI']); ?>" class="input_text" name="directory" />
-		  	<label for="websiteurl">Website URL</label><input type="text" id="websiteurl" value="<?php echo $_SERVER['REQUEST_SCHEME']; ?>://<?php echo $_SERVER['HTTP_HOST'].str_replace("/install/", "", $_SERVER['REQUEST_URI']); ?>" class="input_text" name="websiteurl" />
+		  	<label for="directory">Directory</label><input type="text" id="directory" value="<?php echo str_replace("index.php", "", str_replace("/install/", "", $_SERVER['REQUEST_URI'])); ?>" class="input_text" name="directory" />
+		  	<label for="websiteurl">Website URL</label><input type="text" id="websiteurl" value="<?php echo $_SERVER['REQUEST_SCHEME']; ?>://<?php echo str_replace("index.php", "", $_SERVER['HTTP_HOST'].str_replace("/install/", "", $_SERVER['REQUEST_URI'])); ?>" class="input_text" name="websiteurl" />
 		  	<label for="locator">Default Gridsquare</label><input type="text" id="locator" value="IO91JS" class="input_text" name="locator" />
 		  </fieldset>
 


### PR DESCRIPTION
**Observed anomaly:**
When configuring the Cloudlog setup, if some parameter is wrong, the configuration form adds some paths that are not correct, example:
- With this bad input:
![image](https://github.com/magicbug/Cloudlog/assets/61653175/86df1c77-5cd8-48d4-a77f-c69ae5be6556)
- Turns into this worse input:
![image](https://github.com/magicbug/Cloudlog/assets/61653175/6d62c618-2a9d-4440-a468-15b30b2bd2a8)

**Resolution:**
Replacing the `index.php` part of the string when returning to the setup form