### PR TITLE
Qrz failure fixing - Fixes https://github.com/magicbug/Cloudlog/issues/2198

### DIFF
--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -78,6 +78,7 @@ class Qrz extends CI_Controller {
                     log_message('error', 'QRZ upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);
                     log_message('error', 'QRZ upload failed with the following message: ' .$result['message']);
                     log_message('error', 'QRZ upload stopped for Station_ID: ' .$station_id);
+                    $errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
 		    break; /* If key is invalid, immediate stop syncing for more QSOs of this station */
                 } else {
                     log_message('error', 'QRZ upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);

--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -71,9 +71,14 @@ class Qrz extends CI_Controller {
                     $result = $this->logbook_model->push_qso_to_qrz($qrz_api_key, $adif);
                 }
 
-                if ($result['status'] == 'OK') {
+		if ( ($result['status'] == 'OK') || ( ($result['status'] == 'error') && ($result['message'] == 'STATUS=FAIL&REASON=Unable to add QSO to database: duplicate&EXTENDED=')) ){
                     $this->markqso($qso->COL_PRIMARY_KEY);
                     $i++;
+		} elseif ( ($result['status']=='error') && (substr($result['message'],0,11)  == 'STATUS=AUTH')) {
+                    log_message('error', 'QRZ upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);
+                    log_message('error', 'QRZ upload failed with the following message: ' .$result['message']);
+                    log_message('error', 'QRZ upload stopped for Station_ID: ' .$station_id);
+		    break; /* If key is invalid, immediate stop syncing for more QSOs of this station */
                 } else {
                     log_message('error', 'QRZ upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);
                     log_message('error', 'QRZ upload failed with the following message: ' .$result['message']);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -519,7 +519,6 @@ class Logbook_model extends CI_Model {
 
 			$adif = $CI->adifhelper->getAdifLine($qso[0]);
 			$result = $this->push_qso_to_qrz($result->qrzapikey, $adif);
-			log_message("error","Oink: ".$result['message']);
 			if ( ($result['status'] == 'OK') || ( ($result['status'] == 'error') && ($result['message'] == 'STATUS=FAIL&REASON=Unable to add QSO to database: duplicate&EXTENDED=')) ){
 				$this->mark_qrz_qsos_sent($last_id);
 			}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -519,7 +519,8 @@ class Logbook_model extends CI_Model {
 
 			$adif = $CI->adifhelper->getAdifLine($qso[0]);
 			$result = $this->push_qso_to_qrz($result->qrzapikey, $adif);
-			if ($result['status'] == 'OK') {
+			log_message("error","Oink: ".$result['message']);
+			if ( ($result['status'] == 'OK') || ( ($result['status'] == 'error') && ($result['message'] == 'STATUS=FAIL&REASON=Unable to add QSO to database: duplicate&EXTENDED=')) ){
 				$this->mark_qrz_qsos_sent($last_id);
 			}
 		}


### PR DESCRIPTION
Fixes the following:
- When uploading to qrz with an invalid or expired key, Cloudlog stops immediatly uploading for **that** station, so only one QSO fails, not thousands (in the bad case)
- When uploading to qrz and qrz tells us, that is is a dupe (already uploaded / by hand / whatever), Cloudlog simply marks the QSO as uploaded. So there are no infinity retries on that. This is also applied on live-logging.

Tested for mass_upload (via cron), Frontend-Upload (QRZ Logbook -> Upload Logbook) and Livelogging