### PR TITLE
Added MODE to matching for LotW/eQSL Confirmations

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -497,7 +497,7 @@ class Lotw extends CI_Controller {
 					$record['qsl_rcvd'] = $config['lotw_rcvd_mark'];
 				}
 
-				$status = $this->logbook_model->import_check($time_on, $record['call'], $record['band'],$record['station_callsign']);
+				$status = $this->logbook_model->import_check($time_on, $record['call'], $record['band'], $record['mode'], $record['station_callsign']);
 				$skipNewQso = $this->input->post('importMissing'); // If import missing was checked
 
 				if($status[0] == "No Match" && $skipNewQso != NULL) {

--- a/application/libraries/EqslImporter.php
+++ b/application/libraries/EqslImporter.php
@@ -156,14 +156,14 @@ class EqslImporter
 				$record['qsl_sent'] = $config['eqsl_rcvd_mark'];
 			}
 
-			$status = $this->CI->logbook_model->import_check($time_on, $record['call'], $record['band'],$station_callsign);
+			$status = $this->CI->logbook_model->import_check($time_on, $record['call'], $record['band'], $record['mode'],$station_callsign);
 			$qsoid = 0;
 			if ($status[0] == "Found") {
 				$qsoid = $status[1];
-				$dupe = $this->CI->eqslmethods_model->eqsl_dupe_check($time_on, $record['call'], $record['band'], $config['eqsl_rcvd_mark'],$station_callsign);
+				$dupe = $this->CI->eqslmethods_model->eqsl_dupe_check($time_on, $record['call'], $record['band'], $record['mode'],$config['eqsl_rcvd_mark'],$station_callsign);
 				if ($dupe == false) {
 					$updated += 1;
-					$eqsl_status = $this->CI->eqslmethods_model->eqsl_update($time_on, $record['call'], $record['band'], $config['eqsl_rcvd_mark'],$station_callsign);
+					$eqsl_status = $this->CI->eqslmethods_model->eqsl_update($time_on, $record['call'], $record['band'], $record['mode'], $config['eqsl_rcvd_mark'],$station_callsign);
 				} else {
 					$dupes += 1;
 					$eqsl_status = "Already received an eQSL for this QSO.";

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -156,7 +156,7 @@ class Eqslmethods_model extends CI_Model {
     // Update a QSO with eQSL QSL info
     // We could also probably use this use this: http://eqsl.cc/qslcard/VerifyQSO.txt
     // http://www.eqsl.cc/qslcard/ImportADIF.txt
-    function eqsl_update($datetime, $callsign, $band, $qsl_status,$station_callsign) {
+    function eqsl_update($datetime, $callsign, $band, $mode, $qsl_status,$station_callsign) {
         $data = array(
             'COL_EQSL_QSLRDATE' => date('Y-m-d H:i:s'), // eQSL doesn't give us a date, so let's use current
             'COL_EQSL_QSL_RCVD' => $qsl_status
@@ -167,6 +167,7 @@ class Eqslmethods_model extends CI_Model {
         $this->db->where('COL_CALL', $callsign);
 	$this->db->where('COL_STATION_CALLSIGN', $station_callsign);
         $this->db->where('COL_BAND', $band);
+        $this->db->where('COL_MODE', $mode);
 
         $this->db->update($this->config->item('table_name'), $data);
 
@@ -174,12 +175,13 @@ class Eqslmethods_model extends CI_Model {
     }
 
     // Determine if we've already received an eQSL for this QSO
-    function eqsl_dupe_check($datetime, $callsign, $band, $qsl_status,$station_callsign) {
+    function eqsl_dupe_check($datetime, $callsign, $band, $mode, $qsl_status,$station_callsign) {
         $this->db->select('COL_EQSL_QSLRDATE');
         $this->db->where('COL_TIME_ON >= DATE_ADD(DATE_FORMAT("'.$datetime.'", \'%Y-%m-%d %H:%i\' ), INTERVAL -15 MINUTE )');
         $this->db->where('COL_TIME_ON <= DATE_ADD(DATE_FORMAT("'.$datetime.'", \'%Y-%m-%d %H:%i\' ), INTERVAL 15 MINUTE )');
         $this->db->where('COL_CALL', $callsign);
         $this->db->where('COL_BAND', $band);
+        $this->db->where('COL_MODE', $mode);
 	$this->db->where('COL_STATION_CALLSIGN', $station_callsign);
         $this->db->where('COL_EQSL_QSL_RCVD', $qsl_status);
         $this->db->limit(1);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2469,7 +2469,7 @@ class Logbook_model extends CI_Model {
     }
 
   /* Used to check if the qso is already in the database */
-  function import_check($datetime, $callsign, $band,$station_callsign) {
+  function import_check($datetime, $callsign, $band, $mode, $station_callsign) {
 
     $this->db->select('COL_PRIMARY_KEY, COL_TIME_ON, COL_CALL, COL_BAND');
     $this->db->where('COL_TIME_ON >= DATE_ADD(DATE_FORMAT("'.$datetime.'", \'%Y-%m-%d %H:%i\' ), INTERVAL -15 MINUTE )');
@@ -2477,6 +2477,7 @@ class Logbook_model extends CI_Model {
     $this->db->where('COL_CALL', $callsign);
     $this->db->where('COL_STATION_CALLSIGN', $station_callsign);
     $this->db->where('COL_BAND', $band);
+    $this->db->where('COL_MODE', $mode);
 
     $query = $this->db->get($this->config->item('table_name'));
 


### PR DESCRIPTION
Old behaviour:
- QSO logged with Mode "FT8"
- eQSL/LotW confirmation comes with Mode "SSB"
-> QSO will be confirmed in the Cloudlog-database, but when trying to fetch the eQSL-Image it fails, because eQSL tells us "no QSO found with mode...". Furthermore it is no real match at LotW (for awards)

New behaviour:
- QSO logged with Mode "FT8"
- eQSL/LotW confirmation comes with Mode "SSB"
-> QSO will **not** be confirmed in the Cloudlog-database. Error (when syncing via Frontend) is shown as "QSO not found"