### PR TITLE
Minor Fix: supress fetching empty eqsl-image at qso-detail-view

### DIFF
--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -561,7 +561,9 @@
 
         <div class="tab-pane fade" id="eqslcard" role="tabpanel" aria-labelledby="table-tab">
         <?php
-           echo '<img class="d-block" src="' . base_url() . '/images/eqsl_card_images/' . $row->eqsl_image_file .'" alt="QSL picture #'. $i++.'">';
+	if ($row->eqsl_image_file != null) {
+		echo '<img class="d-block" src="' . base_url() . '/images/eqsl_card_images/' . $row->eqsl_image_file .'" alt="QSL picture #'. $i++.'">';
+	}
         ?>
         </div>
         <?php


### PR DESCRIPTION
Fixes following bug: 

if there's no eqsl-image at the database, qsl-detail-view will try to fetch /images/eqsl_card_images/ which produces a 403 and spams webservers-error-log