### PR TITLE
Always update with LoTW confirmed grid

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2693,21 +2693,6 @@ class Logbook_model extends CI_Model {
       $this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = "'.$datetime.'"');
       $this->db->where('COL_CALL', $callsign);
       $this->db->where('COL_BAND', $band);
-	  $this->db->group_start();
-	  $this->db->where('COL_VUCC_GRIDS');
-	  $this->db->or_where('COL_VUCC_GRIDS', '');
-	  $this->db->group_end();
-      if(strlen($qsl_gridsquare) > 4) {
-        $this->db->group_start();
-        $this->db->where('COL_GRIDSQUARE', "");
-        $this->db->or_where('COL_GRIDSQUARE', substr($qsl_gridsquare, 0, 4));
-        if(strlen($qsl_gridsquare) > 6) {
-          $this->db->or_where('COL_GRIDSQUARE', substr($qsl_gridsquare, 0, 6));
-        }
-        $this->db->group_end();
-      } else {
-        $this->db->where('COL_GRIDSQUARE', "");
-      }
 
       $this->db->update($this->config->item('table_name'), $data);
     }


### PR DESCRIPTION
As we are updating several infos like IOTA, state, county I guess we should also update grid from LoTW confirmations. The code introduced in https://github.com/magicbug/Cloudlog/commit/614452b07e83828ea5c9d27d0a9ea823b4188c87 obviously has a problem here.

I logged a QSO with @int2001 and put his grid wrong (e.g. JO31OO). LoTW confirmation comes in and contains the correct grid (JO30xx). The code would not update the QSO's grid because it is longer than 4 chars but not longer than 6 chars which leads to an SQL statement that does not give a match. So no update on the grid here.

Imho the LoTW confirmation is the most specific grid info here so we should just update the QSO with grid info from LoTW instead of trying to determine which is more specific. Also this would prevent updates if a user logged a wrong but more specific grid ...