### PR TITLE
Lotw per user / fixes lotw-download

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -355,8 +355,11 @@ class Lotw extends CI_Controller {
 			/*
 			|	Download QSO Matches from LoTW
 			*/
-			if ($this->user_model->authorize(2)) {	// Only be verbose if we have a session
+			if ($this->user_model->authorize(2)) {
 				echo "<br><br>";
+				$sync_user_id=$this->session->userdata('user_id');
+			} else {
+				$sync_user_id=null;
 			}
 			echo $this->lotw_download($sync_user_id);
 	}

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -674,7 +674,7 @@ class Lotw extends CI_Controller {
 				ini_set('memory_limit', '-1');
 				$results.= $this->loadFromFile($file, false);
 			}
-				return $results;
+			return $results;
 		} else {
 			return "No LOTW User details found to carry out matches.";
 		}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2701,21 +2701,19 @@ class Logbook_model extends CI_Model {
   }
 
   function lotw_last_qsl_date($user_id) {
-      log_message("error","last QSL for User ".$user_id);
-      $this->db->select('COL_LOTW_QSLRDATE');
-      $this->db->where('COL_LOTW_QSLRDATE IS NOT NULL');
-      $this->db->order_by("COL_LOTW_QSLRDATE", "desc");
-      $this->db->limit(1);
-	/* Todo: Add Join to users / station_profiles / etc, to fetch only last QSL for that user */
-      $query = $this->db->get($this->config->item('table_name'));
-      $row = $query->row();
+	  log_message("error","last QSL for User ".$user_id);
+	  $sql="SELECT MAX(COALESCE(COL_LOTW_QSLRDATE, '1900-01-01 00:00:00')) MAXDATE, ".$this->config->item('table_name').".station_id
+		    FROM ".$this->config->item('table_name')." INNER JOIN station_profile ON (".$this->config->item('table_name').".station_id = station_profile.station_id)
+		    WHERE station_profile.user_id=6 and COL_LOTW_QSLRDATE is not null";
+	  $query = $this->db->query($sql);
+	  $row = $query->row();
 
-      if (isset($row)) {
-        return $row->COL_LOTW_QSLRDATE;
-      }
+	  if (isset($row)) {
+		  return $row->MAXDATE;
+	  }
 
-      return '1900-01-01 00:00:00.000';
-    }
+	  return '1900-01-01 00:00:00.000';
+  }
 
     /*
      * $skipDuplicate - used in ADIF import to skip duplicate checking when importing QSOs

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2701,7 +2701,7 @@ class Logbook_model extends CI_Model {
   }
 
   function lotw_last_qsl_date($user_id) {
-	  $sql="SELECT MAX(COALESCE(COL_LOTW_QSLRDATE, '1900-01-01 00:00:00')) MAXDATE, ".$this->config->item('table_name').".station_id
+	  $sql="SELECT MAX(COALESCE(COL_LOTW_QSLRDATE, '1900-01-01 00:00:00')) MAXDATE
 		    FROM ".$this->config->item('table_name')." INNER JOIN station_profile ON (".$this->config->item('table_name').".station_id = station_profile.station_id)
 		    WHERE station_profile.user_id=".$user_id." and COL_LOTW_QSLRDATE is not null";
 	  $query = $this->db->query($sql);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2707,8 +2707,6 @@ class Logbook_model extends CI_Model {
 	  $query = $this->db->query($sql);
 	  $row = $query->row();
 
-	  log_message("error","last QSL for User ".$user_id." was ".$row->MAXDATE);
-
 	  if (isset($row)) {
 		  return $row->MAXDATE;
 	  }

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2703,7 +2703,7 @@ class Logbook_model extends CI_Model {
   function lotw_last_qsl_date($user_id) {
 	  $sql="SELECT MAX(COALESCE(COL_LOTW_QSLRDATE, '1900-01-01 00:00:00')) MAXDATE, ".$this->config->item('table_name').".station_id
 		    FROM ".$this->config->item('table_name')." INNER JOIN station_profile ON (".$this->config->item('table_name').".station_id = station_profile.station_id)
-		    WHERE station_profile.user_id=6 and COL_LOTW_QSLRDATE is not null";
+		    WHERE station_profile.user_id=".$user_id." and COL_LOTW_QSLRDATE is not null";
 	  $query = $this->db->query($sql);
 	  $row = $query->row();
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2701,12 +2701,13 @@ class Logbook_model extends CI_Model {
   }
 
   function lotw_last_qsl_date($user_id) {
-	  log_message("error","last QSL for User ".$user_id);
 	  $sql="SELECT MAX(COALESCE(COL_LOTW_QSLRDATE, '1900-01-01 00:00:00')) MAXDATE, ".$this->config->item('table_name').".station_id
 		    FROM ".$this->config->item('table_name')." INNER JOIN station_profile ON (".$this->config->item('table_name').".station_id = station_profile.station_id)
 		    WHERE station_profile.user_id=6 and COL_LOTW_QSLRDATE is not null";
 	  $query = $this->db->query($sql);
 	  $row = $query->row();
+
+	  log_message("error","last QSL for User ".$user_id." was ".$row->MAXDATE);
 
 	  if (isset($row)) {
 		  return $row->MAXDATE;

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2700,12 +2700,13 @@ class Logbook_model extends CI_Model {
     return "Updated";
   }
 
-  function lotw_last_qsl_date() {
+  function lotw_last_qsl_date($user_id) {
+      log_message("error","last QSL for User ".$user_id);
       $this->db->select('COL_LOTW_QSLRDATE');
       $this->db->where('COL_LOTW_QSLRDATE IS NOT NULL');
       $this->db->order_by("COL_LOTW_QSLRDATE", "desc");
       $this->db->limit(1);
-
+	/* Todo: Add Join to users / station_profiles / etc, to fetch only last QSL for that user */
       $query = $this->db->get($this->config->item('table_name'));
       $row = $query->row();
 


### PR DESCRIPTION
Old behaviour:
- LotW-Download only worked for one User (not for multiusers), regardless if GUI or cron-triggered.
- When a user triggered LotW-Upload via GUI, every (not uploaded) QSO (of every! user which had a lotw-cert) was uploaded. All results were shown to this user (even the results of other users)
- lotw_upload triggered by cron also exposed every information. (even to users which are not logged in / simply called the url)
- last_download lotw-QSL was taken from the whole database, not from user or station. so (together with the bug 1st mentioned here) some QSOs of some users were never getting the chance of LotW-Confirmations

New behaviour:
- LotW-Download works for current user (if logged in)
- LotW-Upload works for current user (if logged in)
- LotW-Download / Upload is for whole Database when triggered by cron/curl
- LotW-Download / Upload is not longer exposing informations, when triggered by cron/curl without session
- last_download lotw-QSL is now per user. so if you have not enabled your cron and every user syncs by pressing the sync/import button on the gui, the sync takes care of the last received lotw-qsl

pls doublecheck @AndreasK79 / @phl0 / @magicbug 