### PR TITLE
Refactor public search

### DIFF
--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -467,7 +467,7 @@ class Visitor extends CI_Controller {
 	}
 
 	public function search() {
-		$callsign = $this->security->xss_clean($this->input->post('callsign'));
+		$callsign = trim($this->security->xss_clean($this->input->post('callsign')));
 		$public_slug = $this->security->xss_clean($this->input->post('public_slug'));
 		$this->load->model('publicsearch');
 		$data['page_title'] = "Public Search";

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -470,10 +470,12 @@ class Visitor extends CI_Controller {
 		$callsign = $this->security->xss_clean($this->input->post('callsign'));
 		$public_slug = $this->security->xss_clean($this->input->post('public_slug'));
 		$this->load->model('publicsearch');
-		$result = $this->publicsearch->search($public_slug, $callsign);
 		$data['page_title'] = "Public Search";
 		$data['callsign'] = $callsign;
 		$data['slug'] = $public_slug;
+		if ($callsign != '') {
+			$result = $this->publicsearch->search($public_slug, $callsign);
+		}
 		if (!empty($result) && $result->num_rows() > 0) {
 			$data['results'] = $result;
 			$this->load->view('visitor/layout/header', $data);

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -471,6 +471,7 @@ class Visitor extends CI_Controller {
 		$public_slug = $this->security->xss_clean($this->input->post('public_slug'));
 		$this->load->model('publicsearch');
 		$result = $this->publicsearch->search($public_slug, $callsign);
+		$data['page_title'] = "Public Search";
 		$data['callsign'] = $callsign;
 		$data['slug'] = $public_slug;
 		if (!empty($result) && $result->num_rows() > 0) {

--- a/application/models/Publicsearch.php
+++ b/application/models/Publicsearch.php
@@ -5,7 +5,7 @@ class Publicsearch extends CI_Model {
 	function search($slug, $callsign) {
 		if ($this->public_search_enabled($slug)) {
 			$userid = $this->get_userid_for_slug($slug);
-			$this->db->where('COL_CALL', $callsign);
+			$this->db->like('COL_CALL', $callsign);
 			$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
 			$this->db->join('lotw_users', 'lotw_users.callsign = '.$this->config->item('table_name').'.col_call', 'left outer');
 			$this->db->where('station_profile.user_id', $userid);

--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -35,7 +35,7 @@
         var q_lat = 40.313043;
         var q_lng = -32.695312;
         <?php } ?>
-        
+
         <?php if(isset($slug)) { ?>
         var qso_loc = '<?php echo site_url('visitor/map/'.$slug);?>';
         <?php } ?>
@@ -201,6 +201,7 @@
     <?php if ($this->CI->public_search_enabled($slug) || $this->session->userdata('user_type') >= 2) { ?>
     <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/datatables.min.js"></script>
     <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/dataTables.buttons.min.js"></script>
+    <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/buttons.html5.min.js"></script>
     <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/moment.min.js"></script>
     <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/datetime-moment.js"></script>
     <script>
@@ -230,13 +231,14 @@
                 ordering: true,
                 "scrollY":        "500px",
                 "scrollCollapse": true,
-                "paging":         false,
+                "paging":         true,
                 "scrollX": true,
                 "order": [ 0, 'desc' ],
                 dom: 'Bfrtip',
                 buttons: [
                    {
-                      extend: 'csv'
+                      extend: 'csv',
+                      text: 'CSV'
                    },
                    {
                       extend: 'clear',

--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -23,7 +23,8 @@
 </script>
 
     <script type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/L.Maidenhead.js"></script>
-    <script id="leafembed" type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/leafembed.js" tileUrl="<?php echo $this->optionslib->get_option('map_tile_server');?>"></script>    <script type="text/javascript">
+    <script id="leafembed" type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/leafembed.js" tileUrl="<?php echo $this->optionslib->get_option('map_tile_server');?>"></script>
+    <script type="text/javascript">
       $(function () {
         $('[data-toggle="tooltip"]').tooltip()
       });
@@ -257,6 +258,7 @@
             function validateForm() {
                 let x = document.forms["searchForm"]["callsign"].value;
                 if (x == "") {
+                    $('#searchcall').tooltip('show')
                     return false;
                 }
             }

--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -253,6 +253,14 @@
                $('[class*="buttons"]').css("color", "white");
             }
         </script>
+        <script type="text/javascript">
+            function validateForm() {
+                let x = document.forms["searchForm"]["callsign"].value;
+                if (x == "") {
+                    return false;
+                }
+            }
+        </script>
     <?php } ?>
 
   </body>

--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -255,6 +255,13 @@
             }
         </script>
         <script type="text/javascript">
+            $(function () {
+                $(document).on('shown.bs.tooltip', function (e) {
+                    setTimeout(function () {
+                        $(e.target).tooltip('hide');
+                    }, 3000);
+                });
+            });
             function validateForm() {
                 let x = document.forms["searchForm"]["callsign"].value;
                 if (x == "") {

--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -264,7 +264,7 @@
             });
             function validateForm() {
                 let x = document.forms["searchForm"]["callsign"].value;
-                if (x == "") {
+                if (x.trim() == "") {
                     $('#searchcall').tooltip('show')
                     return false;
                 }

--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -47,7 +47,9 @@
             <?php } else { ?>
               var grid = "No";
             <?php } ?>
+            <?php if ($this->uri->segment(2) != "search" && $this->uri->segment(2) != "satellites") { ?>
             initmap(grid);
+            <?php } ?>
 
       });
 

--- a/application/views/visitor/layout/header.php
+++ b/application/views/visitor/layout/header.php
@@ -78,7 +78,7 @@
 			$this->CI =& get_instance();
 			if ($this->CI->public_search_enabled($slug) || $this->session->userdata('user_type') >= 2) { ?>
 				<form method="post" action="<?php echo site_url('visitor/search'); ?>" class="form-inline">
-					<input class="form-control mr-sm-2" id="searchcall" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" aria-label="Search">
+				<input class="form-control mr-sm-2" id="searchcall" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" <?php if (isset($callsign) && $callsign != '') { echo 'value="'.strtoupper($callsign).'"'; } ?> aria-label="Search">
 					<input type="hidden" name="public_slug" value="<?php echo $slug; ?>">
 					<button class="btn btn-outline-success my-2 my-sm-0" type="submit"><i class="fas fa-search"></i> <?php echo lang('menu_search_button'); ?></button>
 				</form>

--- a/application/views/visitor/layout/header.php
+++ b/application/views/visitor/layout/header.php
@@ -78,8 +78,7 @@
 			$this->CI =& get_instance();
 			if ($this->CI->public_search_enabled($slug) || $this->session->userdata('user_type') >= 2) { ?>
 				<form method="post" name="searchForm" action="<?php echo site_url('visitor/search'); ?>" onsubmit="return validateForm()" class="form-inline">
-            <input class="form-control mr-sm-2" id="searchcall" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" <?php if (isset($callsign) && $callsign != '') { echo 'value="'.strtoupper($callsign).'"'; } ?> aria-label="Search" data-toogle="tooltip" data-placement="bottom" data-original-title="Please enter a callsign!" data-delay='{"show":"500", "hide":"100"}'
->
+            <input class="form-control mr-sm-2" id="searchcall" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" <?php if (isset($callsign) && $callsign != '') { echo 'value="'.strtoupper($callsign).'"'; } ?> aria-label="Search" data-toogle="tooltip" data-placement="bottom" data-original-title="Please enter a callsign!">
 					<input type="hidden" name="public_slug" value="<?php echo $slug; ?>">
 					<button class="btn btn-outline-success my-2 my-sm-0" type="submit"><i class="fas fa-search"></i> <?php echo lang('menu_search_button'); ?></button>
 				</form>

--- a/application/views/visitor/layout/header.php
+++ b/application/views/visitor/layout/header.php
@@ -78,7 +78,7 @@
 			$this->CI =& get_instance();
 			if ($this->CI->public_search_enabled($slug) || $this->session->userdata('user_type') >= 2) { ?>
 				<form method="post" name="searchForm" action="<?php echo site_url('visitor/search'); ?>" onsubmit="return validateForm()" class="form-inline">
-				<input class="form-control mr-sm-2" id="searchcall" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" <?php if (isset($callsign) && $callsign != '') { echo 'value="'.strtoupper($callsign).'"'; } ?> aria-label="Search">
+				<input class="form-control mr-sm-2" id="searchcall" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" <?php if (isset($callsign) && $callsign != '') { echo 'value="'.strtoupper($callsign).'"'; } ?> aria-label="Search" data-toogle="tooltip" data-placement="bottom" data-original-title="Please enter a callsign!">
 					<input type="hidden" name="public_slug" value="<?php echo $slug; ?>">
 					<button class="btn btn-outline-success my-2 my-sm-0" type="submit"><i class="fas fa-search"></i> <?php echo lang('menu_search_button'); ?></button>
 				</form>

--- a/application/views/visitor/layout/header.php
+++ b/application/views/visitor/layout/header.php
@@ -78,7 +78,8 @@
 			$this->CI =& get_instance();
 			if ($this->CI->public_search_enabled($slug) || $this->session->userdata('user_type') >= 2) { ?>
 				<form method="post" name="searchForm" action="<?php echo site_url('visitor/search'); ?>" onsubmit="return validateForm()" class="form-inline">
-				<input class="form-control mr-sm-2" id="searchcall" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" <?php if (isset($callsign) && $callsign != '') { echo 'value="'.strtoupper($callsign).'"'; } ?> aria-label="Search" data-toogle="tooltip" data-placement="bottom" data-original-title="Please enter a callsign!">
+            <input class="form-control mr-sm-2" id="searchcall" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" <?php if (isset($callsign) && $callsign != '') { echo 'value="'.strtoupper($callsign).'"'; } ?> aria-label="Search" data-toogle="tooltip" data-placement="bottom" data-original-title="Please enter a callsign!" data-delay='{"show":"500", "hide":"100"}'
+>
 					<input type="hidden" name="public_slug" value="<?php echo $slug; ?>">
 					<button class="btn btn-outline-success my-2 my-sm-0" type="submit"><i class="fas fa-search"></i> <?php echo lang('menu_search_button'); ?></button>
 				</form>

--- a/application/views/visitor/layout/header.php
+++ b/application/views/visitor/layout/header.php
@@ -9,6 +9,7 @@
     <?php if($this->optionslib->get_theme()) { ?>
 		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $this->optionslib->get_theme();?>/bootstrap.min.css">
 		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/general.css">
+		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/visitor.css">
         <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/selectize.bootstrap4.css"/>
 		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/bootstrap-dialog.css"/>
 		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $this->optionslib->get_theme();?>/overrides.css">
@@ -77,7 +78,7 @@
 			$this->CI =& get_instance();
 			if ($this->CI->public_search_enabled($slug) || $this->session->userdata('user_type') >= 2) { ?>
 				<form method="post" action="<?php echo site_url('visitor/search'); ?>" class="form-inline">
-					<input class="form-control mr-sm-2" id="callsign" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" style="text-transform: uppercase;" aria-label="Search">
+					<input class="form-control mr-sm-2" id="searchcall" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" aria-label="Search">
 					<input type="hidden" name="public_slug" value="<?php echo $slug; ?>">
 					<button class="btn btn-outline-success my-2 my-sm-0" type="submit"><i class="fas fa-search"></i> <?php echo lang('menu_search_button'); ?></button>
 				</form>

--- a/application/views/visitor/layout/header.php
+++ b/application/views/visitor/layout/header.php
@@ -77,7 +77,7 @@
 		<?php if (!empty($slug)) {
 			$this->CI =& get_instance();
 			if ($this->CI->public_search_enabled($slug) || $this->session->userdata('user_type') >= 2) { ?>
-				<form method="post" action="<?php echo site_url('visitor/search'); ?>" class="form-inline">
+				<form method="post" name="searchForm" action="<?php echo site_url('visitor/search'); ?>" onsubmit="return validateForm()" class="form-inline">
 				<input class="form-control mr-sm-2" id="searchcall" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" <?php if (isset($callsign) && $callsign != '') { echo 'value="'.strtoupper($callsign).'"'; } ?> aria-label="Search">
 					<input type="hidden" name="public_slug" value="<?php echo $slug; ?>">
 					<button class="btn btn-outline-success my-2 my-sm-0" type="submit"><i class="fas fa-search"></i> <?php echo lang('menu_search_button'); ?></button>

--- a/assets/css/visitor.css
+++ b/assets/css/visitor.css
@@ -1,0 +1,3 @@
+#searchcall:focus {
+   text-transform: uppercase;
+}


### PR DESCRIPTION
Made a few adjustments on the public search:

- Make search a little less picky (as requested by @m0urs in https://github.com/magicbug/Cloudlog/issues/1505#issuecomment-1634926285)
- Added CSV export button to result table
- Fixed a JS error (i.e. not load the map for result page)
- Made search input field upper case only on focus (requested by @AndreasK79)
- Use search term for pre-setting the input field on the result page
- Added page title to result page
- Make search not execute if user searches for empty string