### PR TITLE
Station call check on import

### DIFF
--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -206,7 +206,7 @@ class adif extends CI_Controller {
 
 
 				$custom_errors .= $this->logbook_model->import($record, $this->input->post('station_profile'),
-					$this->input->post('skipDuplicate'), $this->input->post('markLotw'), $this->input->post('dxccAdif'), $this->input->post('markQrz'), $this->input->post('markHrd'), true, $this->input->post('operatorName'));
+					$this->input->post('skipDuplicate'), $this->input->post('markLotw'), $this->input->post('dxccAdif'), $this->input->post('markQrz'), $this->input->post('markHrd'), true, $this->input->post('operatorName'))."<br/>";
 
 			};
 

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -462,8 +462,6 @@ class API extends CI_Controller {
 
 				if(isset($obj['station_profile_id'])) {
 					$this->logbook_model->import($record, $obj['station_profile_id'], NULL, NULL, NULL, NULL, NULL, false, false, true);
-				} else {
-					$this->logbook_model->import($record, 0, NULL, NULL, NULL, NULL, NULL, false, false, true);
 				}
 
 			};

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2749,7 +2749,7 @@ class Logbook_model extends CI_Model {
 	$station_profile=$CI->Stations->profile_clean($station_id);
 	$station_profile_call=$station_profile->station_callsign;
 	if (($station_id != 0) && ($record['station_callsign'] != $station_profile_call)) {	// Check if station_call from import matches profile ONLY when submitting via GUI.
-		return "Wrong station_callsign ".$record['station_callsign']." while importing for ".$station_profile_call;
+		return "Wrong station_callsign ".$record['station_callsign']." while importing QSO with ".$record['call']." for ".$station_profile_call;
 	}
 
         $CI =& get_instance();

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2746,6 +2746,12 @@ class Logbook_model extends CI_Model {
             return 'Station not accessible<br>';
         }
 
+	$station_profile=$CI->Stations->profile_clean($station_id);
+	$station_profile_call=$station_profile->station_callsign;
+	if (($station_id != 0) && ($record['station_callsign'] != $station_profile_call)) {	// Check if station_call from import matches profile ONLY when submitting via GUI.
+		return "Wrong station_callsign ".$record['station_callsign']." while importing for ".$station_profile_call;
+	}
+
         $CI =& get_instance();
         $CI->load->library('frequency');
         $my_error = "";


### PR DESCRIPTION
Old behaviour:
- Chosing a station_profile at import ADIF
- Upload an ADIF with a different Call than that in the station_profile
--> inconsistent Data in Database

New behaviour:
- Chosing a station_profile at import ADIF
- Upload an ADIF with a different Call than that in the station_profile
--> importer skips Records where station_callsign differs from that one in the profile
