### PR TITLE
SecFix: Added checking for session when editing or watching profile

### DIFF
--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -178,7 +178,7 @@ class User extends CI_Controller {
 
 	function edit() {
 		$this->load->model('user_model');
-		if((!$this->user_model->authorize(99)) && ($this->session->userdata('user_id') != $this->uri->segment(3))) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+		if ( ($this->session->userdata('user_id') == '') || ((!$this->user_model->authorize(99)) && ($this->session->userdata('user_id') != $this->uri->segment(3))) ) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
 		$query = $this->user_model->get_by_id($this->uri->segment(3));
 
 		$this->load->model('bands');
@@ -494,6 +494,7 @@ class User extends CI_Controller {
 
 	function profile() {
 		$this->load->model('user_model');
+		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
 		$query = $this->user_model->get_by_id($this->session->userdata('user_id'));
     $q = $query->row();
     $data['page_title'] = "Profile";


### PR DESCRIPTION
Minor Securitybugfix:

Old behaviour:
one could call /index.php/user/edit or /index.php/user/profile without session.
In the profile-case information will be leaked.
in the edit-case the form is shown (with a lot of PHP-Errors).

New behaviour:
Redirect to login in both cases (taking care of admin-level)