### PR TITLE
Set Mode to SSB when inverted SSB transponder, otherwise to LSB/USB

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -228,7 +228,7 @@ $(document).on('change', 'input', function(){
 						$.each( val.Modes, function( key1, val2 ) {
 							if(key1 == selected_sat_mode) {
 
-								if (val2[0].Uplink_Mode == "LSB" || val2[0].Uplink_Mode == "USB") {
+								if ( (val2[0].Downlink_Mode == "LSB" && val2[0].Uplink_Mode == "USB") || (val2[0].Downlink_Mode == "USB" && val2[0].Uplink_Mode == "LSB") )   { // inverting Transponder? set to SSB
 									$("#mode").val("SSB");
 								} else {
 									$("#mode").val(val2[0].Uplink_Mode);


### PR DESCRIPTION
Old behaviour:
- Mode is always set to SSB, when working SATs with LSB **or** USB down/uplink
- When working SAT with bent pipe (like QO100) Up/Down is only USB. Mode is also set to SSB then.

New behaviour:
- Checks if Downlink/Uplink differ and if they're LSB/USB. Sets Mode to SSB
- When working SAT with bent pipe (like QO100) Up/Down is only USB. in this case USB is set
- When working SAT with bent pipe Up/Down is only LSB. in this case LSB is set

plz chk