### PR TITLE
Display Transmit Power in capital letter (W), added space

### DIFF
--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -454,7 +454,7 @@
                     <?php if($row->COL_TX_PWR) { ?>
                     <tr>
                         <td>Station Transmit Power</td>
-                        <td><?php echo $row->COL_TX_PWR; ?>w</td>
+                        <td><?php echo $row->COL_TX_PWR; ?> W</td>
                     </tr>
                     <?php } ?>
 


### PR DESCRIPTION
Display the Unit Watt in capital letter 'W' with space. 
Like: "5 W" 