### PR TITLE
Fixed import_check for duplicates

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -461,7 +461,7 @@ class API extends CI_Controller {
 
 
 				if(isset($obj['station_profile_id'])) {
-					$this->logbook_model->import($record, $obj['station_profile_id'], NULL, NULL, NULL, NULL, NULL, false, false, true);
+					$this->logbook_model->import($record, $obj['station_profile_id'], true, NULL, NULL, NULL, NULL, false, false, true);
 				}
 
 			};

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3062,7 +3062,7 @@ class Logbook_model extends CI_Model {
         }
 
         // Check if QSO is already in the database
-        if ($skipDuplicate != NULL) {
+        if (!$skipDuplicate) {
             $skip = false;
         } else {
             if (isset($record['call'])){

--- a/application/views/adif/import_success.php
+++ b/application/views/adif/import_success.php
@@ -14,7 +14,7 @@
   <div class="card-body">
     <h3 class="card-title">Yay, its imported!</h3>
     <p class="card-text">The ADIF File has been imported, and any dupes skipped.</p>
-    <?php if($adif_errors) { ?>
+    <?php if($adif_errors != '') { ?>
       <h3>ADIF Errors</h3>
       <p>You have ADIF errors, the QSOs have still been added but these fields have not been populated.</p>
       <p class="card-text"><?php echo $adif_errors; ?></p>


### PR DESCRIPTION
There was a bug in "duplicate_check".

Old behaviour:
- Duplicate-Check was ticked at ADIF-Import
- DuplicateCheck never happened

New behaviour:
- Duplicate-Check is ticked at ADIF-Import
- DuplicateCheck now happens, Dupes are ignored

Importcall from Api and import itself at logbook_model had also to be changed/adjusted.

Please check