### PR TITLE
Strong check for station_id when importing

### DIFF
--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -44,7 +44,7 @@
                         <div class="col-md-10">
                             <div class="form-check-inline">
                                 <input class="form-check-input" type="checkbox" name="skipDuplicate" value="1" id="skipDuplicate">
-                                <label class="form-check-label" for="skipDuplicate">Skip duplicate QSO check</label>
+                                <label class="form-check-label" for="skipDuplicate">Import duplicate QSOs</label>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
- Changed (eventually) misleading caption "skip duplicate check" to clearer "import duplicates"
- Implemented Hard Check if chosen station_id belongs to logged in User, when importing ADIF

Tested:
- Dupecheck on / off
- injecting other station_id - errormessage pops up "Station Profile not valid for User"