### PR TITLE
Adjusted caption of contest-session-reset

### DIFF
--- a/application/language/english/contesting_lang.php
+++ b/application/language/english/contesting_lang.php
@@ -3,7 +3,7 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 $lang['contesting_page_title'] = 'Contest Logging';
-$lang['contesting_button_reset_contest_session'] = 'Reset Contest Session';
+$lang['contesting_button_reset_contest_session'] = 'Start new Contest Session';
 
 $lang['contesting_exchange_type'] = 'Exchange Type';
 $lang['contesting_exchange_type_serial'] = 'Serial';

--- a/application/language/german/contesting_lang.php
+++ b/application/language/german/contesting_lang.php
@@ -3,7 +3,7 @@
 defined('BASEPATH') OR exit('Direkter Zugriff auf Skripte ist nicht erlaubt');
 
 $lang['contesting_page_title'] = 'Contest-Logging';
-$lang['contesting_button_reset_contest_session'] = 'Setze Contest-Sitzung zurück';
+$lang['contesting_button_reset_contest_session'] = 'Beginne neue Contest-Sitzung';
 
 $lang['contesting_exchange_type'] = 'Austauschtyp';
 $lang['contesting_exchange_type_serial'] = 'Laufende Nummer';


### PR DESCRIPTION
Changed caption on the contest page.

The old caption was a bit misleading.

If you forget to "reset" and enter contest mode, you don't see the last QSOs from the previous contest (which can give you the hint to reset).

You have to make the first QSO. After adding the old QSOs are visible and you are annoyed not to have reset before.

So "Start new contest Session" instead of "Reset contest Session" will be better.