### PR TITLE
Override 'environment' with environment variable 

### DIFF
--- a/index.php
+++ b/index.php
@@ -53,9 +53,7 @@
  *
  * NOTE: If you change these, also change the error_reporting() code below
  */
-	#define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development');
-	define('ENVIRONMENT', 'development');
-
+        define('ENVIRONMENT', isset($_ENV["ENVIRONMENT"]) ? $_ENV["ENVIRONMENT"] : 'development');
 /*
  *---------------------------------------------------------------
  * ERROR REPORTING


### PR DESCRIPTION
### **Brief Description**:
This is a simple change that allows the default `ENVIRONMENT` (of `development`) to be overridden using an [environment variable](https://www.php.net/manual/en/reserved.variables.environment.php).

### **Why?**:
This is specifically very useful for two cases (that I can think of at-least):
1. **Container Runtimes** (such as docker, crio etc). It's not possible/and or practical to modify the 'index.php' within a container, it's furthermore not a persisted change. If you did persist it, it would complicate tasks such as updates. 
2. **Updating in general**. It's possible that the 'index.php' may need to be updated in the future, changes to this file may be overwritten. That said, I am new to this project, I have not had time to review how updates are done (etc).

All the best
Ashley (M7JNR)