### PR TITLE
DXCluster integration

### DIFF
--- a/application/controllers/Bandmap.php
+++ b/application/controllers/Bandmap.php
@@ -11,6 +11,11 @@ class Bandmap extends CI_Controller {
 	}
 
 	function index() {
+		$this->load->model('cat');
+		$this->load->model('bands');
+		$data['radios'] = $this->cat->radios();
+		$data['bands'] = $this->bands->get_user_bands_for_qso_entry();
+
         $footerData = [];
 		$footerData['scripts'] = [
 			'assets/js/sections/bandmap.js',

--- a/application/controllers/Bandmap.php
+++ b/application/controllers/Bandmap.php
@@ -36,7 +36,7 @@ class Bandmap extends CI_Controller {
 		$footerData = [];
 		$footerData['scripts'] = [
 			'assets/js/moment.min.js',
-                        'assets/js/datetime-moment.js',
+			'assets/js/datetime-moment.js',
 			'assets/js/sections/bandmap_list.js'
 		];
 

--- a/application/controllers/Bandmap.php
+++ b/application/controllers/Bandmap.php
@@ -21,7 +21,7 @@ class Bandmap extends CI_Controller {
 			'assets/js/sections/bandmap.js',
 		];
 
-		$data['page_title'] = "Bandmap";
+		$data['page_title'] = "DXCluster";
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('bandmap/index');
 		$this->load->view('interface_assets/footer', $footerData);

--- a/application/controllers/Bandmap.php
+++ b/application/controllers/Bandmap.php
@@ -26,4 +26,21 @@ class Bandmap extends CI_Controller {
 		$this->load->view('bandmap/index');
 		$this->load->view('interface_assets/footer', $footerData);
 	}
+
+	function list() {
+		$this->load->model('cat');
+		$this->load->model('bands');
+		$data['radios'] = $this->cat->radios();
+		$data['bands'] = $this->bands->get_user_bands_for_qso_entry();
+
+        	$footerData = [];
+		$footerData['scripts'] = [
+			 'assets/js/sections/bandmap_list.js',
+		];
+
+		$data['page_title'] = "DXCluster";
+		$this->load->view('interface_assets/header', $data);
+		$this->load->view('bandmap/list');
+		$this->load->view('interface_assets/footer', $footerData);
+	}
 }

--- a/application/controllers/Bandmap.php
+++ b/application/controllers/Bandmap.php
@@ -1,0 +1,23 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class Bandmap extends CI_Controller {
+
+	function __construct() {
+		parent::__construct();
+
+		$this->load->model('user_model');
+		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+	}
+
+	function index() {
+        $footerData = [];
+		$footerData['scripts'] = [
+			'assets/js/sections/bandmap.js',
+		];
+
+		$data['page_title'] = "Bandmap";
+		$this->load->view('interface_assets/header', $data);
+		$this->load->view('bandmap/index');
+		$this->load->view('interface_assets/footer', $footerData);
+	}
+}

--- a/application/controllers/Bandmap.php
+++ b/application/controllers/Bandmap.php
@@ -33,14 +33,39 @@ class Bandmap extends CI_Controller {
 		$data['radios'] = $this->cat->radios();
 		$data['bands'] = $this->bands->get_user_bands_for_qso_entry();
 
-        	$footerData = [];
+		$footerData = [];
 		$footerData['scripts'] = [
-			 'assets/js/sections/bandmap_list.js',
+			'assets/js/moment.min.js',
+                        'assets/js/datetime-moment.js',
+			'assets/js/sections/bandmap_list.js'
 		];
+
+		$CI =& get_instance();
+		// Get Date format
+		if($CI->session->userdata('user_date_format')) {
+			// If Logged in and session exists
+			$pageData['custom_date_format'] = $CI->session->userdata('user_date_format');
+		} else {
+			// Get Default date format from /config/cloudlog.php
+			$pageData['custom_date_format'] = $CI->config->item('qso_date_format');
+		}
+
+		switch ($pageData['custom_date_format']) {
+		case "d/m/y": $pageData['custom_date_format'] = 'DD/MM/YY'; break;
+		case "d/m/Y": $pageData['custom_date_format'] = 'DD/MM/YYYY'; break;
+		case "m/d/y": $pageData['custom_date_format'] = 'MM/DD/YY'; break;
+		case "m/d/Y": $pageData['custom_date_format'] = 'MM/DD/YYYY'; break;
+		case "d.m.Y": $pageData['custom_date_format'] = 'DD.MM.YYYY'; break;
+		case "y/m/d": $pageData['custom_date_format'] = 'YY/MM/DD'; break;
+		case "Y-m-d": $pageData['custom_date_format'] = 'YYYY-MM-DD'; break;
+		case "M d, Y": $pageData['custom_date_format'] = 'MMM DD, YYYY'; break;
+		case "M d, y": $pageData['custom_date_format'] = 'MMM DD, YY'; break;
+		default: $pageData['custom_date_format'] = 'DD/MM/YYYY';
+		}
 
 		$data['page_title'] = "DXCluster";
 		$this->load->view('interface_assets/header', $data);
-		$this->load->view('bandmap/list');
+		$this->load->view('bandmap/list',$pageData);
 		$this->load->view('interface_assets/footer', $footerData);
 	}
 }

--- a/application/controllers/Dxcluster.php
+++ b/application/controllers/Dxcluster.php
@@ -7,7 +7,7 @@ class Dxcluster extends CI_Controller {
 		parent::__construct();
 		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
-		$this->load->model('logbook_model');
+		$this->load->model('dxcluster_model');
 	}
 
 
@@ -18,8 +18,8 @@ class Dxcluster extends CI_Controller {
 		if ($de == '') {
 			$de = $this->optionslib->get_option('dxcluster_decont');
 		}
-		$calls_found=$this->logbook_model->dxc_spotlist($band, $age, $de);
-        	header('Content-Type: application/json');
+		$calls_found=$this->dxcluster_model->dxc_spotlist($band, $age, $de);
+			header('Content-Type: application/json');
 		if ($calls_found) {
 			echo json_encode($calls_found, JSON_PRETTY_PRINT);
 		} else {
@@ -28,8 +28,8 @@ class Dxcluster extends CI_Controller {
 	}
 
 	function qrg_lookup($qrg) {
-		$call_found=$this->logbook_model->dxc_qrg_lookup($this->security->xss_clean($qrg));
-        	header('Content-Type: application/json');
+		$call_found=$this->dxcluster_model->dxc_qrg_lookup($this->security->xss_clean($qrg));
+			header('Content-Type: application/json');
 		if ($call_found) {
 			echo json_encode($call_found, JSON_PRETTY_PRINT);
 		} else {
@@ -38,12 +38,13 @@ class Dxcluster extends CI_Controller {
 	}
 
 	function call($call) {
+		$this->load->model('logbook_model');
 
 		$date = date('Ymd', time());
 		$dxcc = $this->logbook_model->dxcc_lookup($call, $date);
 
 		if ($dxcc) {
-        		header('Content-Type: application/json');
+			header('Content-Type: application/json');
 			echo json_encode($dxcc, JSON_PRETTY_PRINT);
 		} else {
 			echo '{ "error": "not found" }';

--- a/application/controllers/Dxcluster.php
+++ b/application/controllers/Dxcluster.php
@@ -11,8 +11,14 @@ class Dxcluster extends CI_Controller {
 	}
 
 
-	function spots($band,$age = 60) {
-		$calls_found=$this->logbook_model->dxc_spotlist($band, $age);
+	function spots($band,$age = '', $de = '') {
+		if ($age == '') {
+			$age = $this->optionslib->get_option('dxcluster_maxage');
+		}
+		if ($de == '') {
+			$de = $this->optionslib->get_option('dxcluster_decont');
+		}
+		$calls_found=$this->logbook_model->dxc_spotlist($band, $age, $de);
         	header('Content-Type: application/json');
 		if ($calls_found) {
 			echo json_encode($calls_found, JSON_PRETTY_PRINT);

--- a/application/controllers/Options.php
+++ b/application/controllers/Options.php
@@ -172,7 +172,7 @@ class Options extends CI_Controller {
 				$this->session->set_flashdata('success', $this->lang->line('options_dxcluster_decont_changed_to').$this->input->post('dxcluster_decont'));
 			}
 
-			$dxcluster_url_update = $this->optionslib->update('dxcluster_maxage', $this->input->post('dxcluster_maxage'), 'yes');
+			$dxcluster_maxage_update = $this->optionslib->update('dxcluster_maxage', $this->input->post('dxcluster_maxage'), 'yes');
 			if($dxcluster_maxage_update == TRUE) {
 				$this->session->set_flashdata('success', $this->lang->line('options_dxcluster_maxage_changed_to').$this->input->post('dxcluster_maxage'));
 			}

--- a/application/language/english/menu_lang.php
+++ b/application/language/english/menu_lang.php
@@ -13,6 +13,7 @@ $lang['menu_live_qso'] = 'Live QSO';
 $lang['menu_post_qso'] = 'Post QSO';
 $lang['menu_live_contest_logging'] = 'Live Contest Logging';
 $lang['menu_post_contest_logging'] = 'Post Contest Logging';
+$lang['menu_bandmap'] = 'Bandmap';
 $lang['menu_view_qsl'] = 'View QSL';
 $lang['menu_view_eqsl'] = 'View eQSL';
 

--- a/application/language/german/menu_lang.php
+++ b/application/language/german/menu_lang.php
@@ -13,6 +13,7 @@ $lang['menu_live_qso'] = 'Live QSO';
 $lang['menu_post_qso'] = 'Zeitversetztes QSO';
 $lang['menu_live_contest_logging'] = 'Live Contest Logging';
 $lang['menu_post_contest_logging'] = 'Zeitversetztes Contest Logging';
+$lang['menu_bandmap'] = 'Bandmap';
 $lang['menu_view_qsl'] = 'QSL Ansicht';
 $lang['menu_view_eqsl'] = 'eQSL Ansicht';
 

--- a/application/models/Dxcluster_model.php
+++ b/application/models/Dxcluster_model.php
@@ -56,8 +56,8 @@ class Dxcluster_model extends CI_Model {
 					    	$dxcc=$dxccObj->dxcc_lookup($singlespot->spotter,date('Ymd', time()));
 					    	$singlespot->dxcc_spotter=$dxcc;
 					    }
-					    if ( ($de != '') && (property_exists($singlespot->dxcc_spotter,'cont')) ){	// If we have a "de continent" and a filter-wish filter on that
-						    if ($de == $singlespot->dxcc_spotter->cont) {
+					    if ( ($de != '') && ($de != 'Any') && (property_exists($singlespot->dxcc_spotter,'cont')) ){	// If we have a "de continent" and a filter-wish filter on that
+						    if (strtolower($de) == strtolower($singlespot->dxcc_spotter->cont)) {
 							    $singlespot->worked_call = ($this->logbook_model->check_if_callsign_worked_in_logbook($singlespot->spotted, $logbooks_locations_array, $singlespot->band) == 1);
 							    array_push($spotsout,$singlespot);
 						    }

--- a/application/models/Dxcluster_model.php
+++ b/application/models/Dxcluster_model.php
@@ -7,6 +7,12 @@ class Dxcluster_model extends CI_Model {
 		$this->load->helper(array('psr4_autoloader'));
 	    $CI =& get_instance();
 	    if ( ($this->optionslib->get_option('dxcache_url') != '') ) {
+		if($CI->session->userdata('user_date_format')) {
+                        $custom_date_format = $CI->session->userdata('user_date_format');
+                } else {
+                        $custom_date_format = $CI->config->item('qso_date_format');
+                }
+
 		    $dxcache_url = $this->optionslib->get_option('dxcache_url').'/spots/'.$band;
 		    $CI->load->model('logbooks_model');
 			$CI->load->model('logbook_model');
@@ -39,7 +45,7 @@ class Dxcluster_model extends CI_Model {
 				    $minutes += $spotage->h * 60;
 				    $minutes += $spotage->i;
 				    $singlespot->age=$minutes;
-
+				    $singlespot->when_pretty=date($custom_date_format . " H:i", strtotime($singlespot->when));
 
 				    if ($minutes<=$maxage) {
 					    if (!(property_exists($singlespot,'dxcc_spotted'))) {	// Check if we already have dxcc of spotted

--- a/application/models/Dxcluster_model.php
+++ b/application/models/Dxcluster_model.php
@@ -7,7 +7,7 @@ class Dxcluster_model extends CI_Model {
 		$this->load->helper(array('psr4_autoloader'));
 	    $CI =& get_instance();
 	    if ( ($this->optionslib->get_option('dxcache_url') != '') ) {
-		    $dxcache_url = $this->optionslib->get_option('dxcache_url').'/spots/';
+		    $dxcache_url = $this->optionslib->get_option('dxcache_url').'/spots/'.$band;
 		    $CI->load->model('logbooks_model');
 			$CI->load->model('logbook_model');
 		    $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));

--- a/application/models/Dxcluster_model.php
+++ b/application/models/Dxcluster_model.php
@@ -1,0 +1,113 @@
+<?php
+
+use Cloudlog\Dxcc\Dxcc;
+
+class Dxcluster_model extends CI_Model {
+    public function dxc_spotlist($band = '20m', $maxage = 60, $de = '') {
+		$this->load->helper(array('psr4_autoloader'));
+	    $CI =& get_instance();
+	    if ( ($this->optionslib->get_option('dxcache_url') != '') ) {
+		    $dxcache_url = $this->optionslib->get_option('dxcache_url').'/spots/';
+		    $CI->load->model('logbooks_model');
+			$CI->load->model('logbook_model');
+		    $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+
+		    // CURL Functions
+		    $ch = curl_init();
+		    curl_setopt($ch, CURLOPT_URL, $dxcache_url);
+		    curl_setopt($ch, CURLOPT_USERAGENT, 'Cloudlog DXLookup');
+		    curl_setopt($ch, CURLOPT_HEADER, false);
+		    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		    $jsonraw = curl_exec($ch);
+		    curl_close($ch);
+		    $json = json_decode($jsonraw);
+			$date = date('Ymd', time());
+
+			$dxccObj = new DXCC($date);
+
+		    // Create JSON object
+		    if (strlen($jsonraw)>20) {
+			    $spotsout=[];
+			    foreach($json as $singlespot){
+				    $spotband = $CI->frequency->GetBand($singlespot->frequency*1000);
+				    $singlespot->band=$spotband;
+				    if ($band != $spotband) { continue; }
+				    $datetimecurrent = new DateTime("now", new DateTimeZone('UTC')); // Today's Date/Time
+				    $datetimespot = new DateTime($singlespot->when, new DateTimeZone('UTC'));
+				    $spotage = $datetimecurrent->diff($datetimespot);
+				    $minutes = $spotage->days * 24 * 60;
+				    $minutes += $spotage->h * 60;
+				    $minutes += $spotage->i;
+				    $singlespot->age=$minutes;
+
+
+				    if ($minutes<=$maxage) {
+					    if (!(property_exists($singlespot,'dxcc_spotted'))) {	// Check if we already have dxcc of spotted
+					    	$dxcc=$dxccObj->dxcc_lookup($singlespot->spotted,date('Ymd', time()));
+					    	$singlespot->dxcc_spotted=$dxcc;
+					    }
+					    if (!(property_exists($singlespot,'dxcc_spotter'))) {	// Check if we already have dxcc of spotter
+					    	$dxcc=$dxccObj->dxcc_lookup($singlespot->spotter,date('Ymd', time()));
+					    	$singlespot->dxcc_spotter=$dxcc;
+					    }
+					    if ( ($de != '') && (array_key_exists('cont',$dxcc)) ){
+						    if ($de == $dxcc['cont']) {
+							    $singlespot->worked_call = ($this->logbook_model->check_if_callsign_worked_in_logbook($singlespot->spotted, $logbooks_locations_array, $singlespot->band) == 1);
+							    array_push($spotsout,$singlespot);
+						    }
+					    } else {
+						    $singlespot->worked_call = ($this->logbook_model->check_if_callsign_worked_in_logbook($singlespot->spotted, $logbooks_locations_array, $singlespot->band) == 1);
+						    array_push($spotsout,$singlespot);
+					    }
+				    }
+			    }
+			    return ($spotsout);
+		    } else {
+			    return '';
+		    }
+	    } else {
+		    return '';
+	    }
+    }
+
+    public function dxc_qrg_lookup($qrg, $maxage = 120) {
+		$this->load->helper(array('psr4_autoloader'));
+	    if ( ($this->optionslib->get_option('dxcache_url') != '') && (is_numeric($qrg)) ) {
+		    $dxcache_url = $this->optionslib->get_option('dxcache_url').'/spot/'.$qrg;
+
+		    // CURL Functions
+		    $ch = curl_init();
+		    curl_setopt($ch, CURLOPT_URL, $dxcache_url);
+		    curl_setopt($ch, CURLOPT_USERAGENT, 'Cloudlog DXLookup by QRG');
+		    curl_setopt($ch, CURLOPT_HEADER, false);
+		    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		    $jsonraw = curl_exec($ch);
+		    curl_close($ch);
+		    $json = json_decode($jsonraw);
+
+			$date = date('Ymd', time());
+
+			$dxccObj = new DXCC($date);
+
+		    // Create JSON object
+			if (strlen($jsonraw)>20) {
+			    $datetimecurrent = new DateTime("now", new DateTimeZone('UTC')); // Today's Date/Time
+			    $datetimespot = new DateTime($json->when, new DateTimeZone('UTC'));
+			    $spotage = $datetimecurrent->diff($datetimespot);
+			    $minutes = $spotage->days * 24 * 60;
+			    $minutes += $spotage->h * 60;
+			    $minutes += $spotage->i;
+			    $json->age=$minutes;
+			    if ($minutes<=$maxage) {
+				    $dxcc=$dxccObj->dxcc_lookup($json->spotter,date('Ymd', time()));
+				    $json->dxcc_spotter=$dxcc;
+				    return ($json);
+			    } else {
+				    return '';
+			    }
+		    } else {
+			    return '';
+		    }
+	    }
+    }
+}

--- a/application/models/Dxcluster_model.php
+++ b/application/models/Dxcluster_model.php
@@ -50,12 +50,12 @@ class Dxcluster_model extends CI_Model {
 					    	$dxcc=$dxccObj->dxcc_lookup($singlespot->spotter,date('Ymd', time()));
 					    	$singlespot->dxcc_spotter=$dxcc;
 					    }
-					    if ( ($de != '') && (array_key_exists('cont',$dxcc)) ){
-						    if ($de == $dxcc['cont']) {
+					    if ( ($de != '') && (property_exists($singlespot->dxcc_spotter,'cont')) ){	// If we have a "de continent" and a filter-wish filter on that
+						    if ($de == $singlespot->dxcc_spotter->cont) {
 							    $singlespot->worked_call = ($this->logbook_model->check_if_callsign_worked_in_logbook($singlespot->spotted, $logbooks_locations_array, $singlespot->band) == 1);
 							    array_push($spotsout,$singlespot);
 						    }
-					    } else {
+					    } else {	// No de continent? No Filter --> Just push
 						    $singlespot->worked_call = ($this->logbook_model->check_if_callsign_worked_in_logbook($singlespot->spotted, $logbooks_locations_array, $singlespot->band) == 1);
 						    array_push($spotsout,$singlespot);
 					    }

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -640,7 +640,7 @@ class Logbook_model extends CI_Model {
 	  if ($replaceoption) {
 		  $post_data['Cmd'] = 'UPDATE';
 		  $post_data['ADIFKey'] = $adif;
-	  } 
+	  }
 	  $post_data['ADIFData'] = $adif;
 
 	  $post_data['Callsign'] = $station_callsign;
@@ -2755,7 +2755,7 @@ class Logbook_model extends CI_Model {
 
 	if (($station_id != 0) && ($record['station_callsign'] != $station_profile_call)) {	// Check if station_call from import matches profile ONLY when submitting via GUI.
 		return "Wrong station_callsign ".$record['station_callsign']." while importing QSO with ".$record['call']." for ".$station_profile_call." : SKIPPED";
-	} 
+	}
 
         $CI =& get_instance();
         $CI->load->library('frequency');
@@ -3992,103 +3992,6 @@ class Logbook_model extends CI_Model {
         }
         return false;
     }
-
-    public function dxc_spotlist($band = '20m',$maxage = 60, $de = '') {
-	    $CI =& get_instance();
-	    if ( ($this->optionslib->get_option('dxcache_url') != '') ) {
-		    $dxcache_url = $this->optionslib->get_option('dxcache_url').'/spots/';
-		    $CI->load->model('logbooks_model');
-		    $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
-
-		    // CURL Functions
-		    $ch = curl_init();
-		    curl_setopt($ch, CURLOPT_URL, $dxcache_url);
-		    curl_setopt($ch, CURLOPT_USERAGENT, 'Cloudlog DXLookup');
-		    curl_setopt($ch, CURLOPT_HEADER, false);
-		    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		    $jsonraw = curl_exec($ch);
-		    curl_close($ch);
-		    $json = json_decode($jsonraw);
-
-		    // Create JSON object
-		    if (strlen($jsonraw)>20) {
-			    $spotsout=[];
-			    foreach($json as $singlespot){
-				    $spotband = $CI->frequency->GetBand($singlespot->frequency*1000);
-				    $singlespot->band=$spotband;
-				    if ($band != $spotband) { continue; }
-				    $datetimecurrent = new DateTime("now", new DateTimeZone('UTC')); // Today's Date/Time
-				    $datetimespot = new DateTime($singlespot->when, new DateTimeZone('UTC'));
-				    $spotage = $datetimecurrent->diff($datetimespot);
-				    $minutes = $spotage->days * 24 * 60;
-				    $minutes += $spotage->h * 60;
-				    $minutes += $spotage->i;
-				    $singlespot->age=$minutes;
-				    if ($minutes<=$maxage) {
-					    if (!(property_exists($singlespot,'dxcc_spotted'))) {	// Check if we already have dxcc of spotted
-					    	$dxcc=$this->dxcc_lookup($singlespot->spotted,date('Ymd', time()));
-					    	$singlespot->dxcc_spotted=$dxcc;
-					    }
-					    if (!(property_exists($singlespot,'dxcc_spotter'))) {	// Check if we already have dxcc of spotter
-					    	$dxcc=$this->dxcc_lookup($singlespot->spotter,date('Ymd', time()));
-					    	$singlespot->dxcc_spotter=$dxcc;
-					    }
-					    if ( ($de != '') && (array_key_exists('cont',$dxcc)) ){
-						    if ($de == $dxcc['cont']) {
-							    $singlespot->worked_call = ($this->check_if_callsign_worked_in_logbook($singlespot->spotted, $logbooks_locations_array, $singlespot->band) == 1);
-							    array_push($spotsout,$singlespot);
-						    }
-					    } else {
-						    $singlespot->worked_call = ($this->check_if_callsign_worked_in_logbook($singlespot->spotted, $logbooks_locations_array, $singlespot->band) == 1);
-						    array_push($spotsout,$singlespot);
-					    }
-				    }
-			    }
-			    return ($spotsout);
-		    } else {
-			    return '';
-		    }
-	    } else {
-		    return '';
-	    }
-    }
-
-    public function dxc_qrg_lookup($qrg, $maxage = 120) {
-	    if ( ($this->optionslib->get_option('dxcache_url') != '') && (is_numeric($qrg)) ) {
-		    $dxcache_url = $this->optionslib->get_option('dxcache_url').'/spot/'.$qrg;
-
-		    // CURL Functions
-		    $ch = curl_init();
-		    curl_setopt($ch, CURLOPT_URL, $dxcache_url);
-		    curl_setopt($ch, CURLOPT_USERAGENT, 'Cloudlog DXLookup by QRG');
-		    curl_setopt($ch, CURLOPT_HEADER, false);
-		    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		    $jsonraw = curl_exec($ch);
-		    curl_close($ch);
-		    $json = json_decode($jsonraw);
-
-		    // Create JSON object
-		    if (strlen($jsonraw)>20) {
-			    $datetimecurrent = new DateTime("now", new DateTimeZone('UTC')); // Today's Date/Time
-			    $datetimespot = new DateTime($json->when, new DateTimeZone('UTC'));
-			    $spotage = $datetimecurrent->diff($datetimespot);
-			    $minutes = $spotage->days * 24 * 60;
-			    $minutes += $spotage->h * 60;
-			    $minutes += $spotage->i;
-			    $json->age=$minutes;
-			    if ($minutes<=$maxage) {
-				    $dxcc=$this->dxcc_lookup($json->spotter,date('Ymd', time()));
-				    $json->dxcc_spotter=$dxcc;
-				    return ($json);
-			    } else {
-				    return '';
-			    }
-		    } else {
-			    return '';
-		    }
-	    }
-    }
-	
 }
 
 function validateADIFDate($date, $format = 'Ymd')

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3993,7 +3993,7 @@ class Logbook_model extends CI_Model {
         return false;
     }
 
-    public function dxc_spotlist($band = '20m',$maxage = 60) {
+    public function dxc_spotlist($band = '20m',$maxage = 60, $de = '') {
 	    $CI =& get_instance();
 	    if ( ($this->optionslib->get_option('dxcache_url') != '') ) {
 		    $dxcache_url = $this->optionslib->get_option('dxcache_url').'/spots/';
@@ -4025,7 +4025,13 @@ class Logbook_model extends CI_Model {
 				    if ($minutes<=$maxage) {
 					     $dxcc=$this->dxcc_lookup($singlespot->spotter,date('Ymd', time()));
 					     $singlespot->dxcc_spotter=$dxcc;
-					     array_push($spotsout,$singlespot);
+						if ($de != '') {
+					     		if ($de == $dxcc['cont']) {
+								array_push($spotsout,$singlespot);
+							}
+						} else {
+					     		array_push($spotsout,$singlespot);
+						}
 				    }
 			    }
 			    return ($spotsout);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4025,9 +4025,15 @@ class Logbook_model extends CI_Model {
 				    $minutes += $spotage->i;
 				    $singlespot->age=$minutes;
 				    if ($minutes<=$maxage) {
-					    $dxcc=$this->dxcc_lookup($singlespot->spotter,date('Ymd', time()));
-					    $singlespot->dxcc_spotter=$dxcc;
-					    if ($de != '') {
+					    if (!(property_exists($singlespot,'dxcc_spotted'))) {	// Check if we already have dxcc of spotted
+					    	$dxcc=$this->dxcc_lookup($singlespot->spotted,date('Ymd', time()));
+					    	$singlespot->dxcc_spotted=$dxcc;
+					    }
+					    if (!(property_exists($singlespot,'dxcc_spotter'))) {	// Check if we already have dxcc of spotter
+					    	$dxcc=$this->dxcc_lookup($singlespot->spotter,date('Ymd', time()));
+					    	$singlespot->dxcc_spotter=$dxcc;
+					    }
+					    if ( ($de != '') && (array_key_exists('cont',$dxcc)) ){
 						    if ($de == $dxcc['cont']) {
 							    $singlespot->worked_call = ($this->check_if_callsign_worked_in_logbook($singlespot->spotted, $logbooks_locations_array, $singlespot->band) == 1);
 							    array_push($spotsout,$singlespot);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2749,9 +2749,13 @@ class Logbook_model extends CI_Model {
 	$station_profile=$CI->Stations->profile_clean($station_id);
 	$station_profile_call=$station_profile->station_callsign;
 
-/*	if (($station_id != 0) && ($record['station_callsign'] != $station_profile_call)) {	// Check if station_call from import matches profile ONLY when submitting via GUI.
-		return "Wrong station_callsign ".$record['station_callsign']." while importing QSO with ".$record['call']." for ".$station_profile_call;
-	} */
+	if (($station_id !=0 ) && (!(isset($record['station_callsign'])))) {
+		$record['station_callsign']=$station_profile_call;
+	}
+
+	if (($station_id != 0) && ($record['station_callsign'] != $station_profile_call)) {	// Check if station_call from import matches profile ONLY when submitting via GUI.
+		return "Wrong station_callsign ".$record['station_callsign']." while importing QSO with ".$record['call']." for ".$station_profile_call." : SKIPPED";
+	} 
 
         $CI =& get_instance();
         $CI->load->library('frequency');

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4050,7 +4050,7 @@ class Logbook_model extends CI_Model {
 		    // CURL Functions
 		    $ch = curl_init();
 		    curl_setopt($ch, CURLOPT_URL, $dxcache_url);
-		    curl_setopt($ch, CURLOPT_USERAGENT, 'Cloudlog DXLookup');
+		    curl_setopt($ch, CURLOPT_USERAGENT, 'Cloudlog DXLookup by QRG');
 		    curl_setopt($ch, CURLOPT_HEADER, false);
 		    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		    $jsonraw = curl_exec($ch);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2748,9 +2748,10 @@ class Logbook_model extends CI_Model {
 
 	$station_profile=$CI->Stations->profile_clean($station_id);
 	$station_profile_call=$station_profile->station_callsign;
-	if (($station_id != 0) && ($record['station_callsign'] != $station_profile_call)) {	// Check if station_call from import matches profile ONLY when submitting via GUI.
+
+/*	if (($station_id != 0) && ($record['station_callsign'] != $station_profile_call)) {	// Check if station_call from import matches profile ONLY when submitting via GUI.
 		return "Wrong station_callsign ".$record['station_callsign']." while importing QSO with ".$record['call']." for ".$station_profile_call;
-	}
+	} */
 
         $CI =& get_instance();
         $CI->load->library('frequency');

--- a/application/views/bandmap/index.php
+++ b/application/views/bandmap/index.php
@@ -1,31 +1,38 @@
 <script>
 	var dxcluster_provider="<?php echo base_url(); ?>index.php/dxcluster";
+	var cat_timeout_interval="<?php echo $this->optionslib->get_option('cat_timeout_interval'); ?>";
 </script>
 
-<div class="container">
 
+<div class="container">
 <br>
 
 <h2><?php echo $page_title; ?></h2>
-                <div class="form-group col-md-6">
-                  <label for="band"><?php echo lang('gen_hamradio_band'); ?></label>
+<div class="messages"></div>
+<div class="form-inline">
+		<label class="my-1 mr-2" for="radio"><?php echo lang('gen_hamradio_radio'); ?></label>
+		<select class="form-control-sm radios my-1 mr-sm-2" id="radio" name="radio">
+			<option value="0" selected="selected"><?php echo lang('general_word_none'); ?></option>
+			<?php foreach ($radios->result() as $row) { ?>
+			<option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?></option>
+			<?php } ?>
+		</select>
 
-                  <select id="band" class="form-control form-control-sm" name="band">
-                  <?php 
-			$bands = $this->bands->get_user_bands_for_qso_entry();	
-			foreach($bands as $key=>$bandgroup) {
-                          echo '<optgroup label="' . strtoupper($key) . '">';
-                          foreach($bandgroup as $band) {
-                            echo '<option value="' . $band . '"';
-                              if ($band == "20m") echo ' selected';
-                              echo '>' . $band . '</option>'."\n";
-                          }
-                          echo '</optgroup>';
-                        }
-                  ?>
-                  </select>
-                </div>
-	
+		<label class="my-1 mr-2" for="band"><?php echo lang('gen_hamradio_band'); ?></label>
+		<select id="band" class="form-control-sm my-1 mr-sm-2" name="band">
+			<?php foreach($bands as $key=>$bandgroup) {
+					echo '<optgroup label="' . strtoupper($key) . '">';
+					foreach($bandgroup as $band) {
+					echo '<option value="' . $band . '"';
+						if ($band == "20m") echo ' selected';
+						echo '>' . $band . '</option>'."\n";
+					}
+					echo '</optgroup>';
+				}
+			?>
+		</select>
+	</div>
+
 <figure class="highcharts-figure">
     <div id="bandmap"></div>
     <p class="highcharts-description">

--- a/application/views/bandmap/index.php
+++ b/application/views/bandmap/index.php
@@ -7,8 +7,8 @@
 <div class="container">
 <br>
 <center><button type="button" class="btn" id="menutoggle"><i class="fa fa-arrow-up" id="menutoggle_i"></i></button></center>
-<h2><?php echo $page_title; ?></h2>
-<div class="tabs">
+<h2 id="dxtitle"><?php echo $page_title; ?></h2>
+<div class="tabs" id="dxtabs">
 		<ul class="nav nav-tabs" id="myTab" role="tablist">
 			<li class="nav-item">
 				<a class="nav-link active" href="index">DXMap</a>

--- a/application/views/bandmap/index.php
+++ b/application/views/bandmap/index.php
@@ -11,10 +11,10 @@
 <div class="tabs" id="dxtabs">
 		<ul class="nav nav-tabs" id="myTab" role="tablist">
 			<li class="nav-item">
-				<a class="nav-link active" href="index">DXMap</a>
+				<a class="nav-link active" href="index">BandMap</a>
 			</li>
 			<li class="nav-item">
-				<a class="nav-link" href="list">DXList</a>
+				<a class="nav-link" href="list">BandList</a>
 			</li>
 		</ul>
 </div>

--- a/application/views/bandmap/index.php
+++ b/application/views/bandmap/index.php
@@ -8,6 +8,17 @@
 <br>
 
 <h2><?php echo $page_title; ?></h2>
+<div class="tabs">
+		<ul class="nav nav-tabs" id="myTab" role="tablist">
+			<li class="nav-item">
+				<a class="nav-link active" href="index">DXMap</a>
+			</li>
+			<li class="nav-item">
+				<a class="nav-link" href="list">DXList</a>
+			</li>
+		</ul>
+</div>
+<div class="tab-content" id="myTabContent">
 <div class="messages"></div>
 <div class="form-inline">
 		<label class="my-1 mr-2" for="radio"><?php echo lang('gen_hamradio_radio'); ?></label>
@@ -38,4 +49,5 @@
     <p class="highcharts-description">
     </p>
 </figure>
+</div>
 </div>

--- a/application/views/bandmap/index.php
+++ b/application/views/bandmap/index.php
@@ -6,7 +6,7 @@
 
 <div class="container">
 <br>
-
+<center><button type="button" class="btn" id="menutoggle"><i class="fa fa-arrow-up" id="menutoggle_i"></i></button></center>
 <h2><?php echo $page_title; ?></h2>
 <div class="tabs">
 		<ul class="nav nav-tabs" id="myTab" role="tablist">

--- a/application/views/bandmap/index.php
+++ b/application/views/bandmap/index.php
@@ -1,0 +1,12 @@
+<div class="container">
+
+<br>
+
+<h2><?php echo $page_title; ?></h2>
+
+<figure class="highcharts-figure">
+    <div id="bandmap"></div>
+    <p class="highcharts-description">
+    </p>
+</figure>
+</div>

--- a/application/views/bandmap/index.php
+++ b/application/views/bandmap/index.php
@@ -1,5 +1,6 @@
 <script>
 	var dxcluster_provider="<?php echo base_url(); ?>index.php/dxcluster";
+	var dxcluster_maxage=<?php echo $this->optionslib->get_option('dxcluster_maxage'); ?>;
 	var cat_timeout_interval="<?php echo $this->optionslib->get_option('cat_timeout_interval'); ?>";
 </script>
 

--- a/application/views/bandmap/index.php
+++ b/application/views/bandmap/index.php
@@ -19,7 +19,7 @@
 		</ul>
 </div>
 <div class="tab-content" id="myTabContent">
-<div class="messages"></div>
+<div class="messages my-1 mr-2"></div>
 <div class="form-inline">
 		<label class="my-1 mr-2" for="radio"><?php echo lang('gen_hamradio_radio'); ?></label>
 		<select class="form-control-sm radios my-1 mr-sm-2" id="radio" name="radio">
@@ -28,6 +28,18 @@
 			<option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?></option>
 			<?php } ?>
 		</select>
+
+		<label class="my-1 mr-2" for="decontSelect">Spots de</label>
+		<select class="form-control-sm my-1 mr-sm-2" id="decontSelect" name="dxcluster_decont" aria-describedby="dxcluster_decontHelp" required>
+				<option value="Any">*</option>
+				<option value="AF"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'AF') { echo " selected"; } ?>>Africa</option>
+				<option value="AN"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'AN') { echo " selected"; } ?>>Antarctica</option>
+				<option value="AS"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'AS') { echo " selected"; } ?>>Asia</option>
+				<option value="EU"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'EU') { echo " selected"; } ?>>Europe</option>
+				<option value="NA"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'NA') { echo " selected"; } ?>>North America</option>
+				<option value="OC"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'OC') { echo " selected"; } ?>>Oceania</option>
+				<option value="SA"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'SA') { echo " selected"; } ?>>South America</option>
+                </select>
 
 		<label class="my-1 mr-2" for="band"><?php echo lang('gen_hamradio_band'); ?></label>
 		<select id="band" class="form-control-sm my-1 mr-sm-2" name="band">

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -32,7 +32,7 @@
 </div>
 
 <div class="tab-content" id="myTabContent">
-<div class="messages"></div>
+<div class="messages my-1 mr-2"></div>
 <div class="form-inline">
 		<label class="my-1 mr-2" for="radio"><?php echo lang('gen_hamradio_radio'); ?></label>
 		<select class="form-control-sm radios my-1 mr-sm-2" id="radio" name="radio">
@@ -68,8 +68,6 @@
 		</select>
 	</div>
 
-          <div class="card log">
-                <div class="card-header"><h5 class="card-title">DXCluster</h5></div>
                 <p>
 
                 <table style="width:100%" class="table-sm table spottable table-bordered table-hover table-striped table-condensed">
@@ -86,7 +84,6 @@
                     </tbody>
                 </table>
             </div>
-        </div>
 
 </div>
 </div>

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -27,6 +27,17 @@
 			<option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?></option>
 			<?php } ?>
 		</select>
+		<label class="my-1 mr-2" for="decontSelect">Spots de</label>
+		<select class="form-control-sm my-1 mr-sm-2" id="decontSelect" name="dxcluster_decont" aria-describedby="dxcluster_decontHelp" required>
+				<option value="Any">*</option>
+				<option value="AF"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'AF') { echo " selected"; } ?>>Africa</option>
+				<option value="AN"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'AN') { echo " selected"; } ?>>Antarctica</option>
+				<option value="AS"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'AS') { echo " selected"; } ?>>Asia</option>
+				<option value="EU"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'EU') { echo " selected"; } ?>>Europe</option>
+				<option value="NA"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'NA') { echo " selected"; } ?>>North America</option>
+				<option value="OC"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'OC') { echo " selected"; } ?>>Oceania</option>
+				<option value="SA"<?php if ($this->optionslib->get_option('dxcluster_decont') == 'SA') { echo " selected"; } ?>>South America</option>
+                </select>
 
 		<label class="my-1 mr-2" for="band"><?php echo lang('gen_hamradio_band'); ?></label>
 		<select id="band" class="form-control-sm my-1 mr-sm-2" name="band">

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -1,6 +1,7 @@
 <script>
 	var dxcluster_provider="<?php echo base_url(); ?>index.php/dxcluster";
 	var cat_timeout_interval="<?php echo $this->optionslib->get_option('cat_timeout_interval'); ?>";
+	var dxcluster_maxage=<?php echo $this->optionslib->get_option('dxcluster_maxage'); ?>;
 	var custom_date_format = "<?php echo $custom_date_format ?>";
 </script>
 

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -1,0 +1,56 @@
+<script>
+	var dxcluster_provider="<?php echo base_url(); ?>index.php/dxcluster";
+	var cat_timeout_interval="<?php echo $this->optionslib->get_option('cat_timeout_interval'); ?>";
+</script>
+
+
+<div class="container">
+<br>
+
+<h2><?php echo $page_title; ?></h2>
+<div class="messages"></div>
+<div class="form-inline">
+		<label class="my-1 mr-2" for="radio"><?php echo lang('gen_hamradio_radio'); ?></label>
+		<select class="form-control-sm radios my-1 mr-sm-2" id="radio" name="radio">
+			<option value="0" selected="selected"><?php echo lang('general_word_none'); ?></option>
+			<?php foreach ($radios->result() as $row) { ?>
+			<option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?></option>
+			<?php } ?>
+		</select>
+
+		<label class="my-1 mr-2" for="band"><?php echo lang('gen_hamradio_band'); ?></label>
+		<select id="band" class="form-control-sm my-1 mr-sm-2" name="band">
+			<?php foreach($bands as $key=>$bandgroup) {
+					echo '<optgroup label="' . strtoupper($key) . '">';
+					foreach($bandgroup as $band) {
+					echo '<option value="' . $band . '"';
+						if ($band == "20m") echo ' selected';
+						echo '>' . $band . '</option>'."\n";
+					}
+					echo '</optgroup>';
+				}
+			?>
+		</select>
+	</div>
+
+          <div class="card log">
+                <div class="card-header"><h5 class="card-title">DXCluster</h5></div>
+                <p>
+
+                <table style="width:100%" class="table-sm table spottable table-bordered table-hover table-striped table-condensed text-center">
+                    <thead>
+                        <tr class="log_title titles">
+                            <th><?php echo lang('general_word_date'); ?>/<?php echo lang('general_word_time'); ?></th>
+			    <th><?php echo lang('gen_hamradio_frequency'); ?></th>
+                            <th><?php echo lang('gen_hamradio_call'); ?></th>
+			    <th>DXCC</th>
+                        </tr>
+                    </thead>
+
+                    <tbody class="spots_table_contents">
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+</div>

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -23,10 +23,10 @@
 <div id="dxtabs" class="tabs">
 		<ul class="nav nav-tabs" id="myTab" role="tablist">
 			<li class="nav-item">
-				<a class="nav-link" href="index">DXMap</a>
+				<a class="nav-link" href="index">BandMap</a>
 			</li>
 			<li class="nav-item">
-				<a class="nav-link active" href="list">DXList</a>
+				<a class="nav-link active" href="list">BandList</a>
 			</li>
 		</ul>
 </div>

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -16,8 +16,10 @@
 
 <div class="container">
 <br>
+<center><button type="button" class="btn" id="menutoggle"><i class="fa fa-arrow-up" id="menutoggle_i"></i></button></center>
 
 <h2><?php echo $page_title; ?></h2>
+
 <div class="tabs">
 		<ul class="nav nav-tabs" id="myTab" role="tablist">
 			<li class="nav-item">
@@ -28,6 +30,7 @@
 			</li>
 		</ul>
 </div>
+
 <div class="tab-content" id="myTabContent">
 <div class="messages"></div>
 <div class="form-inline">

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -18,9 +18,9 @@
 <br>
 <center><button type="button" class="btn" id="menutoggle"><i class="fa fa-arrow-up" id="menutoggle_i"></i></button></center>
 
-<h2><?php echo $page_title; ?></h2>
+<h2 id="dxtitle"><?php echo $page_title; ?></h2>
 
-<div class="tabs">
+<div id="dxtabs" class="tabs">
 		<ul class="nav nav-tabs" id="myTab" role="tablist">
 			<li class="nav-item">
 				<a class="nav-link" href="index">DXMap</a>

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -18,6 +18,17 @@
 <br>
 
 <h2><?php echo $page_title; ?></h2>
+<div class="tabs">
+		<ul class="nav nav-tabs" id="myTab" role="tablist">
+			<li class="nav-item">
+				<a class="nav-link" href="index">DXMap</a>
+			</li>
+			<li class="nav-item">
+				<a class="nav-link active" href="list">DXList</a>
+			</li>
+		</ul>
+</div>
+<div class="tab-content" id="myTabContent">
 <div class="messages"></div>
 <div class="form-inline">
 		<label class="my-1 mr-2" for="radio"><?php echo lang('gen_hamradio_radio'); ?></label>
@@ -74,4 +85,5 @@
             </div>
         </div>
 
+</div>
 </div>

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -4,6 +4,15 @@
 	var custom_date_format = "<?php echo $custom_date_format ?>";
 </script>
 
+<style>
+.fresh{
+    -webkit-transition: all 15s ease;
+    -moz-transition: all 15s ease;
+    -o-transition: all 15s ease;
+    transition: all 15s ease;
+}
+</style>
+
 
 <div class="container">
 <br>

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -1,6 +1,7 @@
 <script>
 	var dxcluster_provider="<?php echo base_url(); ?>index.php/dxcluster";
 	var cat_timeout_interval="<?php echo $this->optionslib->get_option('cat_timeout_interval'); ?>";
+	var custom_date_format = "<?php echo $custom_date_format ?>";
 </script>
 
 
@@ -37,7 +38,7 @@
                 <div class="card-header"><h5 class="card-title">DXCluster</h5></div>
                 <p>
 
-                <table style="width:100%" class="table-sm table spottable table-bordered table-hover table-striped table-condensed text-center">
+                <table style="width:100%" class="table-sm table spottable table-bordered table-hover table-striped table-condensed">
                     <thead>
                         <tr class="log_title titles">
                             <th><?php echo lang('general_word_date'); ?>/<?php echo lang('general_word_time'); ?></th>

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -77,6 +77,7 @@
 			    <th><?php echo lang('gen_hamradio_frequency'); ?></th>
                             <th><?php echo lang('gen_hamradio_call'); ?></th>
 			    <th>DXCC</th>
+                            <th><?php echo lang('gen_hamradio_call'); ?> Spotter</th>
                         </tr>
                     </thead>
 

--- a/application/views/debug/main.php
+++ b/application/views/debug/main.php
@@ -111,7 +111,7 @@
                         <td>
                             <?php if(in_array  ('curl', get_loaded_extensions())) { ?>
                                 <span class="badge badge-success">Installed</span>
-                            <?php } else { ?> 
+                            <?php } else { ?>
                                 <span class="badge badge-danger">Not Installed</span>
                             <?php } ?>
                         </td>
@@ -122,7 +122,7 @@
                         <td>
                             <?php if(in_array  ('mysqli', get_loaded_extensions())) { ?>
                                 <span class="badge badge-success">Installed</span>
-                            <?php } else { ?> 
+                            <?php } else { ?>
                                 <span class="badge badge-danger">Not Installed</span>
                             <?php } ?>
                         </td>
@@ -133,7 +133,7 @@
                         <td>
                             <?php if(in_array  ('mbstring', get_loaded_extensions())) { ?>
                                 <span class="badge badge-success">Installed</span>
-                            <?php } else { ?> 
+                            <?php } else { ?>
                                 <span class="badge badge-danger">Not Installed</span>
                             <?php } ?>
                         </td>
@@ -144,7 +144,7 @@
                         <td>
                             <?php if(in_array  ('xml', get_loaded_extensions())) { ?>
                                 <span class="badge badge-success">Installed</span>
-                            <?php } else { ?> 
+                            <?php } else { ?>
                                 <span class="badge badge-danger">Not Installed</span>
                             <?php } ?>
                         </td>
@@ -155,7 +155,7 @@
                         <td>
                             <?php if(in_array  ('openssl', get_loaded_extensions())) { ?>
                                 <span class="badge badge-success">Installed</span>
-                            <?php } else { ?> 
+                            <?php } else { ?>
                                 <span class="badge badge-danger">Not Installed</span>
                             <?php } ?>
                         </td>
@@ -171,22 +171,27 @@
             $owner = '';
             // only proceed here if git can actually be executed
             if ($commitHash != "") {
-               $commitDate = trim(exec('git log --pretty="%ci" -n1 HEAD'));
-               $line = trim(exec('git log -n 1 --pretty=%D HEAD'));
-               $pieces = explode(', ', $line);
-               $lastFetch = trim(exec('stat -c %Y .git/FETCH_HEAD'));
-               $dt = new DateTime("@$lastFetch");
-               if (isset($pieces[1])) {
-                  $remote = substr($pieces[1], 0, strpos($pieces[1], '/'));
-                  $branch = substr($pieces[1], strpos($pieces[1], '/')+1);
-                  $url = trim(exec('git remote get-url '.$remote));
-                  if (strpos($url, 'https://github.com') !== false) {
-                     $owner = preg_replace('/https:\/\/github\.com\/(\w+)\/Cloudlog\.git/', '$1', $url);
-                  } else if (strpos($url, 'git@github.com') !== false) {
-                     $owner = preg_replace('/git@github\.com:(\w+)\/Cloudlog\.git/', '$1', $url);
-                  }
-               }
-               $tag = trim(exec('git describe --tags '.$commitHash));
+				$commitDate = trim(exec('git log --pretty="%ci" -n1 HEAD'));
+				$line = trim(exec('git log -n 1 --pretty=%D HEAD'));
+				$pieces = explode(', ', $line);
+				$lastFetch = trim(exec('stat -c %Y .git/FETCH_HEAD'));
+				//Below is a failsafe for systems without the stat command
+				try {
+					$dt = new DateTime("@$lastFetch");
+				} catch(Exception $e) {
+					$dt = new DateTime(date("Y-m-d H:i:s"));
+				}
+				if (isset($pieces[1])) {
+					$remote = substr($pieces[1], 0, strpos($pieces[1], '/'));
+					$branch = substr($pieces[1], strpos($pieces[1], '/')+1);
+					$url = trim(exec('git remote get-url '.$remote));
+					if (strpos($url, 'https://github.com') !== false) {
+						$owner = preg_replace('/https:\/\/github\.com\/(\w+)\/Cloudlog\.git/', '$1', $url);
+					} else if (strpos($url, 'git@github.com') !== false) {
+						$owner = preg_replace('/git@github\.com:(\w+)\/Cloudlog\.git/', '$1', $url);
+					}
+				}
+				$tag = trim(exec('git describe --tags '.$commitHash));
             }
         ?>
 
@@ -206,7 +211,7 @@
                                 <?php if($owner != "") { ?>
                                     </a>
                                 <?php } ?>
-                            <?php } else { ?> 
+                            <?php } else { ?>
                                 <span class="badge badge-danger">n/a</span>
                             <?php } ?>
                         </td>
@@ -217,7 +222,7 @@
                         <td>
                             <?php if($commitHash != "") { ?>
                                 <a target="_blank" href="https://github.com/magicbug/Cloudlog/commit/<?php echo $commitHash?>"><span class="badge badge-success"><?php echo substr($commitHash,0,8); ?></span></a>
-                            <?php } else { ?> 
+                            <?php } else { ?>
                                 <span class="badge badge-danger">n/a</span>
                             <?php } ?>
                         </td>
@@ -227,7 +232,7 @@
                         <td>
                             <?php if($commitHash != "") { ?>
                                 <a target="_blank" href="https://github.com/magicbug/Cloudlog/releases/tag/<?php echo substr($tag,0,strpos($tag, '-')); ?>"><span class="badge badge-success"><?php echo $tag; ?></span></a>
-                            <?php } else { ?> 
+                            <?php } else { ?>
                                 <span class="badge badge-danger">n/a</span>
                             <?php } ?>
                         </td>
@@ -235,7 +240,7 @@
                     <tr>
                         <td>Last Fetch</td>
                         <td>
-                              <?php echo $dt->format(\DateTime::RFC850); ?>
+							<?php echo ($dt == null ? '' : $dt->format(\DateTime::RFC850)); ?>
                         </td>
                     </tr>
                 </table>

--- a/application/views/debug/main.php
+++ b/application/views/debug/main.php
@@ -165,34 +165,39 @@
         </div>
         <?php if (file_exists('.git')) { ?>
         <?php
-            $commitHash = trim(exec('git log --pretty="%H" -n1 HEAD'));
-            $branch = '';
-            $remote = '';
-            $owner = '';
-            // only proceed here if git can actually be executed
-            if ($commitHash != "") {
-				$commitDate = trim(exec('git log --pretty="%ci" -n1 HEAD'));
-				$line = trim(exec('git log -n 1 --pretty=%D HEAD'));
-				$pieces = explode(', ', $line);
-				$lastFetch = trim(exec('stat -c %Y .git/FETCH_HEAD'));
-				//Below is a failsafe for systems without the stat command
-				try {
-					$dt = new DateTime("@$lastFetch");
-				} catch(Exception $e) {
-					$dt = new DateTime(date("Y-m-d H:i:s"));
-				}
-				if (isset($pieces[1])) {
-					$remote = substr($pieces[1], 0, strpos($pieces[1], '/'));
-					$branch = substr($pieces[1], strpos($pieces[1], '/')+1);
-					$url = trim(exec('git remote get-url '.$remote));
-					if (strpos($url, 'https://github.com') !== false) {
-						$owner = preg_replace('/https:\/\/github\.com\/(\w+)\/Cloudlog\.git/', '$1', $url);
-					} else if (strpos($url, 'git@github.com') !== false) {
-						$owner = preg_replace('/git@github\.com:(\w+)\/Cloudlog\.git/', '$1', $url);
+			//Below is a failsafe where git commands fail
+			try {
+				$commitHash = trim(exec('git log --pretty="%H" -n1 HEAD'));
+				$branch = '';
+				$remote = '';
+				$owner = '';
+				// only proceed here if git can actually be executed
+				if ($commitHash != "") {
+					$commitDate = trim(exec('git log --pretty="%ci" -n1 HEAD'));
+					$line = trim(exec('git log -n 1 --pretty=%D HEAD'));
+					$pieces = explode(', ', $line);
+					$lastFetch = trim(exec('stat -c %Y .git/FETCH_HEAD'));
+					//Below is a failsafe for systems without the stat command
+					try {
+						$dt = new DateTime("@$lastFetch");
+					} catch(Exception $e) {
+						$dt = new DateTime(date("Y-m-d H:i:s"));
 					}
+					if (isset($pieces[1])) {
+						$remote = substr($pieces[1], 0, strpos($pieces[1], '/'));
+						$branch = substr($pieces[1], strpos($pieces[1], '/')+1);
+						$url = trim(exec('git remote get-url '.$remote));
+						if (strpos($url, 'https://github.com') !== false) {
+							$owner = preg_replace('/https:\/\/github\.com\/(\w+)\/Cloudlog\.git/', '$1', $url);
+						} else if (strpos($url, 'git@github.com') !== false) {
+							$owner = preg_replace('/git@github\.com:(\w+)\/Cloudlog\.git/', '$1', $url);
+						}
+					}
+					$tag = trim(exec('git describe --tags '.$commitHash));
 				}
-				$tag = trim(exec('git describe --tags '.$commitHash));
-            }
+			} catch (\Throwable $th) {
+				$commitHash = "";
+			}
         ?>
 
         <?php if($commitHash != "") { ?>

--- a/application/views/gridmap/index.php
+++ b/application/views/gridmap/index.php
@@ -27,7 +27,7 @@
   margin: 0 8px 0 0;
 }
 .coordinates {
-    justify-content: center; 
+    justify-content: center;
     align-items: stretch;
 }
 .cohidden {
@@ -108,7 +108,8 @@
                     </div>
                 </div>
 
-            <button id="plot" type="button" name="plot" class="btn btn-primary  ld-ext-right" onclick="gridPlot(this.form)"><?php echo lang('gridsquares_button_plot'); ?><div class="ld ld-ring ld-spin"></div></button>
+            <button id="plot" type="button" name="plot" class="btn btn-primary mr-1 ld-ext-right ld-ext-right-plot" onclick="gridPlot(this.form)"><?php echo lang('gridsquares_button_plot'); ?><div class="ld ld-ring ld-spin"></div></button>
+			<button id="clear" type="button" name="clear" class="btn btn-primary mr-1 ld-ext-right ld-ext-right-clear" onclick="clearMarkers()">Clear markers<div class="ld ld-ring ld-spin"></div></button>
 </form>
 
 		<?php if($this->session->flashdata('message')) { ?>

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -937,7 +937,7 @@ $(document).on('keypress',function(e) {
 
 	if ($this->optionslib->get_option('dxcache_url') != ''){ ?>
 	<script type="text/javascript">
-		var dxcluster_provider = <?php echo base_url(); ?>'index.php/dxcluster';
+		var dxcluster_provider = '<?php echo base_url(); ?>index.php/dxcluster';
 		$(document).ready(function() {
 			$("#check_cluster").on("click", function() {
 				$.ajax({ url: dxcluster_provider+"/qrg_lookup/"+$("#frequency").val()/1000, cache: false, dataType: "json" }).done(

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2911,6 +2911,15 @@ function viewEqsl(picture, callsign) {
 	</script>
 <?php } ?>
 
+<?php if ($this->uri->segment(1) == "bandmap") { ?>
+
+	<script src="https://code.highcharts.com/highcharts.js"></script>
+	<script src="https://code.highcharts.com/modules/timeline.js"></script>
+	<script src="https://code.highcharts.com/modules/exporting.js"></script>
+	<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+
+<?php } ?>
+
 <?php if ($this->uri->segment(1) == "awards") {
 	// Get Date format
 	if($this->session->userdata('user_date_format')) {

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -82,7 +82,7 @@
 							<a class="dropdown-item" href="<?php echo site_url('contesting?manual=1');?>" title="Post contest QSOs"><i class="fas fa-list"></i> <?php echo lang('menu_post_contest_logging'); ?></a>
 <?php if ($this->optionslib->get_option('dxcache_url') != '') { ?>
 							<div class="dropdown-divider"></div>
-							<a class="dropdown-item" href="<?php echo site_url('bandmap');?>" title="Bandmap"><i class="fa fa-id-card"></i> <?php echo lang('menu_bandmap'); ?></a>
+							<a class="dropdown-item" href="<?php echo site_url('bandmap/index');?>" title="Bandmap"><i class="fa fa-id-card"></i> <?php echo lang('menu_bandmap'); ?></a>
 <?php } ?>
 							<div class="dropdown-divider"></div>
 							<a class="dropdown-item" href="<?php echo site_url('qsl');?>" title="QSL"><i class="fa fa-id-card"></i> <?php echo lang('menu_view_qsl'); ?></a>

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -80,8 +80,10 @@
 							<a class="dropdown-item" href="<?php echo site_url('contesting?manual=0');?>" title="Live contest QSOs"><i class="fas fa-list"></i> <?php echo lang('menu_live_contest_logging'); ?></a>
 							<div class="dropdown-divider"></div>
 							<a class="dropdown-item" href="<?php echo site_url('contesting?manual=1');?>" title="Post contest QSOs"><i class="fas fa-list"></i> <?php echo lang('menu_post_contest_logging'); ?></a>
+<?php if ($this->optionslib->get_option('dxcache_url') != '') { ?>
 							<div class="dropdown-divider"></div>
 							<a class="dropdown-item" href="<?php echo site_url('bandmap');?>" title="Bandmap"><i class="fa fa-id-card"></i> <?php echo lang('menu_bandmap'); ?></a>
+<?php } ?>
 							<div class="dropdown-divider"></div>
 							<a class="dropdown-item" href="<?php echo site_url('qsl');?>" title="QSL"><i class="fa fa-id-card"></i> <?php echo lang('menu_view_qsl'); ?></a>
 							<div class="dropdown-divider"></div>

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -81,6 +81,8 @@
 							<div class="dropdown-divider"></div>
 							<a class="dropdown-item" href="<?php echo site_url('contesting?manual=1');?>" title="Post contest QSOs"><i class="fas fa-list"></i> <?php echo lang('menu_post_contest_logging'); ?></a>
 							<div class="dropdown-divider"></div>
+							<a class="dropdown-item" href="<?php echo site_url('bandmap');?>" title="Bandmap"><i class="fa fa-id-card"></i> <?php echo lang('menu_bandmap'); ?></a>
+							<div class="dropdown-divider"></div>
 							<a class="dropdown-item" href="<?php echo site_url('qsl');?>" title="QSL"><i class="fa fa-id-card"></i> <?php echo lang('menu_view_qsl'); ?></a>
 							<div class="dropdown-divider"></div>
 							<a class="dropdown-item" href="<?php echo site_url('eqsl');?>" title="eQSL"><i class="fa fa-id-card"></i> <?php echo lang('menu_view_eqsl'); ?></a>
@@ -179,7 +181,7 @@
 					<div class="dropdown-divider"></div>
 
 					<a class="dropdown-item" href="<?php echo site_url('debug');?>" title="Debug Information"><i class="fas fa-tools"></i> <?php echo lang('menu_debug_information'); ?></a>
-					
+
 				</div>
         	</li>
 			<?php } ?>
@@ -282,8 +284,8 @@ $oqrs_requests = $CI->oqrs_model->oqrs_requests($location_list);
 				<a class="dropdown-item" href="<?php echo site_url('user/logout');?>" title="Logout"><i class="fas fa-sign-out-alt"></i> <?php echo lang('menu_logout'); ?></a>
 			</div>
         </li>
-		
-		<?php 
+
+		<?php
 			// Can add extra menu items by defining them in options. The format is json.
 			// Useful to add extra things in Cloudlog without the need for modifying files. If you add extras, these files will not be overwritten when updating.
 			//
@@ -308,7 +310,7 @@ $oqrs_requests = $CI->oqrs_model->oqrs_requests($location_list);
 			<li class="nav-item dropdown">
 				<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Extras</a>
 				<div class="dropdown-menu" aria-labelledby="navbarDropdown">
-					<?php 
+					<?php
 						foreach(json_decode($this->optionslib->get_option('menuitems')) as $item) {
 							echo '<a class="dropdown-item" href="' . site_url($item->url) . '" title="Gridsquares"><i class="fas '. $item->icon .'"></i> ' . $item->text . '</a>';
 						}
@@ -316,7 +318,7 @@ $oqrs_requests = $CI->oqrs_model->oqrs_requests($location_list);
 				</div>
 			</li>
 		<?php } ?>
-				
+
 		</ul>
 
         <?php } ?>

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -458,3 +458,53 @@ div#station_logbooks_linked_table_paginate {
 .lotw_info_red {
    background-image: linear-gradient(to bottom, #3fb618, red);
 }
+
+
+.highcharts-strong {
+    font-weight: bold;
+}
+
+.highcharts-figure,
+.highcharts-data-table table {
+    min-width: 320px;
+    max-width: 100%;
+    margin: 1em auto;
+	max-height: calc(100vh - 200px) !important;
+	overflow-y: auto;	
+}
+
+.highcharts-data-table table {
+    font-family: Verdana, sans-serif;
+    border-collapse: collapse;
+    border: 1px solid #ebebeb;
+    margin: 10px auto;
+    text-align: center;
+    width: 100%;
+    max-width: 500px;
+}
+
+.highcharts-data-table caption {
+    padding: 1em 0;
+    font-size: 1.2em;
+    color: #555;
+}
+
+.highcharts-data-table th {
+    font-weight: 600;
+    padding: 0.5em;
+}
+
+.highcharts-data-table td,
+.highcharts-data-table th,
+.highcharts-data-table caption {
+    padding: 0.5em;
+}
+
+.highcharts-data-table thead tr,
+.highcharts-data-table tr:nth-child(even) {
+    background: #f8f8f8;
+}
+
+.highcharts-data-table tr:hover {
+    background: #f1f7ff;
+}

--- a/assets/js/leaflet/geocoding.js
+++ b/assets/js/leaflet/geocoding.js
@@ -6,6 +6,9 @@ const degToRad = deg => (deg % 360) * Math.PI / 180;
 const radToDeg = rad => (rad / Math.PI *180) % 360;
 const isValidPoint = (lat, lng) => (lat >= -90 && lat <= 90) && (lng >= -180 && lng <= 180);
 
+var clickmarkers = [];
+var clicklines = [];
+
 function ConvertDDToDMS(lat, lng) {
 	var LatLng = [];
 
@@ -79,6 +82,8 @@ function onMapClick(event) {
 
 	var marker = L.marker([fromCoords[0], fromCoords[1]], {closeOnClick: false, autoClose: false}).addTo(map).bindPopup(homegrid);
 
+	clickmarkers.push(marker);
+
 	var result = bearingDistance(homegrid, locator);
 
 	var distance = Math.round(result.km * 10) / 10 + ' km';
@@ -99,6 +104,9 @@ function onMapClick(event) {
 
 	var marker2 = L.marker([lat, lng], {closeOnClick: false, autoClose: false}).addTo(map);
 
+
+	clickmarkers.push(marker2);
+
 	marker2.bindTooltip(popupmessage);
 
 	const geodesic = L.geodesic(multiplelines, {
@@ -108,6 +116,8 @@ function onMapClick(event) {
 		wrap: false,
 		steps: 100
 	}).addTo(map);
+
+	clicklines.push(geodesic);
 };
 
 const bearingDistance = (from, to) => {

--- a/assets/js/sections/bandmap.js
+++ b/assets/js/sections/bandmap.js
@@ -144,8 +144,8 @@ $(function() {
 				}
 
 
-				function set_chart(band,maxAgeMinutes) {
-					let dxurl = dxcluster_provider + "/spots/" + band + "/" +maxAgeMinutes;
+				function set_chart(band, de, maxAgeMinutes) {
+					let dxurl = dxcluster_provider + "/spots/" + band + "/" +maxAgeMinutes + "/" + de;
 					$.ajax({
 						url: dxurl,
 						cache: false,
@@ -178,11 +178,15 @@ $(function() {
 			$('#menutoggle_i').addClass('fa-arrow-down');
 		}
 	});
-	
-	set_chart($('#band option:selected').val(),30);
+
+	set_chart($('#band option:selected').val(), $('#decontSelect option:selected').val(), 30);
 	setInterval(function () { update_chart($('#band option:selected').val(),30); },60000);
 	$("#band").on("change",function() {
-		set_chart($('#band option:selected').val(),30);
+		set_chart($('#band option:selected').val(), $('#decontSelect option:selected').val(), 30);
+	});
+
+	$("#decontSelect").on("change",function() {
+		set_chart($('#band option:selected').val(), $('#decontSelect option:selected').val(), 30);
 	});
 });
 

--- a/assets/js/sections/bandmap.js
+++ b/assets/js/sections/bandmap.js
@@ -179,14 +179,14 @@ $(function() {
 		}
 	});
 
-	set_chart($('#band option:selected').val(), $('#decontSelect option:selected').val(), 30);
-	setInterval(function () { update_chart($('#band option:selected').val(),30); },60000);
+	set_chart($('#band option:selected').val(), $('#decontSelect option:selected').val(), dxcluster_maxage);
+	setInterval(function () { update_chart($('#band option:selected').val(),dxcluster_maxage); },60000);
 	$("#band").on("change",function() {
-		set_chart($('#band option:selected').val(), $('#decontSelect option:selected').val(), 30);
+		set_chart($('#band option:selected').val(), $('#decontSelect option:selected').val(), dxcluster_maxage);
 	});
 
 	$("#decontSelect").on("change",function() {
-		set_chart($('#band option:selected').val(), $('#decontSelect option:selected').val(), 30);
+		set_chart($('#band option:selected').val(), $('#decontSelect option:selected').val(), dxcluster_maxage);
 	});
 });
 

--- a/assets/js/sections/bandmap.js
+++ b/assets/js/sections/bandmap.js
@@ -73,6 +73,7 @@ $(function() {
 				}
 			},
 			xAxis: {
+				lineColor: color,
 				visible: true,
 				type: 'linear',
 				labels: {

--- a/assets/js/sections/bandmap.js
+++ b/assets/js/sections/bandmap.js
@@ -1,0 +1,166 @@
+$(function() {
+	(function(H) {
+		H.seriesTypes.timeline.prototype.distributeDL = function() {
+			var series = this,
+				dataLabelsOptions = series.options.dataLabels,
+				options,
+				pointDLOptions,
+				newOptions = {},
+				visibilityIndex = 1,
+				j = 2,
+				distance;
+
+			series.points.forEach(function(point, i) {
+				distance = dataLabelsOptions.distance;
+
+				if (point.visible && !point.isNull) {
+					options = point.options;
+					pointDLOptions = point.options.dataLabels;
+
+					if (!series.hasRendered) {
+						point.userDLOptions = H.merge({}, pointDLOptions);
+					}
+
+					/*
+					if (i === j || i === j + 1) {
+						distance = distance * 2.5
+
+						if (i === j + 1) {
+							j += 4
+						}
+					}
+					*/
+					if (i % 6 == 0) { distance = distance * 1; }
+					if (i % 6 == 1) { distance = distance * -1; }
+					if (i % 6 == 2) { distance = distance * 2; }
+					if (i % 6 == 3) { distance = distance * -2; }
+					if (i % 6 == 4) { distance = distance * 3; }
+					if (i % 6 == 5) { distance = distance * -3; }
+
+					newOptions[series.chart.inverted ? 'x' : 'y'] = distance;
+					// newOptions[series.chart.inverted ? 'x' : 'y'] = dataLabelsOptions.alternate && (visibilityIndex % 3 != 0) ?  -distance : distance;
+
+					options.dataLabels = H.merge(newOptions, point.userDLOptions);
+					visibilityIndex++;
+				}
+			});
+		}
+	}(Highcharts));
+
+	var dxcluster_provider = 'https://dxc.jo30.de/dxcache';
+	var bandMapChart;
+	var color = ifDarkModeThemeReturn('white', 'grey');
+
+	function render_chart (band,spot_data) {
+		let chartObject=Highcharts.chart('bandmap', {
+			chart: {
+				type: 'timeline',
+				zoomType: 'x',
+				inverted: true,
+				backgroundColor: getBodyBackground(),
+				height: '800px'
+			},
+			accessibility: {
+				screenReaderSection: {
+					beforeChartFormat: '<h5>{chartTitle}</h5>' +
+						'<div>{typeDescription}</div>' +
+						'<div>{chartSubtitle}</div>' +
+						'<div>{chartLongdesc}</div>' +
+						'<div>{viewTableButton}</div>'
+				},
+				point: {
+					valueDescriptionFormat: '{index}. {point.label}. {point.description}.'
+				}
+			},
+			xAxis: {
+				visible: true,
+				type: 'linear',
+				labels: {
+					style: {
+						color: color,
+					}
+				}
+			},
+			yAxis: {
+				visible: false,
+			},
+			title: {
+				text: band,
+				style: {
+					color: color
+				}
+			},
+			series: [ { data: spot_data } ]
+		});
+		return chartObject;
+	}
+
+				function SortByQrg(a, b){
+					var a = a.frequency;
+					var b = b.frequency;
+					return ((a< b) ? -1 : ((a> b) ? 1 : 0));
+				}
+
+				function reduce_spots(spotobject) {
+					let unique=[];
+					spotobject.forEach((single) => {
+						if (!spotobject.find((item) => ((item.spotted == single.spotted) && (item.frequency == single.frequency) && (Date.parse(item.when)>Date.parse(single.when))))) {
+							unique.push(single);
+						}
+					});
+					return unique;
+				}
+
+				function convert2high(spotobject) {
+					let ret={};
+					ret.name=spotobject.spotted;
+					ret.x=spotobject.frequency;
+					ret.description=spotobject.frequency + " / "+Math.round( (Date.now() - Date.parse(spotobject.when)) / 1000 / 60)+"min. ago";
+					ret.dataLabels={};
+					ret.dataLabels.alternate=true;
+					ret.dataLabels.distance=200;
+					return ret;
+				}
+
+				function update_chart(lowerQrg,upperQrg,maxAgeMinutes) {
+					$.ajax({
+						url: dxcluster_provider + "/spots",
+						cache: false,
+						dataType: "json"
+					}).done(function(dxspots) {
+						spots4chart=[];
+						dxspots.sort(SortByQrg);
+						dxspots=reduce_spots(dxspots);
+						dxspots.forEach((single) => {
+							if ( (single.frequency >= lowerQrg) && (single.frequency <= upperQrg) && (Date.parse(single.when)>(Date.now() - 1000 * 60 * maxAgeMinutes)) ) {
+								spots4chart.push(convert2high(single));
+							}
+						});
+						// console.log(spots4chart);
+						bandMapChart.series[0].setData(spots4chart);
+						bandMapChart.redraw();
+					});
+				}
+
+
+				function set_chart(lowerQrg,upperQrg,maxAgeMinutes) {
+					$.ajax({
+						url: dxcluster_provider + "/spots",
+						cache: false,
+						dataType: "json"
+					}).done(function(dxspots) {
+						spots4chart=[];
+						dxspots.sort(SortByQrg);
+						dxspots=reduce_spots(dxspots);
+						dxspots.forEach((single) => {
+							if ( (single.frequency >= lowerQrg) && (single.frequency <= upperQrg) && (Date.parse(single.when)>(Date.now() - 1000 * 60 * maxAgeMinutes)) ) {
+								spots4chart.push(convert2high(single));
+							}
+						});
+						bandMapChart=render_chart('20m',spots4chart);
+					});
+				}
+
+	set_chart(14000,14350,30);
+	setInterval(function () { update_chart(14000,14350,30); },60000);
+});

--- a/assets/js/sections/bandmap.js
+++ b/assets/js/sections/bandmap.js
@@ -162,6 +162,17 @@ $(function() {
 						bandMapChart=render_chart(band,spots4chart);
 					});
 				}
+	$("#menutoggle").on("click", function() {
+		if ($('.navbar').is(":hidden")) {
+			$('.navbar').show();
+			$('#menutoggle_i').removeClass('fa-arrow-down');
+			$('#menutoggle_i').addClass('fa-arrow-up');
+		} else {
+			$('.navbar').hide();
+			$('#menutoggle_i').removeClass('fa-arrow-up');
+			$('#menutoggle_i').addClass('fa-arrow-down');
+		}
+	});
 
 	set_chart($('#band option:selected').val(),30);
 	setInterval(function () { update_chart($('#band option:selected').val(),30); },60000);

--- a/assets/js/sections/bandmap.js
+++ b/assets/js/sections/bandmap.js
@@ -162,18 +162,23 @@ $(function() {
 						bandMapChart=render_chart(band,spots4chart);
 					});
 				}
+
 	$("#menutoggle").on("click", function() {
 		if ($('.navbar').is(":hidden")) {
 			$('.navbar').show();
+			$('#dxtabs').show();
+			$('#dxtitle').show();
 			$('#menutoggle_i').removeClass('fa-arrow-down');
 			$('#menutoggle_i').addClass('fa-arrow-up');
 		} else {
 			$('.navbar').hide();
+			$('#dxtabs').hide();
+			$('#dxtitle').hide();
 			$('#menutoggle_i').removeClass('fa-arrow-up');
 			$('#menutoggle_i').addClass('fa-arrow-down');
 		}
 	});
-
+	
 	set_chart($('#band option:selected').val(),30);
 	setInterval(function () { update_chart($('#band option:selected').val(),30); },60000);
 	$("#band").on("change",function() {

--- a/assets/js/sections/bandmap.js
+++ b/assets/js/sections/bandmap.js
@@ -147,7 +147,7 @@ $(function() {
 				function set_chart(band,maxAgeMinutes) {
 					let dxurl = dxcluster_provider + "/spots/" + band + "/" +maxAgeMinutes;
 					$.ajax({
-						url: dxurl, 
+						url: dxurl,
 						cache: false,
 						dataType: "json"
 					}).done(function(dxspots) {
@@ -169,3 +169,62 @@ $(function() {
 		set_chart($('#band option:selected').val(),30);
 	});
 });
+
+var updateFromCAT = function() {
+	if($('select.radios option:selected').val() != '0') {
+		radioID = $('select.radios option:selected').val();
+		$.getJSON( "radio/json/" + radioID, function( data ) {
+
+			if (data.error) {
+				if (data.error == 'not_logged_in') {
+					$(".radio_cat_state" ).remove();
+					if($('.radio_login_error').length == 0) {
+						$('.messages').prepend('<div class="alert alert-danger radio_login_error" role="alert"><i class="fas fa-broadcast-tower"></i> You\'re not logged it. Please <a href="'+base_url+'">login</a></div>');
+					}
+				}
+				// Put future Errorhandling here
+			} else {
+				if($('.radio_login_error').length != 0) {
+					$(".radio_login_error" ).remove();
+				}
+				var band = frequencyToBand(data.frequency);
+
+				if (band !== $("#band").val()) {
+					$("#band").val(band);
+					$("#band").trigger("change");
+				}
+
+				var minutes = Math.floor(cat_timeout_interval / 60);
+
+				if(data.updated_minutes_ago > minutes) {
+					$(".radio_cat_state" ).remove();
+					if($('.radio_timeout_error').length == 0) {
+						$('.messages').prepend('<div class="alert alert-danger radio_timeout_error" role="alert"><i class="fas fa-broadcast-tower"></i> Radio connection timed-out: ' + $('select.radios option:selected').text() + ' data is ' + data.updated_minutes_ago + ' minutes old.</div>');
+					} else {
+						$('.radio_timeout_error').html('Radio connection timed-out: ' + $('select.radios option:selected').text() + ' data is ' + data.updated_minutes_ago + ' minutes old.');
+					}
+				} else {
+					$(".radio_timeout_error" ).remove();
+					text = '<i class="fas fa-broadcast-tower"></i><span style="margin-left:10px;"></span><b>TX:</b> '+(Math.round(parseInt(data.frequency)/100)/10000).toFixed(4)+' MHz';
+					if(data.mode != null) {
+						text = text+'<span style="margin-left:10px"></span>'+data.mode;
+					}
+					if(data.power != null && data.power != 0) {
+						text = text+'<span style="margin-left:10px"></span>'+data.power+' W';
+					}
+					if (! $('#radio_cat_state').length) {
+						$('.messages').prepend('<div aria-hidden="true"><div id="radio_cat_state" class="alert alert-success radio_cat_state" role="alert">'+text+'</div></div>');
+					} else {
+						$('#radio_cat_state').html(text);
+					}
+				}
+			}
+		});
+	}
+};
+
+// Update frequency every three second
+setInterval(updateFromCAT, 3000);
+
+// If a radios selected from drop down select radio update.
+$('.radios').change(updateFromCAT);

--- a/assets/js/sections/bandmap.js
+++ b/assets/js/sections/bandmap.js
@@ -173,7 +173,7 @@ $(function() {
 var updateFromCAT = function() {
 	if($('select.radios option:selected').val() != '0') {
 		radioID = $('select.radios option:selected').val();
-		$.getJSON( "radio/json/" + radioID, function( data ) {
+		$.getJSON( base_url + "radio/json/" + radioID, function( data ) {
 
 			if (data.error) {
 				if (data.error == 'not_logged_in') {

--- a/assets/js/sections/bandmap.js
+++ b/assets/js/sections/bandmap.js
@@ -123,6 +123,7 @@ $(function() {
 				}
 
 				function update_chart(band,maxAgeMinutes) {
+					if ((band != '') && (band !== undefined)) {
 					let dxurl = dxcluster_provider + "/spots/" + band + "/" +maxAgeMinutes;
 					$.ajax({
 						url: dxurl,
@@ -141,10 +142,12 @@ $(function() {
 						bandMapChart.series[0].setData(spots4chart);
 						bandMapChart.redraw();
 					});
+					}
 				}
 
 
 				function set_chart(band, de, maxAgeMinutes) {
+					if ((band != '') && (band !== undefined)) {
 					let dxurl = dxcluster_provider + "/spots/" + band + "/" +maxAgeMinutes + "/" + de;
 					$.ajax({
 						url: dxurl,
@@ -161,6 +164,7 @@ $(function() {
 						}
 						bandMapChart=render_chart(band,spots4chart);
 					});
+					}
 				}
 
 	$("#menutoggle").on("click", function() {

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -84,10 +84,14 @@ $(function() {
 	$("#menutoggle").on("click", function() {
 		if ($('.navbar').is(":hidden")) {
 			$('.navbar').show();
+			$('#dxtabs').show();
+			$('#dxtitle').show();
 			$('#menutoggle_i').removeClass('fa-arrow-down');
 			$('#menutoggle_i').addClass('fa-arrow-up');
 		} else {
 			$('.navbar').hide();
+			$('#dxtabs').hide();
+			$('#dxtitle').hide();
 			$('#menutoggle_i').removeClass('fa-arrow-up');
 			$('#menutoggle_i').addClass('fa-arrow-down');
 		}

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -21,7 +21,13 @@ $(function() {
 			if (dxspots.length>0) {
 				dxspots.sort(SortByQrg);
 				dxspots.forEach((single) => {
-					var data = [[ single.when, single.frequency, single.spotted, single.dxcc_spotted.call ]];
+					// var data = [[ single.when_pretty, single.frequency, single.spotted, single.dxcc_spotted.call ]];
+					var data=[];
+					data[0]=[];
+					data[0].push(single.when_pretty);
+					data[0].push(single.frequency);
+					data[0].push((single.worked_call ?'<span class="text-success">' : '')+single.spotted+(single.worked_call ? '</span>' : ''));
+					data[0].push(single.dxcc_spotted.entity);
 					table.rows.add(data).draw();
 					// add to datatable single
 				});
@@ -89,6 +95,7 @@ $(function() {
 	}
 };
 
+$.fn.dataTable.moment(custom_date_format + ' HH:mm');
 // Update frequency every three second
 // setInterval(updateFromCAT, 3000);
 

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -81,6 +81,17 @@ $(function() {
 		fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),30);
 	});
 
+	$("#menutoggle").on("click", function() {
+		if ($('.navbar').is(":hidden")) {
+			$('.navbar').show();
+			$('#menutoggle_i').removeClass('fa-arrow-down');
+			$('#menutoggle_i').addClass('fa-arrow-up');
+		} else {
+			$('.navbar').hide();
+			$('#menutoggle_i').removeClass('fa-arrow-up');
+			$('#menutoggle_i').addClass('fa-arrow-down');
+		}
+	});
 	
 	var updateFromCAT = function() {
 	if($('select.radios option:selected').val() != '0') {

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -15,29 +15,48 @@ $(function() {
 			dataType: "json"
 		}).done(function(dxspots) {
 			var table = $('.spottable').DataTable();
-			table.clear();
 			table.page.len(50);
-			table.order([1, 'asc']);
+			let oldtable=table.data();
+			table.clear();
 			if (dxspots.length>0) {
 				dxspots.sort(SortByQrg);
 				dxspots.forEach((single) => {
-					// var data = [[ single.when_pretty, single.frequency, single.spotted, single.dxcc_spotted.call ]];
 					var data=[];
 					data[0]=[];
 					data[0].push(single.when_pretty);
 					data[0].push(single.frequency);
 					data[0].push((single.worked_call ?'<span class="text-success">' : '')+single.spotted+(single.worked_call ? '</span>' : ''));
 					data[0].push(single.dxcc_spotted.entity);
-					table.rows.add(data).draw();
-					// add to datatable single
+					if (oldtable.length > 0) {
+						let update=false;
+						oldtable.each( function (srow) {
+							if (JSON.stringify(srow) === JSON.stringify(data[0])) {
+								update=true;
+							} 
+						});
+						if (!update) { 	// Sth. Fresh? So highlight
+							table.rows.add(data).draw().nodes().to$().addClass("fresh bg-info"); 
+						} else { 
+							table.rows.add(data).draw(); 
+						}
+					} else {
+						table.rows.add(data).draw();
+					}
 				});
+				setTimeout(function(){	// Remove Highlights within 15sec
+					$(".fresh").removeClass("bg-info");
+				},1000);
 			}
 		});
 	}
 
+	$('.spottable').DataTable().order([1, 'asc']);
+	$('.spottable').DataTable().clear();
 	fill_list($('#band option:selected').val(),30);
 	setInterval(function () { fill_list($('#band option:selected').val(),30); },60000);
 	$("#band").on("change",function() {
+		$('.spottable').DataTable().order([1, 'asc']);
+		$('.spottable').DataTable().clear();
 		fill_list($('#band option:selected').val(),30);
 	});
 

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -50,6 +50,21 @@ $(function() {
 		});
 	}
 
+	function highlight_current_qrg(qrg) {
+		var table=$('.spottable').DataTable();
+		table.rows().every(function() {
+			var d=this.data();
+			var distance=Math.abs(parseInt(d[1])-qrg);
+			if (distance<=20) {
+				distance++;
+				alpha=(.5/distance);
+				this.nodes().to$().css('background-color', 'rgba(0,0,255,' + alpha + ')');
+			} else {
+				this.nodes().to$().css('background-color', '');
+			}
+		});
+	}
+
 	$('.spottable').DataTable().order([1, 'asc']);
 	$('.spottable').DataTable().clear();
 	fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),30);
@@ -70,7 +85,7 @@ $(function() {
 	var updateFromCAT = function() {
 	if($('select.radios option:selected').val() != '0') {
 		radioID = $('select.radios option:selected').val();
-		$.getJSON( "radio/json/" + radioID, function( data ) {
+		$.getJSON( base_url+"radio/json/" + radioID, function( data ) {
 
 			if (data.error) {
 				if (data.error == 'not_logged_in') {
@@ -103,6 +118,7 @@ $(function() {
 				} else {
 					$(".radio_timeout_error" ).remove();
 					text = '<i class="fas fa-broadcast-tower"></i><span style="margin-left:10px;"></span><b>TX:</b> '+(Math.round(parseInt(data.frequency)/100)/10000).toFixed(4)+' MHz';
+					highlight_current_qrg((parseInt(data.frequency)/1000));
 					if(data.mode != null) {
 						text = text+'<span style="margin-left:10px"></span>'+data.mode;
 					}
@@ -122,7 +138,7 @@ $(function() {
 
 $.fn.dataTable.moment(custom_date_format + ' HH:mm');
 // Update frequency every three second
-// setInterval(updateFromCAT, 3000);
+setInterval(updateFromCAT, 3000);
 
 // If a radios selected from drop down select radio update.
 $('.radios').change(updateFromCAT);

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -68,18 +68,18 @@ $(function() {
 
 	$('.spottable').DataTable().order([1, 'asc']);
 	$('.spottable').DataTable().clear();
-	fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),30);
-	setInterval(function () { fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),30); },60000);
+	fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),dxcluster_maxage);
+	setInterval(function () { fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),dxcluster_maxage); },60000);
 
 	$("#decontSelect").on("change",function() {
 		$('.spottable').DataTable().clear();
-		fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),30);
+		fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),dxcluster_maxage);
 	});
 
 	$("#band").on("change",function() {
 		$('.spottable').DataTable().order([1, 'asc']);
 		$('.spottable').DataTable().clear();
-		fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),30);
+		fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),dxcluster_maxage);
 	});
 
 	$("#spottertoggle").on("click", function() {

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -1,0 +1,100 @@
+$(function() {
+
+	function SortByQrg(a, b){
+		var a = a.frequency;
+		var b = b.frequency;
+		return ((a< b) ? -1 : ((a> b) ? 1 : 0));
+	}
+
+
+	function fill_list(band,maxAgeMinutes) {
+		let dxurl = dxcluster_provider + "/spots/" + band + "/" +maxAgeMinutes;
+		$.ajax({
+			url: dxurl,
+			cache: false,
+			dataType: "json"
+		}).done(function(dxspots) {
+			var table = $('.spottable').DataTable();
+			table.clear();
+			table.page.len(50);
+			table.order([1, 'asc']);
+			if (dxspots.length>0) {
+				dxspots.sort(SortByQrg);
+				dxspots.forEach((single) => {
+					var data = [[ single.when, single.frequency, single.spotted, single.dxcc_spotted.call ]];
+					table.rows.add(data).draw();
+					// add to datatable single
+				});
+			}
+		});
+	}
+
+	fill_list($('#band option:selected').val(),30);
+	setInterval(function () { fill_list($('#band option:selected').val(),30); },60000);
+	$("#band").on("change",function() {
+		fill_list($('#band option:selected').val(),30);
+	});
+
+	
+	var updateFromCAT = function() {
+	if($('select.radios option:selected').val() != '0') {
+		radioID = $('select.radios option:selected').val();
+		$.getJSON( "radio/json/" + radioID, function( data ) {
+
+			if (data.error) {
+				if (data.error == 'not_logged_in') {
+					$(".radio_cat_state" ).remove();
+					if($('.radio_login_error').length == 0) {
+						$('.messages').prepend('<div class="alert alert-danger radio_login_error" role="alert"><i class="fas fa-broadcast-tower"></i> You\'re not logged it. Please <a href="'+base_url+'">login</a></div>');
+					}
+				}
+				// Put future Errorhandling here
+			} else {
+				if($('.radio_login_error').length != 0) {
+					$(".radio_login_error" ).remove();
+				}
+				var band = frequencyToBand(data.frequency);
+
+				if (band !== $("#band").val()) {
+					$("#band").val(band);
+					$("#band").trigger("change");
+				}
+
+				var minutes = Math.floor(cat_timeout_interval / 60);
+
+				if(data.updated_minutes_ago > minutes) {
+					$(".radio_cat_state" ).remove();
+					if($('.radio_timeout_error').length == 0) {
+						$('.messages').prepend('<div class="alert alert-danger radio_timeout_error" role="alert"><i class="fas fa-broadcast-tower"></i> Radio connection timed-out: ' + $('select.radios option:selected').text() + ' data is ' + data.updated_minutes_ago + ' minutes old.</div>');
+					} else {
+						$('.radio_timeout_error').html('Radio connection timed-out: ' + $('select.radios option:selected').text() + ' data is ' + data.updated_minutes_ago + ' minutes old.');
+					}
+				} else {
+					$(".radio_timeout_error" ).remove();
+					text = '<i class="fas fa-broadcast-tower"></i><span style="margin-left:10px;"></span><b>TX:</b> '+(Math.round(parseInt(data.frequency)/100)/10000).toFixed(4)+' MHz';
+					if(data.mode != null) {
+						text = text+'<span style="margin-left:10px"></span>'+data.mode;
+					}
+					if(data.power != null && data.power != 0) {
+						text = text+'<span style="margin-left:10px"></span>'+data.power+' W';
+					}
+					if (! $('#radio_cat_state').length) {
+						$('.messages').prepend('<div aria-hidden="true"><div id="radio_cat_state" class="alert alert-success radio_cat_state" role="alert">'+text+'</div></div>');
+					} else {
+						$('#radio_cat_state').html(text);
+					}
+				}
+			}
+		});
+	}
+};
+
+// Update frequency every three second
+// setInterval(updateFromCAT, 3000);
+
+// If a radios selected from drop down select radio update.
+$('.radios').change(updateFromCAT);
+
+});
+
+

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -8,47 +8,52 @@ $(function() {
 
 
 	function fill_list(band,de,maxAgeMinutes) {
-		let dxurl = dxcluster_provider + "/spots/" + band + "/" +maxAgeMinutes + "/" + de;
-		$.ajax({
-			url: dxurl,
-			cache: false,
-			dataType: "json"
-		}).done(function(dxspots) {
-			var table = $('.spottable').DataTable();
-			table.page.len(50);
-			let oldtable=table.data();
-			table.clear();
-			if (dxspots.length>0) {
-				dxspots.sort(SortByQrg);
-				dxspots.forEach((single) => {
-					var data=[];
-					data[0]=[];
-					data[0].push(single.when_pretty);
-					data[0].push(single.frequency + " kHz");
-					data[0].push((single.worked_call ?'<span class="text-success">' : '')+single.spotted+(single.worked_call ? '</span>' : ''));
-					data[0].push(single.dxcc_spotted.entity);
-					data[0].push(single.spotter);
-					if (oldtable.length > 0) {
-						let update=false;
-						oldtable.each( function (srow) {
-							if (JSON.stringify(srow) === JSON.stringify(data[0])) {
-								update=true;
-							} 
-						});
-						if (!update) { 	// Sth. Fresh? So highlight
-							table.rows.add(data).draw().nodes().to$().addClass("fresh bg-info"); 
-						} else { 
-							table.rows.add(data).draw(); 
+		var table = $('.spottable').DataTable();
+		if ((band != '') && (band !== undefined)) {
+			let dxurl = dxcluster_provider + "/spots/" + band + "/" +maxAgeMinutes + "/" + de;
+			$.ajax({
+				url: dxurl,
+				cache: false,
+				dataType: "json"
+			}).done(function(dxspots) {
+				table.page.len(50);
+				let oldtable=table.data();
+				table.clear();
+				if (dxspots.length>0) {
+					dxspots.sort(SortByQrg);
+					dxspots.forEach((single) => {
+						var data=[];
+						data[0]=[];
+						data[0].push(single.when_pretty);
+						data[0].push(single.frequency + " kHz");
+						data[0].push((single.worked_call ?'<span class="text-success">' : '')+single.spotted+(single.worked_call ? '</span>' : ''));
+						data[0].push(single.dxcc_spotted.entity);
+						data[0].push(single.spotter);
+						if (oldtable.length > 0) {
+							let update=false;
+							oldtable.each( function (srow) {
+								if (JSON.stringify(srow) === JSON.stringify(data[0])) {
+									update=true;
+								} 
+							});
+							if (!update) { 	// Sth. Fresh? So highlight
+								table.rows.add(data).draw().nodes().to$().addClass("fresh bg-info"); 
+							} else { 
+								table.rows.add(data).draw(); 
+							}
+						} else {
+							table.rows.add(data).draw();
 						}
-					} else {
-						table.rows.add(data).draw();
-					}
-				});
-				setTimeout(function(){	// Remove Highlights within 15sec
-					$(".fresh").removeClass("bg-info");
-				},1000);
-			}
-		});
+					});
+					setTimeout(function(){	// Remove Highlights within 15sec
+						$(".fresh").removeClass("bg-info");
+					},1000);
+				}
+			});
+		} else {
+			table.clear();
+			table.draw();
+		}
 	}
 
 	function highlight_current_qrg(qrg) {

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -7,8 +7,8 @@ $(function() {
 	}
 
 
-	function fill_list(band,maxAgeMinutes) {
-		let dxurl = dxcluster_provider + "/spots/" + band + "/" +maxAgeMinutes;
+	function fill_list(band,de,maxAgeMinutes) {
+		let dxurl = dxcluster_provider + "/spots/" + band + "/" +maxAgeMinutes + "/" + de;
 		$.ajax({
 			url: dxurl,
 			cache: false,
@@ -52,12 +52,18 @@ $(function() {
 
 	$('.spottable').DataTable().order([1, 'asc']);
 	$('.spottable').DataTable().clear();
-	fill_list($('#band option:selected').val(),30);
-	setInterval(function () { fill_list($('#band option:selected').val(),30); },60000);
+	fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),30);
+	setInterval(function () { fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),30); },60000);
+
+	$("#decontSelect").on("change",function() {
+		$('.spottable').DataTable().clear();
+		fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),30);
+	});
+
 	$("#band").on("change",function() {
 		$('.spottable').DataTable().order([1, 'asc']);
 		$('.spottable').DataTable().clear();
-		fill_list($('#band option:selected').val(),30);
+		fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),30);
 	});
 
 	

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -24,9 +24,10 @@ $(function() {
 					var data=[];
 					data[0]=[];
 					data[0].push(single.when_pretty);
-					data[0].push(single.frequency);
+					data[0].push(single.frequency + " kHz");
 					data[0].push((single.worked_call ?'<span class="text-success">' : '')+single.spotted+(single.worked_call ? '</span>' : ''));
 					data[0].push(single.dxcc_spotted.entity);
+					data[0].push(single.spotter);
 					if (oldtable.length > 0) {
 						let update=false;
 						oldtable.each( function (srow) {
@@ -54,7 +55,7 @@ $(function() {
 		var table=$('.spottable').DataTable();
 		table.rows().every(function() {
 			var d=this.data();
-			var distance=Math.abs(parseInt(d[1])-qrg);
+			var distance=Math.abs(parseInt(d[1].substring(0,d[1].length-4))-qrg);
 			if (distance<=20) {
 				distance++;
 				alpha=(.5/distance);
@@ -133,7 +134,7 @@ $(function() {
 				} else {
 					$(".radio_timeout_error" ).remove();
 					text = '<i class="fas fa-broadcast-tower"></i><span style="margin-left:10px;"></span><b>TX:</b> '+(Math.round(parseInt(data.frequency)/100)/10000).toFixed(4)+' MHz';
-					highlight_current_qrg((parseInt(data.frequency)/1000));
+					highlight_current_qrg((parseInt(data.frequency))/1000);
 					if(data.mode != null) {
 						text = text+'<span style="margin-left:10px"></span>'+data.mode;
 					}

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -82,6 +82,14 @@ $(function() {
 		fill_list($('#band option:selected').val(), $('#decontSelect option:selected').val(),30);
 	});
 
+	$("#spottertoggle").on("click", function() {
+		if ($('.spottable').DataTable().column(4).visible()) {
+			$('.spottable').DataTable().column(4).visible(false);
+		} else {
+			$('.spottable').DataTable().column(4).visible(true);
+		}
+	});
+
 	$("#menutoggle").on("click", function() {
 		if ($('.navbar').is(":hidden")) {
 			$('.navbar').show();

--- a/assets/js/sections/gridmap.js
+++ b/assets/js/sections/gridmap.js
@@ -16,8 +16,8 @@ var grid_four_confirmed = '';
 var grid_six_confirmed = '';
 
 function gridPlot(form) {
-    $(".ld-ext-right").addClass('running');
-	$(".ld-ext-right").prop('disabled', true);
+    $(".ld-ext-right-plot").addClass('running');
+	$(".ld-ext-right-plot").prop('disabled', true);
     $('#plot').prop("disabled", true);
     // If map is already initialized
     var container = L.DomUtil.get('gridsquare_map');
@@ -41,8 +41,8 @@ function gridPlot(form) {
 		},
 		success: function (data) {
             $('.cohidden').show();
-            $(".ld-ext-right").removeClass('running');
-            $(".ld-ext-right").prop('disabled', false);
+            $(".ld-ext-right-plot").removeClass('running');
+            $(".ld-ext-right-plot").prop('disabled', false);
             $('#plot').prop("disabled", false);
 			grid_two = data.grid_2char;
             grid_four = data.grid_4char;
@@ -146,6 +146,19 @@ function spawnGridsquareModal(loc_4char) {
             });
         }
     });
+}
+
+function clearMarkers() {
+	$(".ld-ext-right-clear").addClass('running');
+	$(".ld-ext-right-clear").prop('disabled', true);
+	clicklines.forEach(function (item) {
+		map.removeLayer(item)
+	});
+	clickmarkers.forEach(function (item) {
+		map.removeLayer(item)
+	});
+	$(".ld-ext-right-clear").removeClass('running');
+	$(".ld-ext-right-clear").prop('disabled', false);
 }
 
 $(document).ready(function(){

--- a/src/Dxcc/Dxcc.php
+++ b/src/Dxcc/Dxcc.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Cloudlog\Dxcc;
+
+class Dxcc {
+	protected $dxcc = array();
+	protected $dxccexceptions = array();
+
+	function __construct($date)
+	{
+		$this->read_data($date);
+	}
+
+	public function dxcc_lookup($call, $date) {
+
+		$csadditions = '/^P$|^R$|^A$|^M$/';
+		$CI =& get_instance();
+
+		if (array_key_exists($call, $this->dxccexceptions)) {
+			return $this->dxccexceptions[$call];
+        } else {
+
+			if (preg_match('/(^KG4)[A-Z09]{3}/', $call)) {       // KG4/ and KG4 5 char calls are Guantanamo Bay. If 4 or 6 char, it is USA
+				$call = "K";
+			} elseif (preg_match('/(^OH\/)|(\/OH[1-9]?$)/', $call)) {   # non-Aland prefix!
+				$call = "OH";                                             # make callsign OH = finland
+			} elseif (preg_match('/(^CX\/)|(\/CX[1-9]?$)/', $call)) {   # non-Antarctica prefix!
+				$call = "CX";                                             # make callsign CX = Uruguay
+			} elseif (preg_match('/(^3D2R)|(^3D2.+\/R)/', $call)) {     # seems to be from Rotuma
+				$call = "3D2/R";                                          # will match with Rotuma
+			} elseif (preg_match('/^3D2C/', $call)) {                   # seems to be from Conway Reef
+				$call = "3D2/C";                                          # will match with Conway
+			} elseif (preg_match('/(^LZ\/)|(\/LZ[1-9]?$)/', $call)) {   # LZ/ is LZ0 by DXCC but this is VP8h
+				$call = "LZ";
+			} elseif (preg_match('/(^KG4)[A-Z09]{2}/', $call)) {
+				$call = "KG4";
+			} elseif (preg_match('/(^KG4)[A-Z09]{1}/', $call)) {
+				$call = "K";
+			} elseif (preg_match('/\w\/\w/', $call)) {
+				if (preg_match_all('/^((\d|[A-Z])+\/)?((\d|[A-Z]){3,})(\/(\d|[A-Z])+)?(\/(\d|[A-Z])+)?$/', $call, $matches)) {
+					$prefix = $matches[1][0];
+					$callsign = $matches[3][0];
+					$suffix = $matches[5][0];
+					if ($prefix) {
+						$prefix = substr($prefix, 0, -1); # Remove the / at the end
+					}
+					if ($suffix) {
+						$suffix = substr($suffix, 1); # Remove the / at the beginning
+					};
+					if (preg_match($csadditions, $suffix)) {
+						if ($prefix) {
+							$call = $prefix;
+						} else {
+							$call = $callsign;
+						}
+					} else {
+						$result = $this->wpx($call, 1);                       # use the wpx prefix instead
+						if ($result == '') {
+							$row['adif'] = 0;
+							$row['entity'] = '- NONE -';
+							$row['cqz'] = 0;
+							$row['long'] = '0';
+							$row['lat'] = '0';
+							return $row;
+						} else {
+							$call = $result . "AA";
+						}
+					}
+				}
+			}
+
+			$len = strlen($call);
+
+			// query the table, removing a character from the right until a match
+			for ($i = $len; $i > 0; $i--){
+				$result = '';
+
+				if (array_key_exists(substr($call, 0, $i), $this->dxcc)) {
+					return $this->dxcc[substr($call, 0, $i)];
+				}
+			}
+		}
+
+		return array("Not Found", "Not Found");
+	}
+
+	function wpx($testcall, $i) {
+		$prefix = '';
+		$a = '';
+		$b = '';
+		$c = '';
+
+		$lidadditions = '/^QRP$|^LGT$/';
+		$csadditions = '/^P$|^R$|^A$|^M$|^LH$/';
+		$noneadditions = '/^MM$|^AM$/';
+
+		# First check if the call is in the proper format, A/B/C where A and C
+		# are optional (prefix of guest country and P, MM, AM etc) and B is the
+		# callsign. Only letters, figures and "/" is accepted, no further check if the
+		# callsign "makes sense".
+		# 23.Apr.06: Added another "/X" to the regex, for calls like RV0AL/0/P
+		# as used by RDA-DXpeditions....
+
+		if (preg_match_all('/^((\d|[A-Z])+\/)?((\d|[A-Z]){3,})(\/(\d|[A-Z])+)?(\/(\d|[A-Z])+)?$/', $testcall, $matches)) {
+
+			# Now $1 holds A (incl /), $3 holds the callsign B and $5 has C
+			# We save them to $a, $b and $c respectively to ensure they won't get
+			# lost in further Regex evaluations.
+			$a = $matches[1][0];
+			$b = $matches[3][0];
+			$c = $matches[5][0];
+
+			if ($a) {
+				$a = substr($a, 0, -1); # Remove the / at the end
+			}
+			if ($c) {
+				$c = substr($c, 1); # Remove the / at the beginning
+			};
+
+			# In some cases when there is no part A but B and C, and C is longer than 2
+			# letters, it happens that $a and $b get the values that $b and $c should
+			# have. This often happens with liddish callsign-additions like /QRP and
+			# /LGT, but also with calls like DJ1YFK/KP5. ~/.yfklog has a line called
+			# "lidadditions", which has QRP and LGT as defaults. This sorts out half of
+			# the problem, but not calls like DJ1YFK/KH5. This is tested in a second
+			# try: $a looks like a call (.\d[A-Z]) and $b doesn't (.\d), they are
+			# swapped. This still does not properly handle calls like DJ1YFK/KH7K where
+			# only the OP's experience says that it's DJ1YFK on KH7K.
+			if (!$c && $a && $b) {                          # $a and $b exist, no $c
+				if (preg_match($lidadditions, $b)) {        # check if $b is a lid-addition
+					$b = $a;
+					$a = null;                              # $a goes to $b, delete lid-add
+				} elseif ((preg_match('/\d[A-Z]+$/', $a)) && (preg_match('/\d$/', $b))) {   # check for call in $a
+					$temp = $b;
+					$b = $a;
+					$a = $temp;
+				}
+			}
+
+			# *** Added later ***  The check didn't make sure that the callsign
+			# contains a letter. there are letter-only callsigns like RAEM, but not
+			# figure-only calls.
+
+			if (preg_match('/^[0-9]+$/', $b)) {            # Callsign only consists of numbers. Bad!
+				return null;            # exit, undef
+			}
+
+			# Depending on these values we have to determine the prefix.
+			# Following cases are possible:
+			#
+			# 1.    $a and $c undef --> only callsign, subcases
+			# 1.1   $b contains a number -> everything from start to number
+			# 1.2   $b contains no number -> first two letters plus 0
+			# 2.    $a undef, subcases:
+			# 2.1   $c is only a number -> $a with changed number
+			# 2.2   $c is /P,/M,/MM,/AM -> 1.
+			# 2.3   $c is something else and will be interpreted as a Prefix
+			# 3.    $a is defined, will be taken as PFX, regardless of $c
+
+			if (($a == null) && ($c == null)) {                     # Case 1
+				if (preg_match('/\d/', $b)) {                       # Case 1.1, contains number
+					preg_match('/(.+\d)[A-Z]*/', $b, $matches);     # Prefix is all but the last
+					$prefix = $matches[1];                          # Letters
+				} else {                                            # Case 1.2, no number
+					$prefix = substr($b, 0, 2) . "0";               # first two + 0
+				}
+			} elseif (($a == null) && (isset($c))) {                # Case 2, CALL/X
+				if (preg_match('/^(\d)/', $c)) {                    # Case 2.1, number
+					preg_match('/(.+\d)[A-Z]*/', $b, $matches);     # regular Prefix in $1
+					# Here we need to find out how many digits there are in the
+					# prefix, because for example A45XR/0 is A40. If there are 2
+					# numbers, the first is not deleted. If course in exotic cases
+					# like N66A/7 -> N7 this brings the wrong result of N67, but I
+					# think that's rather irrelevant cos such calls rarely appear
+					# and if they do, it's very unlikely for them to have a number
+					# attached.   You can still edit it by hand anyway..
+					if (preg_match('/^([A-Z]\d)\d$/', $matches[1])) {        # e.g. A45   $c = 0
+						$prefix = $matches[1] . $c;  # ->   A40
+					} else {                         # Otherwise cut all numbers
+						preg_match('/(.*[A-Z])\d+/', $matches[1], $match); # Prefix w/o number in $1
+						$prefix = $match[1] . $c; # Add attached number
+					}
+				} elseif (preg_match($csadditions, $c)) {
+					preg_match('/(.+\d)[A-Z]*/', $b, $matches);     # Known attachment -> like Case 1.1
+					$prefix = $matches[1];
+				} elseif (preg_match($noneadditions, $c)) {
+					return '';
+				} elseif (preg_match('/^\d\d+$/', $c)) {            # more than 2 numbers -> ignore
+					preg_match('/(.+\d)[A-Z]* /', $b, $matches);    # see above
+					$prefix = $matches[1][0];
+				} else {                                            # Must be a Prefix!
+					if (preg_match('/\d$/', $c)) {                  # ends in number -> good prefix
+						$prefix = $c;
+					} else {                                        # Add Zero at the end
+						$prefix = $c . "0";
+					}
+				}
+			} elseif (($a) && (preg_match($noneadditions, $c))) {                # Case 2.1, X/CALL/X ie TF/DL2NWK/MM - DXCC none
+			return '';
+			} elseif ($a) {
+				# $a contains the prefix we want
+				if (preg_match('/\d$/', $a)) {                      # ends in number -> good prefix
+					$prefix = $a;
+				} else {                                            # add zero if no number
+					$prefix = $a . "0";
+				}
+			}
+			# In very rare cases (right now I can only think of KH5K and KH7K and FRxG/T
+			# etc), the prefix is wrong, for example KH5K/DJ1YFK would be KH5K0. In this
+			# case, the superfluous part will be cropped. Since this, however, changes the
+			# DXCC of the prefix, this will NOT happen when invoked from with an
+			# extra parameter $_[1]; this will happen when invoking it from &dxcc.
+
+			if (preg_match('/(\w+\d)[A-Z]+\d/', $prefix, $matches) && $i == null) {
+				$prefix = $matches[1][0];
+			}
+			return $prefix;
+		} else {
+			return '';
+		}
+	}
+
+	  /*
+    * Read cty.dat from AD1C
+    */
+    function read_data($date) {
+		$CI =& get_instance();
+		$dxcc_exceptions = $CI->db->select('`entity`, `adif`, `cqz`, `start`, `end`, `call`, `cont`, `long`, `lat`')
+		->where('(start <= ', $date)
+		->or_where('start is null)', NULL, false)
+		->where('(end >= ', $date)
+		->or_where('end is null)', NULL, false)
+		->get('dxcc_exceptions');
+
+		if ($dxcc_exceptions->num_rows() > 0){
+			foreach ($dxcc_exceptions->result() as $dxcce) {
+				$this->dxccexceptions[$dxcce->call]['adif'] = $dxcce->adif;
+				$this->dxccexceptions[$dxcce->call]['cont'] = $dxcce->cont;
+				$this->dxccexceptions[$dxcce->call]['entity'] = $dxcce->entity;
+				$this->dxccexceptions[$dxcce->call]['cqz'] = $dxcce->cqz;
+				$this->dxccexceptions[$dxcce->call]['start'] = $dxcce->start;
+				$this->dxccexceptions[$dxcce->call]['end'] = $dxcce->end;
+				$this->dxccexceptions[$dxcce->call]['long'] = $dxcce->long;
+				$this->dxccexceptions[$dxcce->call]['lat'] = $dxcce->lat;
+			}
+		}
+
+		$dxcc_result = $CI->db->select('*')
+		->where('(start <= ', $date)
+		->or_where("start is null)", NULL, false)
+		->where('(end >= ', $date)
+		->or_where("end is null)", NULL, false)
+		->get('dxcc_prefixes');
+
+		if ($dxcc_result->num_rows() > 0){
+			foreach ($dxcc_result->result() as $dx) {
+				$this->dxcc[$dx->call]['adif'] = $dx->adif;
+				$this->dxcc[$dx->call]['cont'] = $dx->cont;
+				$this->dxcc[$dx->call]['entity'] = $dx->entity;
+				$this->dxcc[$dx->call]['cqz'] = $dx->cqz;
+				$this->dxcc[$dx->call]['start'] = $dx->start;
+				$this->dxcc[$dx->call]['end'] = $dx->end;
+				$this->dxcc[$dx->call]['long'] = $dx->long;
+				$this->dxcc[$dx->call]['lat'] = $dx->lat;
+			}
+		}
+
+    }
+
+}


### PR DESCRIPTION
# Integrated DXCluster into Cloudlog

New feature can be activated by going (as admin) to Admin -> Global Options -> DXCluster
Once this is filled (and saved) a new item called "Bandmap" appears at "QSO".

Default View is a graphical one, but you can also switch to "DXList".

## Features:
### General:
* DXCluster will be refreshed every minute.
* You can collapse the Menus, if your screen is too small (i prefer a 2nd Screen, where the List is shown)
* if a station is spotted twice or more, only the "youngest" spot will be shown
* if CAT is enabled and used, the view switches automagically to the Band your TRX is at.
* Old spots (see Admin-Settings) will disappear, when they're out of the timewindow

### List-View:
* New spots appear highlighted (fading out after a little time)
* If CAT is enabled/used, the QRG where your TRX stands, will also be highlighted
* Calls you already worked appear green
* List is sortable and searchable


## Technically:
* Cloudlog acts as proxy between the DXCluster-API Cache and the user. It enriches the data with "already worked" and some more information
* The small magnifier glass at "add QSO" is also based on the same controller. So no direct DXCluster-API Access via the browser is nescessary
* The whole logic will also work if the DXCluster-API doesn't provide DXCC-Informations (but a bit slower)
* To use your own DXCluster-API follow this: https://github.com/int2001/DXClusterAPI/tree/dxcc_gearman

Thanks a lot for all Feedback given from Users at Socialmedia and from local Hamgroup. Special thanks to @AndreasK79   for developing and help.
It's the first version, so please be kind. Constructive feedback is more than welcome :)

PS: A lot of tests have been done here. But please doublecheck, since there are a lot of changes, @magicbug 