### PR TITLE
Reset LoTW upload for LEDSAT

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 130;
+$config['migration_version'] = 131;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/migrations/131_reset_lotw_upload_for_ledsat.php
+++ b/application/migrations/131_reset_lotw_upload_for_ledsat.php
@@ -1,0 +1,17 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_reset_lotw_upload_for_ledsat extends CI_Migration
+{
+	public function up()
+	{
+        $this->db->set('COL_LOTW_QSL_SENT', 'N');
+        $this->db->where('COL_SAT_NAME', 'LEDSAT');
+        $this->db->update($this->config->item('table_name'));
+	}
+
+	public function down()
+	{
+        // Not Possible
+	}
+}


### PR DESCRIPTION
New tqsl config accepts LEDSAT asnew satellite. so we need to reset LoTW uploadsfor this bird to make sure these QSOs get re-uploaded.