### PR TITLE
Fixed Submode/Mode issue when checking if worked

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -222,7 +222,7 @@ class Logbook extends CI_Controller {
 			if($type == "SAT") {
 				$this->db->where('COL_PROP_MODE', 'SAT');
 			} else {
-				$this->db->where('COL_MODE', $mode);
+				$this->db->where('COL_MODE', $this->logbook_model->get_main_mode_from_mode($mode));
 				$this->db->where('COL_BAND', $band);
 				$this->db->where('COL_PROP_MODE !=','SAT');
 
@@ -263,7 +263,7 @@ class Logbook extends CI_Controller {
 		if($type == "SAT") {
 			$this->db->where('COL_PROP_MODE', 'SAT');
 		} else {
-			$this->db->where('COL_MODE', $mode);
+			$this->db->where('COL_MODE', $this->logbook_model->get_main_mode_from_mode($mode));
 			$this->db->where('COL_BAND', $band);
 			$this->db->where('COL_PROP_MODE !=','SAT');
 
@@ -293,12 +293,13 @@ class Logbook extends CI_Controller {
 		$CI =& get_instance();
         $CI->load->model('logbooks_model');
         $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+	$CI->load->model('logbook_model');
 
 		if(!empty($logbooks_locations_array)) { 
 			if($type == "SAT") {
 				$this->db->where('COL_PROP_MODE', 'SAT');
 			} else {
-				$this->db->where('COL_MODE', $mode);
+				$this->db->where('COL_MODE', $this->logbook_model->get_main_mode_from_mode($mode));
 				$this->db->where('COL_BAND', $band);
 				$this->db->where('COL_PROP_MODE !=','SAT');
 
@@ -338,12 +339,13 @@ class Logbook extends CI_Controller {
 		$CI =& get_instance();
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+		$CI->load->model('logbook_model');
 
 		if(!empty($logbooks_locations_array)) { 
 			if($type == "SAT") {
 				$this->db->where('COL_PROP_MODE', 'SAT');
 			} else {
-				$this->db->where('COL_MODE', $mode);
+				$this->db->where('COL_MODE', $this->logbook_model->get_main_mode_from_mode($mode));
 				$this->db->where('COL_BAND', $band);
 				$this->db->where('COL_PROP_MODE !=','SAT');
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3313,6 +3313,10 @@ class Logbook_model extends CI_Model {
         return $my_error;
     }
 
+    function get_main_mode_from_mode($mode) {
+	return ($this->get_main_mode_if_submode($mode) == null ? $mode : $this->get_main_mode_if_submode($mode));
+    }
+
     function get_main_mode_if_submode($mode) {
 		$this->db->select('mode');
         $this->db->where('submode', $mode);


### PR DESCRIPTION
Old Behaviour:

Consider II1WRTC worked on 20m with logged Mode "USB"

When trying to log him again, DXCC, Grid and Call is shown red (Never worked). This results in comparing the Submode (USB) to the Database (which holds only the Mainmode - in this case "SSB")

New behaviour:
Mode is always converted to mainmode before checking. if it already is mainmode - no problem.
So in the above case II1WRTC with grid and dxcc will be shown as "worked" when Mode ist "USB", "LSB" or "SSB".