### PR TITLE
Fixed handling of empty continent of spotter

### DIFF
--- a/application/models/Dxcluster_model.php
+++ b/application/models/Dxcluster_model.php
@@ -57,7 +57,7 @@ class Dxcluster_model extends CI_Model {
 					    	$singlespot->dxcc_spotter=$dxcc;
 					    }
 					    if ( ($de != '') && ($de != 'Any') && (property_exists($singlespot->dxcc_spotter,'cont')) ){	// If we have a "de continent" and a filter-wish filter on that
-						    if (strtolower($de) == strtolower($singlespot->dxcc_spotter->cont)) {
+						    if (strtolower($de) == strtolower($singlespot->dxcc_spotter->cont ?? '')) {
 							    $singlespot->worked_call = ($this->logbook_model->check_if_callsign_worked_in_logbook($singlespot->spotted, $logbooks_locations_array, $singlespot->band) == 1);
 							    array_push($spotsout,$singlespot);
 						    }


### PR DESCRIPTION
at very rare circumstances the dxcc_spotter-Object exists, but the "cont" field is null/empty.
This _can_ cause problems with PHP 8.1.2 (at PHP 8.2 no problem - strange).

So fixed this.