### PR TITLE
Split SAT mode in (adv) logbook and QSO view

### DIFF
--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -197,7 +197,7 @@
                     <?php if($row->COL_SAT_MODE != null) { ?>
                     <tr>
                         <td><?php echo lang('gen_hamradio_satellite_mode'); ?></td>
-                        <td><?php echo $row->COL_SAT_MODE; ?></td>
+                        <td><?php echo (strlen($row->COL_SAT_MODE) == 2 ? (strtoupper($row->COL_SAT_MODE[0]).'/'.strtoupper($row->COL_SAT_MODE[1])) : strtoupper($row->COL_SAT_MODE)); ?></td>
                     </tr>
                     <?php } ?>
                     <?php if($row->name != null) { ?>

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -150,7 +150,7 @@ class QSO
 		$this->rstR = $data['COL_RST_RCVD'];
 		$this->rstS = $data['COL_RST_SENT'];
 		$this->propagationMode = $data['COL_PROP_MODE'] ?? '';
-		$this->satelliteMode = $data['COL_SAT_MODE'] ?? '';
+		$this->satelliteMode = $data['COL_SAT_MODE'] != '' ? (strlen($data['COL_SAT_MODE']) == 2 ? (strtoupper($data['COL_SAT_MODE'][0]).'/'.strtoupper($data['COL_SAT_MODE'][1])) : strtoupper($data['COL_SAT_MODE'])) : '';
 		$this->satelliteName = $data['COL_SAT_NAME'] ?? '';
 
 		$this->name = $data['COL_NAME'] ?? '';


### PR DESCRIPTION
If SAT mode is stored with only 2 chars (e.g. "UV") display it with slash (i.e. "U/V") just like in the SAT input box during logging.