### PR TITLE
Added Menu for maintenance

### DIFF
--- a/application/controllers/Backup.php
+++ b/application/controllers/Backup.php
@@ -10,7 +10,7 @@ class Backup extends CI_Controller {
 	public function index()
 	{
 		$this->load->model('user_model');
-		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
 
 		$data['page_title'] = "Backup";
 
@@ -23,7 +23,7 @@ class Backup extends CI_Controller {
 	public function adif($key = null){ 
 		if ($key == null) {
 			$this->load->model('user_model');
-			if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+			if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
 		}
 
 		$this->load->helper('file');
@@ -58,7 +58,7 @@ class Backup extends CI_Controller {
 	public function notes($key = null) {
 		if ($key == null) {
 			$this->load->model('user_model');
-			if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+			if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
 		}
 
 		$this->load->helper('file');

--- a/application/controllers/Maintenance.php
+++ b/application/controllers/Maintenance.php
@@ -1,0 +1,56 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class Maintenance extends CI_Controller {
+	function __construct()
+	{
+		parent::__construct();
+	}
+	
+	/* User Facing Links to Maintenance URLs */
+	public function index() {
+		$this->load->model('user_model');
+		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+		$this->load->model('Logbook_model');
+		$this->load->model('Stations');
+		$data['stations']=$this->Stations->all();
+		$data['page_title'] = "Maintenance";
+		$data['is_there_qsos_with_no_station_id'] = $this->Logbook_model->check_for_station_id();
+		if ($data['is_there_qsos_with_no_station_id']) {
+			$data['calls_wo_sid']=$this->Logbook_model->calls_without_station_id();
+		}
+		$this->load->view('interface_assets/header', $data);
+		$this->load->view('maintenance/main');
+		$this->load->view('interface_assets/footer');
+	}
+
+	public function reassign() {
+		$this->load->model('user_model');
+		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+		$this->load->model('Logbook_model');
+		$this->load->model('Stations');
+		$call = xss_clean(($this->input->post('call')));
+		$station_profile_id = xss_clean(($this->input->post('station_id')));
+
+		// Check if target-station-id exists
+		$allowed=false;
+		$status=false;
+		$stations=$this->Stations->all();
+		foreach ($stations->result() as $station) {
+			if ($station->station_id == $station_profile_id) { $allowed=true; }
+		}
+		if ($allowed) {
+			log_message("error",$call." to ".$station_profile_id);
+			$status=$this->Logbook_model->update_all_station_ids($station_profile_id,$call);
+		} else {
+			$status=false;
+		}
+
+		header('Content-Type: application/json');
+		echo json_encode(array('status' => $status));
+		return;
+
+	}
+
+}
+
+/* End of file Backup.php */

--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -19,6 +19,9 @@ class Station extends CI_Controller {
 	{
 		$this->load->model('stations');
 		$this->load->model('Logbook_model');
+		$this->load->model('user_model');
+
+		$data['is_admin'] = ($this->user_model->authorize(99));
 
 		$data['stations'] = $this->stations->all_with_count();
 		$data['current_active'] = $this->stations->find_active();
@@ -156,13 +159,6 @@ class Station extends CI_Controller {
 		redirect('station');
 	}
 
-	function assign_all() {
-		$this->load->model('Logbook_model');
-		$this->Logbook_model->update_all_station_ids();
-
-		redirect('station');
-	}
-
 	public function delete($id) {
 		$this->load->model('stations');
 		if ($this->stations->check_station_is_accessible($id)) {
@@ -171,7 +167,7 @@ class Station extends CI_Controller {
 		redirect('station');
 	}
 
-    public function deletelog($id) {
+    	public function deletelog($id) {
         $this->load->model('stations');
 	if ($this->stations->check_station_is_accessible($id)) {
         	$this->stations->deletelog($id);

--- a/application/language/english/menu_lang.php
+++ b/application/language/english/menu_lang.php
@@ -83,3 +83,5 @@ $lang['menu_hardware_interfaces'] = 'Hardware Interfaces';
 $lang['menu_help'] = 'Help';
 $lang['menu_forum'] = 'Forum';
 $lang['menu_logout'] = 'Logout';
+
+$lang['menu_maintenance']='Maintenance';

--- a/application/language/german/menu_lang.php
+++ b/application/language/german/menu_lang.php
@@ -83,3 +83,5 @@ $lang['menu_hardware_interfaces'] = 'Hardware-Schnittstellen';
 $lang['menu_help'] = 'Hilfe';
 $lang['menu_forum'] = 'Forum';
 $lang['menu_logout'] = 'Logout';
+
+$lang['menu_maintenance'] = 'Wartung';

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3850,6 +3850,12 @@ class Logbook_model extends CI_Model {
         $this->db->trans_complete();
     }
 
+    public function calls_without_station_id() {
+		$query=$this->db->query("select distinct COL_STATION_CALLSIGN from ".$this->config->item('table_name')." where station_id is null or station_id = ''");
+	    $result = $query->result_array();
+	    return $result;
+    }
+
     public function check_for_station_id() {
       $this->db->where('station_id =', NULL);
       $query = $this->db->get($this->config->item('table_name'));
@@ -3909,14 +3915,20 @@ class Logbook_model extends CI_Model {
         }
     }
 
-    public function update_all_station_ids() {
+    public function update_all_station_ids($station_id,$station_callsign) {
 
-      $data = array(
-        'station_id' => '1',
-      );
+	    $data = array(
+		    'station_id' => $station_id,
+	    );
 
-      $this->db->where(array('station_id' => NULL));
-      return $this->db->update($this->config->item('table_name'), $data);
+	    $this->db->where(array('station_id' => NULL));
+	    $this->db->where('col_station_callsign', $station_callsign);
+	    $this->db->update($this->config->item('table_name'), $data);
+	    if ($this->db->affected_rows() > 0) {
+		    return TRUE;
+	    } else {
+		    return FALSE;
+	    }
     }
 
     public function parse_frequency($frequency)

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -77,6 +77,10 @@ function load_was_map() {
     <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/tempusdominus-bootstrap-4.min.js"></script>
 <?php } ?>
 
+<?php if ($this->uri->segment(1) == "maintenance" ) { ?>
+    <script src="<?php echo base_url() ;?>assets/js/sections/maintenance.js"></script>
+<?php } ?>
+
 <?php if ($this->uri->segment(1) == "adif" ) { ?>
     <script src="<?php echo base_url() ;?>assets/js/sections/adif.js"></script>
 <?php } ?>

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -182,6 +182,10 @@
 
 					<div class="dropdown-divider"></div>
 
+					<a class="dropdown-item" href="<?php echo site_url('maintenance');?>" title="maintenance"><i class="fas fa-tools"></i> <?php echo lang('menu_maintenance'); ?></a>
+
+					<div class="dropdown-divider"></div>
+
 					<a class="dropdown-item" href="<?php echo site_url('debug');?>" title="Debug Information"><i class="fas fa-tools"></i> <?php echo lang('menu_debug_information'); ?></a>
 
 				</div>

--- a/application/views/maintenance/main.php
+++ b/application/views/maintenance/main.php
@@ -1,0 +1,57 @@
+<div class="container">
+<br>
+	<?php if($this->session->flashdata('message')) { ?>
+		<!-- Display Message -->
+		<div class="alert-message error">
+		  <p><?php echo $this->session->flashdata('message'); ?></p>
+		</div>
+	<?php } ?>
+
+<h2><?php echo $page_title; ?></h2>
+
+<div class="card">
+  <div class="card-header">
+    Maintenance
+  </div>
+<?php if($is_there_qsos_with_no_station_id >= 1) { ?>
+                        <div class="alert alert-danger" role="alert">
+                                <span class="badge badge-pill badge-warning">Warning</span> The Database contains QSOs without a station-profile (location)<br/>
+                        </div>
+  <div class="card-body">
+    <p class="card-text">Please reassign those QSOs to an existing station location:</p>
+
+
+ <div class="table-responsive">
+                <table id="station_locations_table" class="table table-sm table-striped">
+                        <thead>
+                                <tr>
+                                        <th scope="col">Call</th>
+                                        <th scope="col">Target Location</th>
+                                        <th scope="col">Reassign</th>
+                                </tr>
+                        </thead>
+                        <tbody>
+        <?php 
+		foreach ($calls_wo_sid as $call) {
+			echo '<tr><td>'.$call['COL_STATION_CALLSIGN'].'</td><td><select name="station_profile" id="station_profile">';
+				$options='';
+				foreach ($stations->result() as $station) {
+					$options.='<option value='.$station->station_id.'>'.$station->station_profile_name.' ('.$station->station_callsign.')</option>';
+				}
+			echo $options.'</select></td><td><button class="btn btn-warning" onClick="reassign(\''.$call['COL_STATION_CALLSIGN'].'\',$(\'#station_profile option:selected\').val());"><i class="fas fa-sync"></i>Reassign</a></button></td></tr>'; 
+		} ?>
+	</tbody></table>
+  </div>
+  </div>
+                <?php 
+	} else { ?>
+                        <div class="alert alert-secondary" role="alert">
+                                <span class="badge badge-pill badge-success">Everything ok</span> Every QSO in your Database is assigned to a station-profile (location)
+                        </div>
+		<?php } ?>
+
+  </div>
+
+
+</div>
+

--- a/application/views/station_profile/index.php
+++ b/application/views/station_profile/index.php
@@ -33,7 +33,7 @@
 			<div class="alert alert-danger" role="alert">
 		  		<span class="badge badge-pill badge-warning">Warning</span> Due to recent changes within Cloudlog you need to reassign QSOs to your station profiles.
 				</br>
-		  		Please reassign them at <a href="<?php echo site_url('maintenance/'); ?>" class="btn btn-danger"><i class="fas fa-trash-alt"></i>Admin/Maintenance</a>
+		  		Please reassign them at <a href="<?php echo site_url('maintenance/'); ?>" class="btn btn-warning"><i class="fas fa-sync"></i>Admin/Maintenance</a>
 			</div>
 		<?php } ?>
 	  

--- a/application/views/station_profile/index.php
+++ b/application/views/station_profile/index.php
@@ -29,11 +29,11 @@
 		</div>
 		<?php } ?>
 
-		<?php if($is_there_qsos_with_no_station_id >= 1) { ?>
+		<?php if (($is_there_qsos_with_no_station_id >= 1) && ($is_admin)) { ?>
 			<div class="alert alert-danger" role="alert">
 		  		<span class="badge badge-pill badge-warning">Warning</span> Due to recent changes within Cloudlog you need to reassign QSOs to your station profiles.
-
-		  		Create a station profile, if you haven't already, then <a href="<?php echo site_url('station/assign_all/'); ?>" class="btn btn-danger" onclick="return confirm('Assign All QSOs to Default Station ID"><i class="fas fa-trash-alt"></i> press this button to assign all QSOs to the first Station Profile.</a>
+				</br>
+		  		Please reassign them at <a href="<?php echo site_url('maintenance/'); ?>" class="btn btn-danger"><i class="fas fa-trash-alt"></i>Admin/Maintenance</a>
 			</div>
 		<?php } ?>
 	  
@@ -68,9 +68,6 @@
 							<span class="badge badge-success">Active Station</span>
 						<?php } ?>
 
-						<?php if($is_there_qsos_with_no_station_id >= 1) { ?>
-							<a href="<?php echo site_url('station/reassign_profile/').$row->station_id; ?>" class="btn btn-outline-secondary btn-sm" onclick="return confirm('Are you sure you want to reassign QSOs to the <?php echo $row->station_profile_name; ?> profile?');">Reassign</a>
-						<?php } ?>
 						<br>
 						<span class="badge badge-info">ID: <?php echo $row->station_id;?></span>
 						<span class="badge badge-light"><?php echo $row->qso_total;?> QSOs</span>

--- a/assets/js/sections/maintenance.js
+++ b/assets/js/sections/maintenance.js
@@ -1,0 +1,12 @@
+function reassign(call,target_profile_id) {
+	$.ajax({
+		url: base_url + 'index.php/maintenance/reassign',
+		type: 'post',
+		data: {'call': call, 'station_id': target_profile_id},
+		success: function (resu) {
+			if (resu.status) {
+				location.reload();
+			}
+		}
+	});
+}


### PR DESCRIPTION
if there are QSOs without station_id only admin can reassign those QSOs to existing station locations.
Therefore a new Menu-Item at "Admin" was createt. "Maintenance".

One can choose the target-Location by station_callsign and reassign.

The old "reassign to station-id 1" at Station Locations for Users isn't shown any longer. if logged in as admin there's a hint / link for the Admin to reassign those QSOs at Admin->Maintenance.

![Picture of Admin-UI for reassigning QSOs](https://github.com/magicbug/Cloudlog/assets/1410708/95d2baf2-5934-4b41-a57b-470c0e8672f8)
