### PR TITLE
Delete HW-Radio worked only for admins. Fixed that

### DIFF
--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -202,7 +202,7 @@
 	function delete($id) {
 		// Check Auth
 		$this->load->model('user_model');
-		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+		if(!$this->user_model->authorize(3)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
 
 		$this->load->model('cat');
 


### PR DESCRIPTION
Normal User is now also able to delete his Radio-Interfaces at the Menu