### PR TITLE
Prevent QSO being updated twice or more when LoTW-Cnf arrives

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2725,6 +2725,7 @@ class Logbook_model extends CI_Model {
     $this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = "'.$datetime.'"');
     $this->db->where('COL_CALL', $callsign);
     $this->db->where('COL_BAND', $band);
+    $this->db->where('COL_LOTW_QSL_RCVD !=', $qsl_status);	// Prevent QSO from beeing updated twice (or more)
     $this->db->where('COL_STATION_CALLSIGN', $station_callsign);
 
     $this->db->update($this->config->item('table_name'), $data);


### PR DESCRIPTION
Otherwise Clublog and qrz.com will get updates the whole day.

LoTW always delivers the full day, so all LoTW-Confs are updated all day long (until midnight)