### PR TITLE
Only show the spinner for clicked button

### DIFF
--- a/application/views/qrz/export.php
+++ b/application/views/qrz/export.php
@@ -45,7 +45,7 @@
                     echo '<td id ="modcount'.$station->station_id.'">' . $station->modcount . '</td>';
                     echo '<td id ="notcount'.$station->station_id.'">' . $station->notcount . '</td>';
                     echo '<td id ="totcount'.$station->station_id.'">' . $station->totcount . '</td>';
-                    echo '<td><button id="qrzUpload" type="button" name="qrzUpload" class="btn btn-primary btn-sm ld-ext-right" onclick="ExportQrz('. $station->station_id .')"><i class="fas fa-cloud-upload-alt"></i> Upload<div class="ld ld-ring ld-spin"></div></button></td>';
+                    echo '<td><button id="qrzUpload" type="button" name="qrzUpload" class="btn btn-primary btn-sm ld-ext-right ld-ext-right-'.$station->station_id.'" onclick="ExportQrz('. $station->station_id .')"><i class="fas fa-cloud-upload-alt"></i> Upload<div class="ld ld-ring ld-spin"></div></button></td>';
                     echo '</tr>';
                 }
                 echo '</tfoot></table>';

--- a/assets/js/sections/qrzlogbook.js
+++ b/assets/js/sections/qrzlogbook.js
@@ -17,16 +17,16 @@ function ExportQrz(station_id) {
 	if ($(".errormessages").length > 0) {
 		$(".errormessages").remove();
 	}
-	$(".ld-ext-right").addClass('running');
-	$(".ld-ext-right").prop('disabled', true);
+	$(".ld-ext-right-"+station_id).addClass('running');
+	$(".ld-ext-right-"+station_id).prop('disabled', true);
 
 	$.ajax({
 		url: base_url + 'index.php/qrz/upload_station',
 		type: 'post',
 		data: {'station_id': station_id},
 		success: function (data) {
-			$(".ld-ext-right").removeClass('running');
-			$(".ld-ext-right").prop('disabled', false);
+			$(".ld-ext-right-"+station_id).removeClass('running');
+			$(".ld-ext-right-"+station_id).prop('disabled', false);
 			if (data.status == 'OK') {
 				$.each(data.info, function(index, value){
 					$('#modcount'+value.station_id).html(value.modcount);


### PR DESCRIPTION
Fixes an issue where all buttons show spinners during QRZ upload instead of only the clicked one.

![signal-2023-08-14-093121_002](https://github.com/magicbug/Cloudlog/assets/7112907/c5be3c4f-0ff5-4331-a1ad-27d606c271cf)
