### PR TITLE
Added OperatorCall to Contesting

### DIFF
--- a/application/views/contesting/index.php
+++ b/application/views/contesting/index.php
@@ -30,6 +30,11 @@
 									} ?>
                                 </select>
                             </div>
+
+                            <label class="col-auto control-label" for="operatorcall">Operator Callsign</label>
+                            <div class="col-auto">
+                                <input type="text" class="form-control form-control-sm" id="operator_callsign" name="operator_callsign" value='<?php echo $this->session->userdata('operator_callsign'); ?>' required>
+                            </div>
                         </div>
 
                         <div class="form-row">


### PR DESCRIPTION
Simple Field at contesting for the OP-Call.

So multiple OPs are able to work together with a ClubCall or ContestCallsign.
Simply share credentials for the Login, enter your OP-Callsign and do contesting.

Warning: When leaving Contest-Mode, and re-entering Contest-Mode you have to type in your Call again. This is intended, because assumption is: When you're doing contest, you're doing contest.

![Screenshot of OP-Call-Field at Contest-Logging](https://github.com/magicbug/Cloudlog/assets/1410708/7feddb79-2cb9-4753-98ec-64e814e294ad)
