### PR TITLE
Handle VUCC grid lines and corners in Qrb mapping

### DIFF
--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -164,34 +164,38 @@ function get_bearing($lat1, $lon1, $lat2, $lon2) {
 }
 
 function qra2latlong($strQRA) {
-    if (substr_count($strQRA, ',') == 3) {
-       // Handle grid corners
-       $grids = explode(',', $strQRA);
-       $coords = array(0, 0);
-       for($i=0; $i<4; $i++) {
-           $cornercoords[$i] = qra2latlong($grids[$i]);
-           $coords[0] += $cornercoords[$i][0];
-           $coords[1] += $cornercoords[$i][1];
-       }
-       return array (round($coords[0]/4), round($coords[1]/4));
-    } else if (substr_count($strQRA, ',') == 1) {
-       // Handle grid lines
-       $grids = explode(',', $strQRA);
-       $coords = array(0, 0);
-       for($i=0; $i<2; $i++) {
-           $linecoords[$i] = qra2latlong($grids[$i]);
-       }
-       if ($linecoords[0][0] != $linecoords[1][0]) {
-          $coords[0] = round((($linecoords[0][0] + $linecoords[1][0]) / 2),1);
+    if (substr_count($strQRA, ',') > 0) {
+       if (substr_count($strQRA, ',') == 3) {
+          // Handle grid corners
+          $grids = explode(',', $strQRA);
+          $coords = array(0, 0);
+          for($i=0; $i<4; $i++) {
+              $cornercoords[$i] = qra2latlong($grids[$i]);
+              $coords[0] += $cornercoords[$i][0];
+              $coords[1] += $cornercoords[$i][1];
+          }
+          return array (round($coords[0]/4), round($coords[1]/4));
+       } else if (substr_count($strQRA, ',') == 1) {
+          // Handle grid lines
+          $grids = explode(',', $strQRA);
+          $coords = array(0, 0);
+          for($i=0; $i<2; $i++) {
+              $linecoords[$i] = qra2latlong($grids[$i]);
+          }
+          if ($linecoords[0][0] != $linecoords[1][0]) {
+             $coords[0] = round((($linecoords[0][0] + $linecoords[1][0]) / 2),1);
+          } else {
+             $coords[0] = round($linecoords[0][0],1);
+          }
+          if ($linecoords[0][1] != $linecoords[1][1]) {
+             $coords[1] = round(($linecoords[0][1] + $linecoords[1][1]) / 2);
+          } else {
+             $coords[1] = round($linecoords[0][1]);
+          }
+          return $coords;
        } else {
-          $coords[0] = round($linecoords[0][0],1);
+          return false;
        }
-       if ($linecoords[0][1] != $linecoords[1][1]) {
-          $coords[1] = round(($linecoords[0][1] + $linecoords[1][1]) / 2);
-       } else {
-          $coords[1] = round($linecoords[0][1]);
-       }
-       return $coords;
     }
 
     if ((strlen($strQRA) % 2 == 0) && (strlen($strQRA) <= 8)) {	// Check if QRA is EVEN (the % 2 does that) and smaller/equal 8

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -345,13 +345,13 @@ function calculateQrb() {
             data: {'locator1': locator1,
                     'locator2': locator2},
             success: function (html) {
-                
+
                 var result = "<h5>Negative latitudes are south of the equator, negative longitudes are west of Greenwich. <br/>";
                 result += ' ' + locator1.toUpperCase() + ' Latitude = ' + html['latlng1'][0] + ' Longitude = ' + html['latlng1'][1] + '<br/>';
                 result += ' ' + locator2.toUpperCase() + ' Latitude = ' + html['latlng2'][0] + ' Longitude = ' + html['latlng2'][1] + '<br/>';
                 result += 'Distance between ' + locator1.toUpperCase() + ' and ' + locator2.toUpperCase() + ' is ' + html['distance'] + '.<br />';
                 result += 'The bearing is ' + html['bearing'] + '.</h5>';
-                
+
                 $(".qrbResult").html(result);
                 newpath(html['latlng1'], html['latlng2'], locator1, locator2);
             }
@@ -365,7 +365,7 @@ function validateLocator(locator) {
     if(locator.length < 4 && !(/^[a-rA-R]{2}[0-9]{2}[a-xA-X]{0,2}[0-9]{0,2}[a-xA-X]{0,2}$/.test(locator))) {
         return false;
     }
-    
+
     return true;
 }
 

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -362,6 +362,10 @@ function calculateQrb() {
 }
 
 function validateLocator(locator) {
+    vucc_gridno = locator.split(",").length;
+    if(vucc_gridno == 3 || vucc_gridno > 4) {
+        return false;
+    }
     if(locator.length < 4 && !(/^[a-rA-R]{2}[0-9]{2}[a-xA-X]{0,2}[0-9]{0,2}[a-xA-X]{0,2}$/.test(locator))) {
         return false;
     }


### PR DESCRIPTION
The current code regarding mapping does not handle VUCC grid lines and corners. In such cases it just strips off the first 4-char grid and take the center of this for mapping.
This change calculates the coordinates from VUCC_GRIDS by determining the grid corner of the center of a grid line.