### PR TITLE
We need to allow , in URI chars to enable vucc grid lookups

### DIFF
--- a/install/config/config.php
+++ b/install/config/config.php
@@ -290,7 +290,7 @@ $config['composer_autoload'] = FALSE;
 | DO NOT CHANGE THIS UNLESS YOU FULLY UNDERSTAND THE REPERCUSSIONS!!
 |
 */
-$config['permitted_uri_chars'] = 'a-z 0-9~%.:_\-';
+$config['permitted_uri_chars'] = 'a-z 0-9~%.:_\-,';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
VUCC grid lookup fail with HTTP 400 because commas are not allowed as URI characters:

![Screenshot from 2023-08-24 23-06-38](https://github.com/magicbug/Cloudlog/assets/7112907/902dec19-a9a2-462b-b520-ddc34ee06f3e)
