### PR TITLE
[WIP] Convert bearing lookup to POST request

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -917,7 +917,9 @@ class Logbook extends CI_Controller {
 	}
 
 	/* return distance */
-	function searchdistance($locator, $station_id = null) {
+	function searchdistance() {
+			$locator = xss_clean($this->input->post('grid'));
+			$station_id = xss_clean($this->input->post('stationProfile'));
 			$this->load->library('Qra');
 
 			if($locator != null) {

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -878,7 +878,9 @@ class Logbook extends CI_Controller {
 
 
 	/* return station bearing */
-	function searchbearing($locator, $station_id = null) {
+	function searchbearing() {
+			$locator = xss_clean($this->input->post('grid'));
+			$station_id = xss_clean($this->input->post('stationProfile'));
 			$this->load->library('Qra');
 
 			if($locator != null) {

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -1016,7 +1016,6 @@ class Logbook extends CI_Controller {
 
 	function qralatlngjson() {
 		$qra = xss_clean($this->input->post('qra'));
-		log_message('debug','TEST QRA '.$qra);
 		$this->load->library('Qra');
 		$latlng = $this->qra->qra2latlong($qra);
 		print json_encode($latlng);

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -1012,7 +1012,9 @@ class Logbook extends CI_Controller {
 		return $latlng;
 	}
 
-	function qralatlngjson($qra) {
+	function qralatlngjson() {
+		$qra = xss_clean($this->input->post('qra'));
+		log_message('debug','TEST QRA '.$qra);
 		$this->load->library('Qra');
 		$latlng = $this->qra->qra2latlong($qra);
 		print json_encode($latlng);

--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -26,9 +26,12 @@ class Qra {
 		$my = qra2latlong($tx);
 		$stn = qra2latlong($rx);
 
-		$bearing = bearing($my[0], $my[1], $stn[0], $stn[1], $unit);
-
-		return $bearing;
+		if ($my !== false && $stn !== false ) {
+			$bearing = bearing($my[0], $my[1], $stn[0], $stn[1], $unit);
+			return $bearing;
+		} else {
+			return false;
+		}
 	}
 
 	/*
@@ -168,6 +171,11 @@ function qra2latlong($strQRA) {
        if (substr_count($strQRA, ',') == 3) {
           // Handle grid corners
           $grids = explode(',', $strQRA);
+          $gridlengths = array(strlen($grids[0]), strlen($grids[1]), strlen($grids[2]), strlen($grids[3]));
+          $same = array_count_values($gridlengths);
+          if (count($same) != 1) {
+             return false;
+          }
           $coords = array(0, 0);
           for($i=0; $i<4; $i++) {
               $cornercoords[$i] = qra2latlong($grids[$i]);
@@ -178,6 +186,9 @@ function qra2latlong($strQRA) {
        } else if (substr_count($strQRA, ',') == 1) {
           // Handle grid lines
           $grids = explode(',', $strQRA);
+          if (strlen($grids[0]) != strlen($grids[1])) {
+             return false;
+          }
           $coords = array(0, 0);
           for($i=0; $i<2; $i++) {
               $linecoords[$i] = qra2latlong($grids[$i]);

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -981,18 +981,29 @@ $(document).on('keypress',function(e) {
   var markers = L.layerGroup();
   var pos = [51.505, -0.09];
   var mymap = L.map('qsomap').setView(pos, 12);
-  <?php
-  if ($active_station_info->station_gridsquare != "") { ?>
-  $.getJSON('logbook/qralatlngjson/<?php echo $user_gridsquare; ?>', function(result) {
-     mymap.panTo([result[0], result[1]]);
-     pos = result;
-  })
-  <?php } else if (null !== $this->config->item('locator')) { ?>
-  $.getJSON('logbook/qralatlngjson/<?php echo $this->config->item('locator'); ?>', function(result) {
-     mymap.panTo([result[0], result[1]]);
-     pos = result;
-  })
-  <?php } ?>
+  $.ajax({
+     url: base_url + 'index.php/logbook/qralatlngjson',
+     type: 'post',
+     data: {
+<?php if ($active_station_info->station_gridsquare != "") { ?>
+        qra: '<?php echo $user_gridsquare; ?>',
+<?php } else if (null !== $this->config->item('locator')) { ?>
+        qra: '<?php echo $this->config->item('locator'); ?>',
+<?php } else { ?>
+        // Fallback to London in case all else fails
+        qra: 'IO91WM',
+<?php } ?>
+     },
+     success: function(data) {
+        result = JSON.parse(data);
+        if (typeof result[0] !== "undefined" && typeof result[1] !== "undefined") {
+           mymap.panTo([result[0], result[1]]);
+           pos = result;
+        }
+     },
+     error: function() {
+     },
+  });
 
   L.tileLayer('<?php echo $this->optionslib->get_option('option_map_tile_server');?>', {
     maxZoom: 18,

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -177,7 +177,7 @@ function qso_edit(id) {
                                   document.getElementById("distance").value = data;
                                },
                                error: function() {
-                                  document.getElementById("distance").value = 'Error calculating distance!';
+                                  document.getElementById("distance").value = null;
                                },
                             });
                         }

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -153,8 +153,19 @@ function qso_edit(id) {
                     $('#locator').change(function(){
                         if ($(this).val().length >= 4) {
                             $('#locator_info').load(base_url + "index.php/logbook/searchbearing/" + $(this).val() + "/" + $('#stationProfile').val()).fadeIn("slow");
-                            $.get(base_url + 'index.php/logbook/searchdistance/' + $(this).val() + "/" + $('#stationProfile').val(), function(result) {
-                                document.getElementById("distance").value = result;
+                            $.ajax({
+                               url: base_url + 'index.php/logbook/searchdistance',
+                               type: 'post',
+                               data: {
+                                  grid: $(this).val(),
+                                  stationProfile: $('#stationProfile').val()
+                               },
+                               success: function(data) {
+                                  document.getElementById("distance").value = data;
+                               },
+                               error: function() {
+                                  document.getElementById("distance").value = 'Error calculating distance!';
+                               },
                             });
                         }
                     });

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -152,7 +152,20 @@ function qso_edit(id) {
 
                     $('#locator').change(function(){
                         if ($(this).val().length >= 4) {
-                            $('#locator_info').load(base_url + "index.php/logbook/searchbearing/" + $(this).val() + "/" + $('#stationProfile').val()).fadeIn("slow");
+                            $.ajax({
+                               url: base_url + 'index.php/logbook/searchbearing',
+                               type: 'post',
+                               data: {
+                                  grid: $(this).val(),
+                                  stationProfile: $('#stationProfile').val()
+                               },
+                               success: function(data) {
+                                  $('#locator_info').html(data).fadeIn("slow");
+                               },
+                               error: function() {
+                                  $('#locator_info').text("Error loading bearing!").fadeIn("slow");
+                               },
+                            });
                             $.ajax({
                                url: base_url + 'index.php/logbook/searchdistance',
                                type: 'post',

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -863,7 +863,7 @@ $("#locator").keyup(function(){
 					document.getElementById("distance").value = data;
 				},
 				error: function() {
-					document.getElementById("distance").value = 'Error calculating distance!';
+					document.getElementById("distance").value = null;
 				},
 			});
 		}

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -829,7 +829,20 @@ $("#locator").keyup(function(){
 				markers.addLayer(marker).addTo(mymap);
 			})
 
-			$('#locator_info').load(base_url +"index.php/logbook/searchbearing/" + $(this).val() + "/" + $('#stationProfile').val()).fadeIn("slow");
+			$.ajax({
+				url: base_url + 'index.php/logbook/searchbearing',
+				type: 'post',
+				data: {
+					grid: $(this).val(),
+					stationProfile: $('#stationProfile').val()
+				},
+				success: function(data) {
+					$('#locator_info').html(data).fadeIn("slow");
+				},
+				error: function() {
+					$('#locator_info').text("Error loading bearing and distance").fadeIn("slow");
+				},
+			});
 			$.get(base_url + 'index.php/logbook/searchdistance/' + $(this).val() + "/" + $('#stationProfile').val(), function(result) {
 				document.getElementById("distance").value = result;
 			});

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -849,11 +849,22 @@ $("#locator").keyup(function(){
 					$('#locator_info').html(data).fadeIn("slow");
 				},
 				error: function() {
-					$('#locator_info').text("Error loading bearing and distance").fadeIn("slow");
+					$('#locator_info').text("Error loading bearing!").fadeIn("slow");
 				},
 			});
-			$.get(base_url + 'index.php/logbook/searchdistance/' + $(this).val() + "/" + $('#stationProfile').val(), function(result) {
-				document.getElementById("distance").value = result;
+			$.ajax({
+				url: base_url + 'index.php/logbook/searchdistance',
+				type: 'post',
+				data: {
+					grid: $(this).val(),
+					stationProfile: $('#stationProfile').val()
+				},
+				success: function(data) {
+					document.getElementById("distance").value = data;
+				},
+				error: function() {
+					document.getElementById("distance").value = 'Error calculating distance!';
+				},
 			});
 		}
 	}

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -811,23 +811,32 @@ $("#locator").keyup(function(){
 		}
 
 		if(qra_input.length >= 4 && $(this).val().length > 0) {
-			$.getJSON(base_url + 'index.php/logbook/qralatlngjson/' + $(this).val(), function(result)
-			{
-				// Set Map to Lat/Long
-				markers.clearLayers();
-				if (typeof result !== "undefined") {
-					var redIcon = L.icon({
-						iconUrl: icon_dot_url,
-						iconSize:     [18, 18], // size of the icon
-					});
+			$.ajax({
+				url: base_url + 'index.php/logbook/qralatlngjson',
+				type: 'post',
+				data: {
+					qra: $(this).val(),
+				},
+				success: function(data) {
+					// Set Map to Lat/Long
+					result = JSON.parse(data);
+					markers.clearLayers();
+					if (typeof result[0] !== "undefined" && typeof result[1] !== "undefined") {
+						var redIcon = L.icon({
+							iconUrl: icon_dot_url,
+							iconSize:     [18, 18], // size of the icon
+						});
 
-					var marker = L.marker([result[0], result[1]], {icon: redIcon});
-					mymap.setZoom(8);
-					mymap.panTo([result[0], result[1]]);
-					mymap.setView([result[0], result[1]], 8);
-				}
-				markers.addLayer(marker).addTo(mymap);
-			})
+						var marker = L.marker([result[0], result[1]], {icon: redIcon});
+						mymap.setZoom(8);
+						mymap.panTo([result[0], result[1]]);
+						mymap.setView([result[0], result[1]], 8);
+					   markers.addLayer(marker).addTo(mymap);
+					}
+				},
+				error: function() {
+				},
+			});
 
 			$.ajax({
 				url: base_url + 'index.php/logbook/searchbearing',


### PR DESCRIPTION
The bearing and distance functions fail for gridline and gridcorners because comma is not a permitted URI character. Instead of changing the config we convert the AJAX lookups to POST requests. Overcomes https://github.com/magicbug/Cloudlog/pull/2427 which will be closed instead.