### PR TITLE
IMPORTANT Security fix: eQSL uses HTTP (not encrypted) communication

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 138;
+$config['migration_version'] = 139;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -277,13 +277,13 @@ class eqsl extends CI_Controller {
 		return $table;
 	}
 
-	// Build out the ADIF info string according to specs http://eqsl.cc/qslcard/ADIFContentSpecs.cfm
+	// Build out the ADIF info string according to specs https://eqsl.cc/qslcard/ADIFContentSpecs.cfm
 	function generateAdif($qsl, $data) {
 		$COL_QSO_DATE = date('Ymd',strtotime($qsl['COL_TIME_ON']));
 		$COL_TIME_ON = date('Hi',strtotime($qsl['COL_TIME_ON']));
 		
 		# Set up the single record file
-		$adif = "http://www.eqsl.cc/qslcard/importADIF.cfm?";
+		$adif = "https://www.eqsl.cc/qslcard/importADIF.cfm?";
 		$adif .= "ADIFData=CloudlogUpload%20";
 		
 		/* Handy reference of escaping chars

--- a/application/libraries/EqslImporter.php
+++ b/application/libraries/EqslImporter.php
@@ -111,7 +111,7 @@ class EqslImporter
 							foreach ($matches[2] as $match) {
 								// Look for the link that has the .adi file, and download it to $file
 								if (substr($match, -4, 4) == ".adi") {
-									file_put_contents($this->adif_file, file_get_contents("http://eqsl.cc/qslcard/" . $match));
+									file_put_contents($this->adif_file, file_get_contents("https://eqsl.cc/qslcard/" . $match));
 									return $this->import();
 								}
 							}

--- a/application/migrations/139_modify_eQSL_url.php
+++ b/application/migrations/139_modify_eQSL_url.php
@@ -1,0 +1,16 @@
+﻿<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_modify_eQSL_url extends CI_Migration {
+
+	public function up()
+	{
+		$sql = "UPDATE config SET eqsl_download_url = 'https://www.eqsl.cc/qslcard/DownloadInBox.cfm' WHERE id=1";
+		$this->db->query($sql);
+	}
+
+	public function down()
+	{
+		// Will not go back to insecure connections
+	}
+}
+?>

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -154,8 +154,8 @@ class Eqslmethods_model extends CI_Model {
     }
 
     // Update a QSO with eQSL QSL info
-    // We could also probably use this use this: http://eqsl.cc/qslcard/VerifyQSO.txt
-    // http://www.eqsl.cc/qslcard/ImportADIF.txt
+    // We could also probably use this use this: https://eqsl.cc/qslcard/VerifyQSO.txt
+    // https://www.eqsl.cc/qslcard/ImportADIF.txt
     function eqsl_update($datetime, $callsign, $band, $mode, $qsl_status,$station_callsign) {
         $data = array(
             'COL_EQSL_QSLRDATE' => date('Y-m-d H:i:s'), // eQSL doesn't give us a date, so let's use current

--- a/application/views/eqsl/import.php
+++ b/application/views/eqsl/import.php
@@ -30,7 +30,7 @@
 			    Import from file...
 			  </label>
  			  <br><br>
-			  <p>Upload the Exported ADIF file from eQSL from the <a href="http://eqsl.cc/qslcard/DownloadInBox.cfm" target="_blank">Download Inbox</a> page, to mark QSOs as confirmed on eQSL.</p>
+			  <p>Upload the Exported ADIF file from eQSL from the <a href="https://eqsl.cc/qslcard/DownloadInBox.cfm" target="_blank">Download Inbox</a> page, to mark QSOs as confirmed on eQSL.</p>
 					<p><span class="label important">Important</span> Log files must have the file type .adi</p>
 					<input type="file" name="userfile" size="20" />
 			  <br/><br/>


### PR DESCRIPTION
Since eqsl using HTTPS, there is no single reason (maybe just for debugging purposes) to use un-encrypted HTTP connection, especially if there are passwords in requests.

This PR replacing endpoints to HTTPS. What it does NOT do is update in database table "config", which was seeded from migration script 004. I am not familiar with this PHP database framework. So please add there change of

`
		$sql = "UPDATE config SET eqsl_download_url = 'http://www.eqsl.cc/qslcard/DownloadInBox.cfm' WHERE id=1";
`
to 
`
		$sql = "UPDATE config SET eqsl_download_url = 'https://www.eqsl.cc/qslcard/DownloadInBox.cfm' WHERE id=1";
`

I tested it on my server and communication is TLS based and works fine.

Before patch:
![image](https://github.com/magicbug/Cloudlog/assets/6428351/4afbc583-dd90-4dae-b01d-2a442ea0284d)



After patch
![image](https://github.com/magicbug/Cloudlog/assets/6428351/4f5a4ace-a2d8-46cd-bb14-c74ed8172e0f)

