### PR TITLE
Updatefix

### DIFF
--- a/update_cloudlog.sh
+++ b/update_cloudlog.sh
@@ -10,7 +10,7 @@
 # The user and group that own the CLOUDLOG_SUBDIR directories. Passed to 'chown' as-is.
 DIR_OWNERSHIP="root:www-data"
 # The list of directories that need to have ownership restored after a git pull
-declare -a CLOUDLOG_SUBDIRS=("application/config" "assets" "backup" "updates" "uploads")
+declare -a CLOUDLOG_SUBDIRS=("application/config" "assets" "backup" "updates" "uploads" "images/eqsl_card_images")
 # The name of the Git remote to fetch/pull from
 GIT_REMOTE="origin"
 # If true, pull from the HEAD of the configured origin, otherwise the latest tag


### PR DESCRIPTION
just added missing images for eQSL folder.
Do not know if there are more of them, but this one I spotted now.

Anyway, is there any way how to move  those data to one "data" folder, which can be pointed by config to some different location? So that location can be mounted as other storage? Like RAID, backuped etc...

since now it is part of git tree, it is hard to do symlinks... Inspiration from nextcloud for example 