### PR TITLE
Updating PHP to version 8.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,24 +1,24 @@
-FROM php:7.4-apache                                                                                                                                         
+FROM php:8.2-apache             
+# Enabling custom upload settings in PHP                                                                                                                            
 RUN touch /usr/local/etc/php/conf.d/uploads.ini \                                                                                                           
 && echo "file_uploads = On" >> /usr/local/etc/php/conf.d/uploads.ini \
 && echo "memory_limit = 64M" >> /usr/local/etc/php/conf.d/uploads.ini \
 && echo "upload_max_filesize = 64M" >> /usr/local/etc/php/conf.d/uploads.ini \
 && echo "post_max_size = 64M" >> /usr/local/etc/php/conf.d/uploads.ini \
 && echo "max_execution_time = 60" >> /usr/local/etc/php/conf.d/uploads.ini
+# Adding required libraries and modules
 RUN apt-get update \
 && apt-get install -y git curl libxml2-dev libonig-dev
 RUN docker-php-ext-install mysqli mbstring xml
-#RUN docker-php-ext-install curl
-#RUN docker-php-ext-install openssl
+# Cleanup
 RUN rm -rf /var/www/html/docker/
+# Copy proper file to target image
 COPY ./ /var/www/html/
 WORKDIR /var/www/html
 # Setting permissions as: https://github.com/magicbug/Cloudlog/wiki/Installation
 RUN cd /var/www/html \
-&& echo "Setting root as owner of the html folder" \
 && chown -R root:www-data /var/www/html
-RUN echo "Setting permissions to the install folder" \
-&& chmod -R g+rw ./application/config/ \
+RUN chmod -R g+rw ./application/config/ \
 && chmod -R g+rw ./application/logs/ \
 && chmod -R g+rw ./assets/qslcard/ \
 && chmod -R g+rw ./backup/ \

--- a/install/index.php
+++ b/install/index.php
@@ -19,9 +19,9 @@ function delDir($dir) {
 		}
     }
 	// This step may be not needed
-    if (file_exists($dir)) {
-		rmdir( $dir );
-	}
+    // if (file_exists($dir)) {
+	// 	rmdir( $dir );
+	// }
 }
 
 if (file_exists($db_file_path)) {


### PR DESCRIPTION
I have upgraded the base PHP image to 8.0

This version is supported up to 26 Nov 2023, i read in the Wiki that 8.1 and later are not recommended, is this still true?