### PR TITLE
[LBA] Use station profile table for MY_xxx info

### DIFF
--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -38,7 +38,6 @@ class QSO
 	private string $iota;
 	/** @var string[] */
 	private string $deVUCCGridsquares;
-	private string $stationGridsquare;
 	private string $dxGridsquare;
 	private string $dxIOTA;
 	private string $dxSig;
@@ -156,16 +155,14 @@ class QSO
 		$this->email = $data['COL_EMAIL'] ?? '';
 		$this->address = $data['COL_ADDRESS'] ?? '';
 
-		$this->deGridsquare = $data['COL_MY_GRIDSQUARE'] ?? '';
-		$this->deIOTA = $data['COL_MY_IOTA'] ?? '';
-		$this->deSig = $data['COL_MY_SIG'] ?? '';
-		$this->deSigInfo = $data['COL_MY_SIG_INFO'] ?? '';
+		$this->deGridsquare = $data['station_gridsquare'] ?? '';
+		$this->deIOTA = $data['station_iota'] ?? '';
+		$this->deSig = $data['station_sig'] ?? '';
+		$this->deSigInfo = $data['station_sig_info'] ?? '';
 		$this->deIOTAIslandID = $data['COL_MY_IOTA_ISLAND_ID'] ?? '';
-		$this->deSOTAReference = $data['COL_MY_SOTA_REF'] ?? '';
+		$this->deSOTAReference = $data['station_sota'] ?? '';
 
 		$this->deVUCCGridsquares = $data['COL_MY_VUCC_GRIDS'] ?? '';
-
-		$this->stationGridsquare = $data['station_gridsquare'] ?? '';
 
 		$this->dxGridsquare = $data['COL_GRIDSQUARE'] ?? '';
 		$this->dxIOTA = $data['COL_IOTA'] ?? '';
@@ -862,9 +859,9 @@ class QSO
 	{
 		$refs = [];
 		if ($this->dxVUCCGridsquares !== '') {
-			$refs[] = '<span id="dxgrid">' . $this->dxVUCCGridsquares . '</span> ' .$this->getQrbLink($this->stationGridsquare, $this->dxVUCCGridsquares, $this->dxGridsquare);
+			$refs[] = '<span id="dxgrid">' . $this->dxVUCCGridsquares . '</span> ' .$this->getQrbLink($this->deGridsquare, $this->dxVUCCGridsquares, $this->dxGridsquare);
 		} else if ($this->dxGridsquare !== '') {
-			$refs[] = '<span id="dxgrid">' . $this->dxGridsquare . '</span> ' .$this->getQrbLink($this->stationGridsquare, $this->dxVUCCGridsquares, $this->dxGridsquare);
+			$refs[] = '<span id="dxgrid">' . $this->dxGridsquare . '</span> ' .$this->getQrbLink($this->deGridsquare, $this->dxVUCCGridsquares, $this->dxGridsquare);
 		}
 		if ($this->dxSOTAReference !== '') {
 			$refs[] = "SOTA: " . '<span id="dxsota">' . $this->dxSOTAReference. '</span>';


### PR DESCRIPTION
LBA shows references from MY_xxx columns of contacts table istead of the joined station_profile table. This leads to wrong information display if you change the station location for a QSO after logging.

Correct data in QSO view:
![Screenshot from 2023-09-06 09-16-57](https://github.com/magicbug/Cloudlog/assets/7112907/6b7f0440-c2ab-4095-a2cd-5fec315f0e2e)

Wrong/old data in LBA view:
![Screenshot from 2023-09-06 09-17-22](https://github.com/magicbug/Cloudlog/assets/7112907/90d16fd0-ecc5-4eb2-9fff-9983eabf3ad9)
