### PR TITLE
Added different colors for worked and confirmed

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -226,8 +226,9 @@ class Logbook extends CI_Controller {
 	function jsonlookupgrid($gridsquare, $type, $band, $mode) {
 		$return = [
 			"workedBefore" => false,
+			"confirmed" => false,
 		];
-
+		$user_gridmap_confirmation = $this->session->userdata('user_gridmap_confirmation');
 		$CI =& get_instance();
         $CI->load->model('logbooks_model');
         $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
@@ -251,6 +252,52 @@ class Logbook extends CI_Controller {
 			$return['workedBefore'] = true;
 		}
 
+		
+		$extrawhere='';
+		if (isset($user_gridmap_confirmation) && strpos($user_gridmap_confirmation, 'Q') !== false) { 
+			$extrawhere="COL_QSL_RCVD='Y'"; 
+		}
+		if (isset($user_gridmap_confirmation) && strpos($user_gridmap_confirmation, 'L') !== false) {
+			if ($extrawhere!='') {
+				$extrawhere.=" OR";
+			}
+			$extrawhere.=" COL_LOTW_QSL_RCVD='Y'";
+		}
+		if (isset($user_gridmap_confirmation) && strpos($user_gridmap_confirmation, 'E') !== false) {
+			if ($extrawhere!='') {
+				$extrawherei.=" OR";
+			}
+			$extrawhere.=" COL_EQSL_QSL_RCVD='Y'";
+		}
+
+		if($type == "SAT") {
+			$this->db->where('COL_PROP_MODE', 'SAT');
+			if ($extrawhere != '') {
+				$this->db->where('('.$extrawhere.')');
+			} else {
+				$this->db->where("1=0");
+			}
+		} else {
+			$CI->load->model('logbook_model');
+			$this->db->where('COL_MODE', $CI->logbook_model->get_main_mode_from_mode($mode));
+			$this->db->where('COL_BAND', $band);
+			$this->db->where('COL_PROP_MODE !=','SAT');
+			if ($extrawhere != '') {
+				$this->db->where($extrawhere);
+			} else {
+				$this->db->where("1=0");
+			}
+		}
+
+		$this->db->where_in('station_id', $logbooks_locations_array);
+
+		$this->db->like('SUBSTRING(COL_GRIDSQUARE, 1, 4)', substr($gridsquare, 0, 4));
+		$query = $this->db->get($this->config->item('table_name'), 1, 0);
+		log_message("error",$this->db->last_query());
+		foreach ($query->result() as $workedBeforeRow) {
+			$return['confirmed']=true;
+		}
+
 		header('Content-Type: application/json');
 		echo json_encode($return, JSON_PRETTY_PRINT);
 
@@ -261,12 +308,14 @@ class Logbook extends CI_Controller {
 
 		$return = [
 			"workedBefore" => false,
+			"confirmed" => false,
 		];
 
+		$user_gridmap_confirmation = $this->session->userdata('user_gridmap_confirmation');
 		$CI =& get_instance();
-        $CI->load->model('logbooks_model');
-        $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
-	$CI->load->model('logbook_model');
+		$CI->load->model('logbooks_model');
+		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+		$CI->load->model('logbook_model');
 
 		if(!empty($logbooks_locations_array)) {
 			if($type == "SAT") {
@@ -287,12 +336,60 @@ class Logbook extends CI_Controller {
 				$return['workedBefore'] = true;
 			}
 
+			$extrawhere='';
+			if (isset($user_gridmap_confirmation) && strpos($user_gridmap_confirmation, 'Q') !== false) { 
+				$extrawhere="COL_QSL_RCVD='Y'"; 
+			}
+			if (isset($user_gridmap_confirmation) && strpos($user_gridmap_confirmation, 'L') !== false) {
+				if ($extrawhere!='') {
+					$extrawhere.=" OR";
+				}
+				$extrawhere.=" COL_LOTW_QSL_RCVD='Y'";
+			}
+			if (isset($user_gridmap_confirmation) && strpos($user_gridmap_confirmation, 'E') !== false) {
+				if ($extrawhere!='') {
+					$extrawherei.=" OR";
+				}
+				$extrawhere.=" COL_EQSL_QSL_RCVD='Y'";
+			}
+
+
+			if($type == "SAT") {
+				$this->db->where('COL_PROP_MODE', 'SAT');
+				if ($extrawhere != '') {
+					$this->db->where('('.$extrawhere.')');
+				} else {
+					$this->db->where("1=0");
+				}
+			} else {
+				$CI->load->model('logbook_model');
+				$this->db->where('COL_MODE', $CI->logbook_model->get_main_mode_from_mode($mode));
+				$this->db->where('COL_BAND', $band);
+				$this->db->where('COL_PROP_MODE !=','SAT');
+				if ($extrawhere != '') {
+					$this->db->where($extrawhere);
+				} else {
+					$this->db->where("1=0");
+				}
+			}
+
+			$this->db->where_in('station_id', $logbooks_locations_array);
+			$this->db->where('COL_COUNTRY', urldecode($country));
+
+			$query = $this->db->get($this->config->item('table_name'), 1, 0);
+			log_message("error",$this->db->last_query());
+			foreach ($query->result() as $workedBeforeRow) {
+				$return['confirmed']=true;
+			}
+
+
 			header('Content-Type: application/json');
 			echo json_encode($return, JSON_PRETTY_PRINT);
 
 			return;
 		} else {
 			$return['workedBefore'] = false;
+			$return['confirmed'] = false;
 
 			header('Content-Type: application/json');
 			echo json_encode($return, JSON_PRETTY_PRINT);
@@ -307,8 +404,10 @@ class Logbook extends CI_Controller {
 
 		$return = [
 			"workedBefore" => false,
+			"confirmed" => false,
 		];
 
+		$user_gridmap_confirmation = $this->session->userdata('user_gridmap_confirmation');
 		$CI =& get_instance();
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
@@ -338,6 +437,7 @@ class Logbook extends CI_Controller {
 			return;
 		} else {
 			$return['workedBefore'] = false;
+			$return['confirmed'] = false;
 			header('Content-Type: application/json');
 			echo json_encode($return, JSON_PRETTY_PRINT);
 			return;

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -432,6 +432,50 @@ class Logbook extends CI_Controller {
 				$return['workedBefore'] = true;
 			}
 
+			$extrawhere='';
+			if (isset($user_gridmap_confirmation) && strpos($user_gridmap_confirmation, 'Q') !== false) { 
+				$extrawhere="COL_QSL_RCVD='Y'"; 
+			}
+			if (isset($user_gridmap_confirmation) && strpos($user_gridmap_confirmation, 'L') !== false) {
+				if ($extrawhere!='') {
+					$extrawhere.=" OR";
+				}
+				$extrawhere.=" COL_LOTW_QSL_RCVD='Y'";
+			}
+			if (isset($user_gridmap_confirmation) && strpos($user_gridmap_confirmation, 'E') !== false) {
+				if ($extrawhere!='') {
+					$extrawherei.=" OR";
+				}
+				$extrawhere.=" COL_EQSL_QSL_RCVD='Y'";
+			}
+
+
+			if($type == "SAT") {
+				$this->db->where('COL_PROP_MODE', 'SAT');
+				if ($extrawhere != '') {
+					$this->db->where('('.$extrawhere.')');
+				} else {
+					$this->db->where("1=0");
+				}
+			} else {
+				$CI->load->model('logbook_model');
+				$this->db->where('COL_MODE', $CI->logbook_model->get_main_mode_from_mode($mode));
+				$this->db->where('COL_BAND', $band);
+				$this->db->where('COL_PROP_MODE !=','SAT');
+				if ($extrawhere != '') {
+					$this->db->where($extrawhere);
+				} else {
+					$this->db->where("1=0");
+				}
+			}
+			$this->db->where_in('station_id', $logbooks_locations_array);
+			$this->db->where('COL_CALL', strtoupper($callsign));
+
+			$query = $this->db->get($this->config->item('table_name'), 1, 0);
+			foreach ($query->result() as $workedBeforeRow) {
+				$return['confirmed'] = true;
+			}
+
 			header('Content-Type: application/json');
 			echo json_encode($return, JSON_PRETTY_PRINT);
 			return;

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -293,7 +293,6 @@ class Logbook extends CI_Controller {
 
 		$this->db->like('SUBSTRING(COL_GRIDSQUARE, 1, 4)', substr($gridsquare, 0, 4));
 		$query = $this->db->get($this->config->item('table_name'), 1, 0);
-		log_message("error",$this->db->last_query());
 		foreach ($query->result() as $workedBeforeRow) {
 			$return['confirmed']=true;
 		}
@@ -377,7 +376,6 @@ class Logbook extends CI_Controller {
 			$this->db->where('COL_COUNTRY', urldecode($country));
 
 			$query = $this->db->get($this->config->item('table_name'), 1, 0);
-			log_message("error",$this->db->last_query());
 			foreach ($query->result() as $workedBeforeRow) {
 				$return['confirmed']=true;
 			}

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -283,7 +283,7 @@ class Logbook extends CI_Controller {
 			$this->db->where('COL_BAND', $band);
 			$this->db->where('COL_PROP_MODE !=','SAT');
 			if ($extrawhere != '') {
-				$this->db->where($extrawhere);
+				$this->db->where('('.$extrawhere.')');
 			} else {
 				$this->db->where("1=0");
 			}
@@ -367,7 +367,7 @@ class Logbook extends CI_Controller {
 				$this->db->where('COL_BAND', $band);
 				$this->db->where('COL_PROP_MODE !=','SAT');
 				if ($extrawhere != '') {
-					$this->db->where($extrawhere);
+					$this->db->where('('.$extrawhere.')');
 				} else {
 					$this->db->where("1=0");
 				}
@@ -463,7 +463,7 @@ class Logbook extends CI_Controller {
 				$this->db->where('COL_BAND', $band);
 				$this->db->where('COL_PROP_MODE !=','SAT');
 				if ($extrawhere != '') {
-					$this->db->where($extrawhere);
+					$this->db->where('('.$extrawhere.')');
 				} else {
 					$this->db->where("1=0");
 				}

--- a/application/language/english/account_lang.php
+++ b/application/language/english/account_lang.php
@@ -95,3 +95,4 @@ $lang['account_user_mastodon'] = 'URL of Mastodonserver';
 
 $lang['account_gridmap_settings'] = 'Settings for Gridsquare Map';
 $lang['account_gridmap_default_band'] = 'Default Band';
+$lang['account_qsl_settings'] = 'Default QSL-Method shown in views (Gridsquare and Add-QSO)';

--- a/application/language/german/account_lang.php
+++ b/application/language/german/account_lang.php
@@ -95,3 +95,4 @@ $lang['account_user_mastodon'] = 'URL des Mastodonservers';
 
 $lang['account_gridmap_settings'] = 'Einstellung der Planquadratkarte';
 $lang['account_gridmap_default_band'] = 'Standardband';
+$lang['account_qsl_settings'] = 'QSL-Methoden, die in der Planquadratkarte und beim anlegen eines QSOs angezeigt werden';

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -562,6 +562,11 @@
 							} ?>
 							</select>
 						</div>
+					</div>
+					<div class="card-header">
+						<?php echo lang('account_qsl_settings'); ?>
+					</div>
+					<div class="card-body">
 						<div class="form-group">
 							<label class="my-1 mr-2"><?php echo lang('gridsquares_confirmation'); ?></label>
 							<div class="form-check-inline">

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -144,8 +144,12 @@ thead > tr > td {
     text-transform: uppercase;
 }
 
-.workedGrid {
+.confirmedGrid {
     border-color: green;
+}
+
+.workedGrid {
+    border-color: yellow;
 }
 
 .newGrid {

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -523,11 +523,14 @@ $("#callsign").focusout(function() {
 						{
 							// Reset CSS values before updating
 							$('#callsign').removeClass("workedGrid");
+							$('#callsign').removeClass("confirmedGrid");
 							$('#callsign').removeClass("newGrid");
 							$('#callsign').attr('title', '');
 
-							if (result.workedBefore)
-							{
+							if (result.confirmed) {
+								$('#callsign').addClass("confirmedGrid");
+								$('#callsign').attr('title', 'Callsign was already worked and confirmed in the past on this band and mode!');
+							} else if (result.workedBefore) {
 								$('#callsign').addClass("workedGrid");
 								$('#callsign').attr('title', 'Callsign was already worked in the past on this band and mode!');
 							}
@@ -541,20 +544,22 @@ $("#callsign").focusout(function() {
 						$.getJSON(base_url + 'index.php/logbook/jsonlookupcallsign/' + find_callsign.replace(/\//g, "-") + '/0/' + $("#band").val() +'/' + $("#mode").val(), function(result)
 						{
 							// Reset CSS values before updating
+							$('#callsign').removeClass("confirmedGrid");
 							$('#callsign').removeClass("workedGrid");
 							$('#callsign').removeClass("newGrid");
 							$('#callsign').attr('title', '');
 
-							if (result.workedBefore)
-							{
+							if (result.confirmed) {
+								$('#callsign').addClass("confirmedGrid");
+								$('#callsign').attr('title', 'Callsign was already worked and confirmed in the past on this band and mode!');
+							} else if (result.workedBefore) {
 								$('#callsign').addClass("workedGrid");
 								$('#callsign').attr('title', 'Callsign was already worked in the past on this band and mode!');
-							}
-							else
-							{
+							} else {
 								$('#callsign').addClass("newGrid");
 								$('#callsign').attr('title', 'New Callsign!');
 							}
+
 						})
 					}
 
@@ -634,20 +639,19 @@ $("#callsign").focusout(function() {
 
 					if (result.callsign_qra != "")
 					{
-						if (result.workedBefore)
-						{
+						if (result.confirmed) {
+							$('#locator').addClass("confirmedGrid");
+							$('#locator').attr('title', 'Grid was already worked and confirmed in the past');
+						} else if (result.workedBefore) {
 							$('#locator').addClass("workedGrid");
 							$('#locator').attr('title', 'Grid was already worked in the past');
-						}
-						else
-						{
+						} else {
 							$('#locator').addClass("newGrid");
 							$('#locator').attr('title', 'New grid!');
 						}
-					}
-					else
-					{
+					} else {
 						$('#locator').removeClass("workedGrid");
+						$('#locator').removeClass("confirmedGrid");
 						$('#locator').removeClass("newGrid");
 						$('#locator').attr('title', '');
 					}
@@ -775,17 +779,18 @@ $("#locator").keyup(function(){
 				$.getJSON(base_url + 'index.php/logbook/jsonlookupgrid/' + qra_lookup.toUpperCase() + '/SAT/0/0', function(result)
 				{
 					// Reset CSS values before updating
+					$('#locator').removeClass("confirmedGrid");
 					$('#locator').removeClass("workedGrid");
 					$('#locator').removeClass("newGrid");
 					$('#locator').attr('title', '');
 
-					if (result.workedBefore)
-					{
+					if (result.confirmed) {
+						$('#locator').addClass("confirmedGrid");
+						$('#locator').attr('title', 'Grid was already worked and confirmed in the past');
+					} else if (result.workedBefore) {
 						$('#locator').addClass("workedGrid");
 						$('#locator').attr('title', 'Grid was already worked in the past');
-					}
-					else
-					{
+					} else {
 						$('#locator').addClass("newGrid");
 						$('#locator').attr('title', 'New grid!');
 					}
@@ -794,20 +799,22 @@ $("#locator").keyup(function(){
 				$.getJSON(base_url + 'index.php/logbook/jsonlookupgrid/' + qra_lookup.toUpperCase() + '/0/' + $("#band").val() +'/' + $("#mode").val(), function(result)
 				{
 					// Reset CSS values before updating
+					$('#locator').removeClass("confirmedGrid");
 					$('#locator').removeClass("workedGrid");
 					$('#locator').removeClass("newGrid");
 					$('#locator').attr('title', '');
-
-					if (result.workedBefore)
-					{
+					
+					if (result.confirmed) {
+						$('#locator').addClass("confirmedGrid");
+						$('#locator').attr('title', 'Grid was already worked and confimred in the past');
+					} else if (result.workedBefore) {
 						$('#locator').addClass("workedGrid");
 						$('#locator').attr('title', 'Grid was already worked in the past');
-					}
-					else
-					{
+					} else {
 						$('#locator').addClass("newGrid");
 						$('#locator').attr('title', 'New grid!');
 					}
+
 				})
 			}
 		}

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -445,8 +445,10 @@ function reset_fields() {
 	$('#locator').val("");
 	$('#iota_ref').val("");
 	$('#sota_ref').val("");
+	$("#locator").removeClass("confirmedGrid");
 	$("#locator").removeClass("workedGrid");
 	$("#locator").removeClass("newGrid");
+	$("#callsign").removeClass("confirmedGrid");
 	$("#callsign").removeClass("workedGrid");
 	$("#callsign").removeClass("newGrid");
 	$('#callsign_info').removeClass("badge-secondary");

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -967,8 +967,10 @@ function resetDefaultQSOFields() {
 	$('#iota_ref').val("");
 	$('#sota_ref').val("");
 	$("#locator").removeClass("workedGrid");
+	$("#locator").removeClass("confirmedGrid");
 	$("#locator").removeClass("newGrid");
 	$("#callsign").removeClass("workedGrid");
+	$("#callsign").removeClass("confirmedGrid");
 	$("#callsign").removeClass("newGrid");
 	$('#callsign_info').removeClass("badge-secondary");
 	$('#callsign_info').removeClass("badge-success");

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -386,18 +386,20 @@ function changebadge(entityname) {
 		$.getJSON(base_url + 'index.php/logbook/jsonlookupdxcc/' + convert_case(entityname) + '/SAT/0/0', function(result)
 		{
 
+			$('#callsign_info').removeClass("lotw_info_orange");
 			$('#callsign_info').removeClass("badge-secondary");
 			$('#callsign_info').removeClass("badge-success");
 			$('#callsign_info').removeClass("badge-danger");
 			$('#callsign_info').attr('title', '');
 
-			if (result.workedBefore)
-			{
+			if (result.confirmed) {
 				$('#callsign_info').addClass("badge-success");
+				$('#callsign_info').attr('title', 'DXCC was already worked and confirmed in the past on this band and mode!');
+			} else if (result.workedBefore) {
+				$('#callsign_info').addClass("badge-success");
+				$('#callsign_info').addClass("lotw_info_orange");
 				$('#callsign_info').attr('title', 'DXCC was already worked in the past on this band and mode!');
-			}
-			else
-			{
+			} else {
 				$('#callsign_info').addClass("badge-danger");
 				$('#callsign_info').attr('title', 'New DXCC, not worked on this band and mode!');
 			}
@@ -406,18 +408,20 @@ function changebadge(entityname) {
 		$.getJSON(base_url + 'index.php/logbook/jsonlookupdxcc/' + convert_case(entityname) + '/0/' + $("#band").val() +'/' + $("#mode").val(), function(result)
 		{
 			// Reset CSS values before updating
+			$('#callsign_info').removeClass("lotw_info_orange");
 			$('#callsign_info').removeClass("badge-secondary");
 			$('#callsign_info').removeClass("badge-success");
 			$('#callsign_info').removeClass("badge-danger");
 			$('#callsign_info').attr('title', '');
 
-			if (result.workedBefore)
-			{
+			if (result.confirmed) {
 				$('#callsign_info').addClass("badge-success");
+				$('#callsign_info').attr('title', 'DXCC was already worked and confirmed in the past on this band and mode!');
+			} else if (result.workedBefore) {
+				$('#callsign_info').addClass("badge-success");
+				$('#callsign_info').addClass("lotw_info_orange");
 				$('#callsign_info').attr('title', 'DXCC was already worked in the past on this band and mode!');
-			}
-			else
-			{
+			} else {
 				$('#callsign_info').addClass("badge-danger");
 				$('#callsign_info').attr('title', 'New DXCC, not worked on this band and mode!');
 			}


### PR DESCRIPTION
Old behaviour:

When working a station the grid, dxcc and call got a "green" frame, if the station was worked in the past (regardless of confirmation)

New behaviour:

When working a station the grid, dxcc and call got a "yellow" frame, if the station was worked in the past but didn't confirm.
If the station (or the dxcc, grid) was confirmed in the past, the frames are getting "green".

You can adjust the QSL-Methods for that feature at account-settings