### PR TITLE
API: Add additional output to QSO-call

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -164,6 +164,9 @@ class API extends CI_Controller {
 
 		$this->load->model('stations');
 
+		$return_msg = array();
+		$return_count = 0;
+
 		// Decode JSON and store
 		$obj = json_decode(file_get_contents("php://input"), true);
 		if ($obj === NULL) {
@@ -213,12 +216,18 @@ class API extends CI_Controller {
 
 					$this->api_model->update_last_used($obj['key']);
 
-					$this->logbook_model->import($record, $obj['station_profile_id'], NULL, NULL, NULL, NULL, NULL, NULL, false, false, true);
+					$msg = $this->logbook_model->import($record, $obj['station_profile_id'], NULL, NULL, NULL, NULL, NULL, NULL, false, false, true);
+
+					if ( $msg == "" ) {
+						$return_count++;
+					} else {
+						$return_msg[] = $msg;
+					}
 				}
 
 			};
 			http_response_code(201);
-			echo json_encode(['status' => 'created', 'type' => $obj['type'], 'string' => $obj['string']]);
+			echo json_encode(['status' => 'created', 'type' => $obj['type'], 'string' => $obj['string'], 'created' => $return_count, 'messages' => $return_msg ]);
 
 		}
 


### PR DESCRIPTION
Two return fields added for improved reporting:
* Messages returned from Logbook-import
* Number of QSO's added without message

To discuss:
* Number of QSO's depends on import-function returning empty string for successful import - maybe add documentation there
* Maybe add strings of errornous ADIF's to output?

I appreciate ideas/comments...