### PR TITLE
Handle multigrids in hams.at display

### DIFF
--- a/application/views/components/hamsat/table.php
+++ b/application/views/components/hamsat/table.php
@@ -5,7 +5,8 @@
     <table class="table table-striped table-hover">
         <thead>
             <tr>
-                <th>Date / Time</th>
+                <th>Date</th>
+                <th>Time</th>
                 <th>Callsign</th>
                 <th>Satellite</th>
                 <th>Gridsquare(s)</th>
@@ -30,10 +31,11 @@
                         ?>
 
                         <?php $timestamp = strtotime($rove['date']);
-                        echo date($custom_date_format, $timestamp); ?>
+                           echo date($custom_date_format, $timestamp); ?>
 
-                        - <?php echo $rove['start_time']; ?> - <?php echo $rove['end_time']; ?>
-
+                    </td>
+                    <td>
+                        <?php echo $rove['start_time']." - ".$rove['end_time']; ?>
                     </td>
                     <td>
                         <?php

--- a/application/views/components/hamsat/table.php
+++ b/application/views/components/hamsat/table.php
@@ -8,7 +8,7 @@
                 <th>Date / Time</th>
                 <th>Callsign</th>
                 <th>Satellite</th>
-                <th>Gridsquare</th>
+                <th>Gridsquare(s)</th>
                 <th></th>
             </tr>
         </thead>
@@ -58,11 +58,23 @@
                         <?php
 
                         // Load the logbook model and call check_if_grid_worked_in_logbook
-                        $worked = $CI->logbook_model->check_if_grid_worked_in_logbook($rove['gridsquare'], null, "SAT");
-                        if ($worked != 0) {
-                            echo " <span data-toggle=\"tooltip\" title=\"Worked\" class=\"badge badge-success\">" . $rove['gridsquare'] . "</span>";
+                        if (strpos($rove['gridsquare'], '/') !== false) {
+                           $grids = explode('/', $rove['gridsquare']);
+                           foreach ($grids as $grid) {
+                           $worked = $CI->logbook_model->check_if_grid_worked_in_logbook($grid, null, "SAT");
+                              if ($worked != 0) {
+                                  echo " <span data-toggle=\"tooltip\" title=\"Worked\" class=\"badge badge-success\">" . $grid . "</span>";
+                              } else {
+                                  echo " <span data-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge badge-danger\">" . $grid . "</span>";
+                              }
+                           }
                         } else {
-                            echo " <span data-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge badge-danger\">" . $rove['gridsquare'] . "</span>";
+                           $worked = $CI->logbook_model->check_if_grid_worked_in_logbook($rove['gridsquare'], null, "SAT");
+                           if ($worked != 0) {
+                               echo " <span data-toggle=\"tooltip\" title=\"Worked\" class=\"badge badge-success\">" . $rove['gridsquare'] . "</span>";
+                           } else {
+                               echo " <span data-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge badge-danger\">" . $rove['gridsquare'] . "</span>";
+                           }
                         }
                         ?>
 


### PR DESCRIPTION
Hams.at announcements with multiple grids should be dealt with to show status of each grid separately. 
Before:

![Screenshot 2023-09-20 135300](https://github.com/magicbug/Cloudlog/assets/7112907/ad8c85c5-cf23-4162-97d0-695274192d7a)

After:
![Screenshot 2023-09-20 135251](https://github.com/magicbug/Cloudlog/assets/7112907/6bcb34fe-420e-4e89-bdd2-2cd48a92eecf)
