### PR TITLE
Improve errror handling on importing wrong station callsigns

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2888,7 +2888,8 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
 	}
 
         if ((!$skipStationCheck) && ($station_id != 0) && (strtoupper($record['station_callsign']) != strtoupper($station_profile_call))) {     // Check if station_call from import matches profile ONLY when submitting via GUI.
-                return "Wrong station_callsign ".$record['station_callsign']." while importing QSO with ".$record['call']." for ".$station_profile_call." : SKIPPED";
+           return "Wrong station callsign <b>\"".htmlentities($record['station_callsign'])."\"</b> while importing QSO with ".$record['call']." for <b>".$station_profile_call."</b> : SKIPPED" .
+              "<br>See the <a target=\"_blank\" href=\"https://github.com/magicbug/Cloudlog/wiki/ADIF-file-can't-be-imported\">Cloudlog Wiki</a> for hints about errors in ADIF files.";
         }
 
         $CI =& get_instance();


### PR DESCRIPTION
This addresses https://github.com/magicbug/Cloudlog/commit/827528e84ba75e22d9cd47d0ef82a629f518d007 and the previous code changes to prevent importing logs with different station callsigns.

My analysis of DK9JC's failed ADIF import showed that the code didn't properly handle the case that a station_callsign had an incorrect length in the ADIF tag to be imported. E.g.:

```
<STATION_CALLSIGN:9>DF2ET
<MY_CITY:6>Bochum
```

This led to a misleading error message:

![Screenshot from 2023-09-22 08-41-05](https://github.com/magicbug/Cloudlog/assets/7112907/3bbb31f5-fdb9-411f-adf3-f1961e7092ba)

The code took "DF2ET <MY" as the station callsign which is nonsense obviously. In addition the part of the following ADIF tag (MY_CITY) was sent to the browser and interpreted as HTML source code and this hidden from the user. See the HTML source of the output below.

So the code was changed to show the callsign using htmlentities (i.e. encoding the special chars to be displayed) and add some more details to the error message including a link to the wiki:

![Screenshot from 2023-09-22 08-40-04](https://github.com/magicbug/Cloudlog/assets/7112907/e323677d-1ae1-48ed-9440-3e230f039e0e)

Hope this prevents forced import with wrong data ...