### PR TITLE
Adapt to API changes (timestamp was given in local time instead of UTC)

### DIFF
--- a/assets/js/sections/sattimers.js
+++ b/assets/js/sections/sattimers.js
@@ -10,8 +10,8 @@ function update(i) {
   } else {
 
      //var distance = dateArray[i] - now.getTime();
-     var distance = parseInt(dateArray[i]) - new Date(now.getTime()+now.getTimezoneOffset()*60*1000);
-     var satDate = new Date(parseInt(dateArray[i]) - now.getTimezoneOffset()*60*1000);
+     var distance = parseInt(dateArray[i]) - new Date(now.getTime());
+     var satDate = new Date(parseInt(dateArray[i]));
 
      var days = Math.floor(distance / (1000 * 60 * 60 * 24));
      var hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));

--- a/assets/js/sections/sattimers.js
+++ b/assets/js/sections/sattimers.js
@@ -9,7 +9,6 @@ function update(i) {
     element.innerHTML = "&#x1F480;";
   } else {
 
-     //var distance = dateArray[i] - now.getTime();
      var distance = parseInt(dateArray[i]) - new Date(now.getTime());
      var satDate = new Date(parseInt(dateArray[i]));
 


### PR DESCRIPTION
SAT timers API gave timestamp in local time instead of UTC. As that is fixed now we need to remove the offset calculation in CL.