### PR TITLE
Handle exception for LilacSat-2 / CAS-3H on amsat status page

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -886,6 +886,8 @@ class Logbook_model extends CI_Model {
          } else if ($data['COL_MODE'] == 'PKT') {
             $sat_name = 'ISS-DATA';
          }
+      } else if ($data['COL_SAT_NAME'] == 'CAS-3H') {
+         $sat_name = 'LilacSat-2';
       } else {
          $sat_name = $data['COL_SAT_NAME'];
       }


### PR DESCRIPTION
We need to set SAT name to LilacSat-2 for the amsat.org status page to work.