### PR TITLE
Fix Gridsearch / QSO-Details

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -352,7 +352,7 @@ class Logbook_model extends CI_Model {
 			if ($searchmode == 'activated') {
 				$this->db->where("station_gridsquare like '%" . $searchphrase . "%'");
 			} else {
-				$this->db->where("(COL_GRIDSQUARE like '" . $searchphrase . "%' OR COL_VUCC_GRIDS like '" . $searchphrase ."%')");
+				$this->db->where("(COL_GRIDSQUARE like '" . $searchphrase . "%' OR COL_VUCC_GRIDS like '%" . $searchphrase ."%')");
 			}
 			break;
 		case 'CQZone':

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -352,7 +352,7 @@ class Logbook_model extends CI_Model {
 			if ($searchmode == 'activated') {
 				$this->db->where("station_gridsquare like '%" . $searchphrase . "%'");
 			} else {
-				$this->db->where("(COL_GRIDSQUARE like '%" . $searchphrase . "%' OR COL_VUCC_GRIDS like'%" . $searchphrase ."%')");
+				$this->db->where("(COL_GRIDSQUARE like '" . $searchphrase . "%' OR COL_VUCC_GRIDS like '" . $searchphrase ."%')");
 			}
 			break;
 		case 'CQZone':


### PR DESCRIPTION
Behaviour:

Search for Grid (e.g. awards/VUCC) "CM" shows also QSOs where "CM" is at the end (FN75CM).
But it should only show Grids which START with "CM"

Please check this, before merging @AndreasK79 or @phl0