### PR TITLE
Fix contestlog-reload on Fieldreset

### DIFF
--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -257,7 +257,7 @@ function checkIfWorkedBefore() {
 	}
 }
 
-function reset_log_fields() {
+async function reset_log_fields() {
 	$('#name').val("");
 	$('.callsign-suggestions').text("");
 	$('#callsign').val("");
@@ -269,6 +269,7 @@ function reset_log_fields() {
 	setRst($("#mode").val());
 	$('#callsign_info').text("");
 
+	await refresh_qso_table(sessiondata);
 	var qTable = $('.qsotable').DataTable();
 	qTable.search('').draw();
 }


### PR DESCRIPTION
Old behaviour:
After logging Contest-QSO the whole List disappears, when clicking "Reset QSO" or pressing ESC

New behaviour:
Reset QSO or pressing ESC will reload the actual QSO-List and show it correctly