### PR TITLE
Search for "Base-Call" instead of Prefix+Call

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -135,7 +135,18 @@ class Logbook extends CI_Controller {
 		];
 
 		$return['dxcc'] = $this->dxcheck($callsign);
-		$return['partial'] = $this->partial($callsign);
+		$split_callsign=explode('/',$callsign);
+		if (isset($split_callsign[1]) && ($split_callsign[1] != "")) {	// Do we have "/" in Call?
+			if (strlen($split_callsign[1])>3) {			// Last Element longer than 3 chars? Take that as call
+				$lookupcall = $split_callsign[1];
+			} else {						// Last Element up to 3 Chars? Take first element as Call
+				$lookupcall = $split_callsign[0];
+			}
+		} else {
+			$lookupcall=$callsign;
+		}
+
+		$return['partial'] = $this->partial($lookupcall);
 
 		$callbook = $this->logbook_model->loadCallBook($callsign, $this->config->item('use_fullname'));
 
@@ -872,7 +883,11 @@ function worked_grid_before($gridsquare, $type, $band, $mode)
 		$fixedid = $id;
 
 		if ($id2 != "") {
-			$fixedid = $id . '/' . $id2;
+			if (strlen($id2)>3) {	// Last Element longer than 3 chars? Take that as call
+				$fixedid = $id2;
+			} else {		// Last Element up to 3 Chars? Take first element as Call
+				$fixedid = $id;
+			}
 		}
 
 		$query = $this->querydb($fixedid);


### PR DESCRIPTION
Old behaviour:

Lets say i worked DF2ET while he was at PA. So i logged PA/DF2ET
After a few weeks, DF2ET is QRV from HB0, so i enter "HB0/DF2ET". No previous QSO with DF2ET will show up. And no QSO will show up at Search-Bar.

New behaviour:
Lets say i worked DF2ET while he was at PA. So i logged PA/DF2ET
After a few weeks, DF2ET is QRV from HB0, so i enter "HB0/DF2ET". All previous QSOs with DF2ET will show up at search, the last 5 at logging

@AndreasK79 / @phl0 : plz have a look / test this. tnx in advance