### PR TITLE
Add update function for DCL DOK data

### DIFF
--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -165,6 +165,7 @@ class adif extends CI_Controller {
 		$data['active_station_info'] = $station_profile->row();
 
 		$data['page_title'] = "ADIF Import";
+		$data['tab'] = "adif";
 
 		$config['upload_path'] = './uploads/';
 		$config['allowed_types'] = 'adi|ADI|adif|ADIF';
@@ -177,7 +178,7 @@ class adif extends CI_Controller {
 			$data['max_upload'] = ini_get('upload_max_filesize');
 
 			$this->load->view('interface_assets/header', $data);
-			$this->load->view('adif/import');
+			$this->load->view('adif/import', $data);
 			$this->load->view('interface_assets/footer');
 		} else {
 			if ($this->stations->check_station_is_accessible($this->input->post('station_profile'))) {
@@ -221,6 +222,67 @@ class adif extends CI_Controller {
 
 		}
 	}
+
+	public function dcl() {
+		$this->load->model('stations');
+		$data['station_profile'] = $this->stations->all_of_user();
+
+		$data['page_title'] = "DCL Import";
+		$data['tab'] = "dcl";
+
+		$config['upload_path'] = './uploads/';
+		$config['allowed_types'] = 'adi|ADI|adif|ADIF';
+
+		$this->load->library('upload', $config);
+
+		if ( ! $this->upload->do_upload()) {
+			$data['error'] = $this->upload->display_errors();
+
+			$data['max_upload'] = ini_get('upload_max_filesize');
+
+			$this->load->view('interface_assets/header', $data);
+			$this->load->view('adif/import', $data);
+			$this->load->view('interface_assets/footer');
+		} else {
+			$data = array('upload_data' => $this->upload->data());
+
+			ini_set('memory_limit', '-1');
+			set_time_limit(0);
+
+			$this->load->model('logbook_model');
+
+			$this->load->library('adif_parser');
+
+			$this->adif_parser->load_from_file('./uploads/'.$data['upload_data']['file_name']);
+
+			$this->adif_parser->initialize();
+			$error_count = array(0, 0);
+			$custom_errors = "";
+			while($record = $this->adif_parser->get_record())
+			{
+				if(count($record) == 0) {
+					break;
+				};
+
+				$dok_result = $this->logbook_model->update_dok($record, $this->input->post('ignoreAmbiguous'), $this->input->post('onlyConfirmed'), $this->input->post('overwriteDok'));
+				if (!empty($dok_result)) {
+					if ($dok_result[0] != 0) {
+						$custom_errors .= $dok_result[1]."<br/>";
+						$error_count[1]++;
+					} else {
+						$error_count[0]++;
+					}
+				}
+			};
+			unlink('./uploads/'.$data['upload_data']['file_name']);
+			$data['dcl_error_count'] = $error_count;
+			$data['dcl_errors'] = $custom_errors;
+			$data['page_title'] = "DCL Data Imported";
+			$this->load->view('interface_assets/header', $data);
+			$this->load->view('adif/dcl_success');
+			$this->load->view('interface_assets/footer');
+		}
+   }
 }
 
 /* End of file adif.php */

--- a/application/language/bulgarian/adif_lang.php
+++ b/application/language/bulgarian/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/chinese_simplified/adif_lang.php
+++ b/application/language/chinese_simplified/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/czech/adif_lang.php
+++ b/application/language/czech/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/dutch/adif_lang.php
+++ b/application/language/dutch/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/english/adif_lang.php
+++ b/application/language/english/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different).";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched.";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/finnish/adif_lang.php
+++ b/application/language/finnish/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/french/adif_lang.php
+++ b/application/language/french/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/german/adif_lang.php
+++ b/application/language/german/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSO's markiert";
 $lang['adif_yay_its_done'] = "Yay, geschafft!";
 $lang['adif_qso_lotw_marked_confirm'] = "Die QSO wurden als 'zu LoTW hochgeladen' markiert";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Gehe zum";
+$lang['adif_dcl_text_post'] = "und exportiere dein Logbuch mit bestätigten DOKs. Um den Prozess zu beschleunigen, kannst du QSOs ausschließlich mit DL-Stationen auswählen (indem du \"DL\" in die Präfixliste einträgst). Die heruntergeladene ADIF-Datei kannst du hier hochladen, um dein Logbuch mit DOK Informationen zu aktualisieren.";
+
+$lang['only_confirmed_qsos'] = "Importiere nur DOK Informationen von QSOs, die auf DCL bestätigt sind.";
+$lang['only_confirmed_qsos_hint'] = "Deaktiviere diese Option, um auch DOK Infos von QSOS zu importieren, die auf DCL nicht bestätig sind.";
+
+$lang['overwrite_by_dcl'] = "Überschreibe existierende DOK im Logbuch durch DCL (wenn unterschiedlich).";
+$lang['overwrite_by_dcl_hint'] = "Wenn aktiviert, wird Cloudlog den existierenden DOK mit dem DOK aus dem DCL überschreiben.";
+
+$lang['ignore_ambiguous'] = "Ignoriere QSOs, die nicht eindeutig zugeordnet werden können.";
+$lang['ignore_ambiguous_hint'] = "Wenn deaktiviert, werden auch Infos zu QSOs angezeigt, die im Logbuch nicht gefunden werden konnten.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Duplikate wurden übersprungen.";
 
 $lang['adif_import_errors'] = "ADIF Fehler";
 $lang['adif_import_errors_hint'] = "Es gibt ADIF Fehler. Die QSO wurden hinzugefügt, jedoch wurden die fehlerhaften Felder nicht ausgefüllt.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Ergebnisse des DCL DOK Updates";
+$lang['dcl_info_updated'] = "QSOs wurden mit der DOK Information aus dem DCL aktualisiert.";
+$lang['dcl_qsos_updated'] = "Aktualisierte QSOs:";
+$lang['dcl_qsos_ignored'] = "Ignorierte QSOs:";
+$lang['dcl_no_qsos_updated'] = "Keine QSOs aktualisiert.";
+$lang['dcl_dok_errors'] = "DOK Fehler";
+$lang['dcl_dok_errors_details'] = "Die DOK Informationen im Logbuch weichen von denen im DCL ab:";

--- a/application/language/greek/adif_lang.php
+++ b/application/language/greek/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/italian/adif_lang.php
+++ b/application/language/italian/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/polish/adif_lang.php
+++ b/application/language/polish/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/russian/adif_lang.php
+++ b/application/language/russian/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/spanish/adif_lang.php
+++ b/application/language/spanish/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/swedish/adif_lang.php
+++ b/application/language/swedish/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/language/turkish/adif_lang.php
+++ b/application/language/turkish/adif_lang.php
@@ -12,6 +12,7 @@ ________________________________________________________________________________
 $lang['adif_import'] = "ADIF Import";
 $lang['adif_export'] = "ADIF Export";
 // $lang['lotw_title']                      --> application/language/english/lotw_lang.php
+$lang['darc_dcl'] = "DARC DCL";
 
 
 /*
@@ -81,6 +82,22 @@ $lang['adif_qso_marked'] = "QSOs marked";
 $lang['adif_yay_its_done'] = "Yay, its done!";
 $lang['adif_qso_lotw_marked_confirm'] = "The QSOs are marked as exported to LoTW.";
 
+/*
+___________________________________________________________________________________________
+DARC DCL
+___________________________________________________________________________________________
+*/
+$lang['adif_dcl_text_pre'] = "Go to";
+$lang['adif_dcl_text_post'] = "and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put \"DL\" into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info.";
+
+$lang['only_confirmed_qsos'] = "Only import DOK data from QSOs confirmed on DCL.";
+$lang['only_confirmed_qsos_hint'] = "Uncheck if you also want to update DOK with data from unconfirmed QSOs in DCL.";
+
+$lang['overwrite_by_dcl'] = "Overwrite exisiting DOK in log by DCL (if different)";
+$lang['overwrite_by_dcl_hint'] = "If checked Cloudlog will forcibly overwrite existing DOK with DOK from DCL log.";
+
+$lang['ignore_ambiguous'] = "Ignore QSOs that cannot be matched";
+$lang['ignore_ambiguous_hint'] = "If unchecked information about QSO which could not be found in Cloudlog will be displayed.";
 
 /*
 ___________________________________________________________________________________________
@@ -97,3 +114,17 @@ $lang['adif_import_dupes_skipped'] = " Dupes were skipped.";
 
 $lang['adif_import_errors'] = "ADIF Errors";
 $lang['adif_import_errors_hint'] = "You have ADIF errors, the QSOs have still been added but these fields have not been populated.";
+
+/*
+___________________________________________________________________________________________
+DCL Success
+___________________________________________________________________________________________
+*/
+
+$lang['dcl_results'] = "Results of DCL DOK Update";
+$lang['dcl_info_updated'] = "DCL information for DOKs has been updated.";
+$lang['dcl_qsos_updated'] = "QSOs updated:";
+$lang['dcl_qsos_ignored'] = "QSOs ignored:";
+$lang['dcl_no_qsos_updated'] = "No QSOs updated.";
+$lang['dcl_dok_errors'] = "DOK Errors";
+$lang['dcl_dok_errors_details'] = "There is different data for DOK in your log compared to DCL:";

--- a/application/views/adif/dcl_success.php
+++ b/application/views/adif/dcl_success.php
@@ -1,0 +1,33 @@
+<div class="container">
+<br>
+	<?php if($this->session->flashdata('message')) { ?>
+		<!-- Display Message -->
+		<div class="alert-message error">
+		  <p><?php echo $this->session->flashdata('message'); ?></p>
+		</div>
+	<?php } ?>
+
+<div class="card">
+  <div class="card-header">
+    <?php echo lang('dcl_results');?>
+  </div>
+  <div class="card-body">
+    <?php if($dcl_error_count[0] > 0) { ?>
+       <h3 class="card-title">Yay, its updated!</h3>
+       <p class="card-text"><?php echo lang('dcl_info_updated')?></p>
+       <p class="card-text"><?php echo lang('dcl_qsos_updated')?> <?php echo $dcl_error_count[0] ?>.</p>
+       <p class="card-text"><?php echo lang('dcl_qsos_ignored')?> <?php echo $dcl_error_count[1] ?>.</p>
+    <?php } else { ?>
+       <h3 class="card-title"><?php echo lang('dcl_no_qsos_updated')?></h3>
+       <p>
+    <?php } ?>
+    <?php if($dcl_errors) { ?>
+      <h3><?php echo lang('dcl_dok_errors')?></h3>
+      <p><?php echo lang('dcl_dok_errors_details')?></p>
+      <p class="card-text"><?php echo $dcl_errors; ?></p>
+    <?php } ?>
+  </div>
+</div>
+
+
+</div>

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -2,11 +2,18 @@
 <div class="container adif">
 
 	<h2><?php echo $page_title; ?></h2>
+   <?php
+        $showtab = '';
+        if(isset($tab)) {
+           $showtab = $tab;
+        }
+    ?>
+
     <div class="card">
     <div class="card-header">
     <ul class="nav nav-tabs card-header-tabs pull-right" role="tablist">
         <li class="nav-item">
-            <a class="nav-link active" id="import-tab" data-toggle="tab" href="#import" role="tab" aria-controls="import" aria-selected="true"><?php echo lang('adif_import')?></a>
+            <a class="nav-link <?php if($showtab == '' || $showtab == 'adif') { echo 'active'; } ?>" id="import-tab" data-toggle="tab" href="#import" role="tab" aria-controls="import" aria-selected="<?php if ($showtab == '' || $showtab == 'adif') { echo 'true'; } else { echo 'false'; } ?>"><?php echo lang('adif_import')?></a>
         </li>
         <li class="nav-item">
             <a class="nav-link" id="export-tab" data-toggle="tab" href="#export" role="tab" aria-controls="export" aria-selected="false"><?php echo lang('adif_export')?></a>
@@ -14,14 +21,17 @@
         <li class="nav-item">
             <a class="nav-link" id="lotw-tab" data-toggle="tab" href="#lotw" role="tab" aria-controls="lotw" aria-selected="false"><?php echo lang('lotw_title')?></a>
         </li>
+        <li class="nav-item">
+            <a class="nav-link <?php if ($showtab == 'dcl') { echo 'active'; } ?>" id="dcl-tab" data-toggle="tab" href="#dcl" role="tab" aria-controls="dcl" aria-selected="<?php if ($showtab == 'dcl') { echo 'true'; } else { echo 'false'; } ?>"><?php echo lang('darc_dcl')?></a>
+        </li>
     </ul>
     </div>
 
     <div class="card-body">
         <div class="tab-content">
-            <div class="tab-pane  active" id="import" role="tabpanel" aria-labelledby="home-tab">
+            <div class="tab-pane <?php if($showtab == '' || $showtab == 'adif') { echo 'active'; } else { echo 'fade'; } ?>" id="import" role="tabpanel" aria-labelledby="home-tab">
 
-                <?php if(isset($error)) { ?>
+                <?php if(isset($error) && ($showtab == '' || $showtab == 'adif')) { ?>
                     <div class="alert alert-danger" role="alert">
                       <?php echo $error; ?>
                     </div>
@@ -213,6 +223,47 @@
                 <button type="submit" class="btn-sm btn-primary" value="Export"><?php echo lang('adif_mark_qso_as_exported_to_lotw')?></button>
             </form>
             </div>
+        <div class="tab-pane <?php if ($showtab == 'dcl') { echo 'active'; } else { echo 'fade'; } ?>" id="dcl" role="tabpanel" aria-labelledby="home-tab">
+                <?php if(isset($error) && $showtab == 'dcl') { ?>
+                    <div class="alert alert-danger" role="alert">
+                      <?php echo $error; ?>
+                    </div>
+                <?php } ?>
+
+                <p class="card-text"><?php echo lang('adif_dcl_text_pre')?> <a href="http://dcl.darc.de/dml/export_adif_form.php" target="_blank"><?php echo lang('darc_dcl')?></a> <?php echo lang('adif_dcl_text_post')?></p>
+                <form class="form" action="<?php echo site_url('adif/dcl'); ?>" method="post" enctype="multipart/form-data">
+
+                    <div class="form-group row">
+                        <div class="col-md-10">
+                            <div class="form-check-inline">
+                                <input class="form-check-input" type="checkbox" name="onlyConfirmed" value="1" id="onlyConfirmed" checked>
+                                <label class="form-check-label" for="onlyConfirmed"><?php echo lang('only_confirmed_qsos')?></label>
+                            </div>
+                            <div class="small form-text text-muted"><?php echo lang('only_confirmed_qsos_hint')?></div>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <div class="col-md-10">
+                            <div class="form-check-inline">
+                                <input class="form-check-input" type="checkbox" name="overwriteDok" value="1" id="overwriteDok">
+                                <label class="form-check-label" for="overwriteDok"><span class="badge badge-warning"><?php echo lang('general_word_warning')?></span> <?php echo lang('overwrite_by_dcl')?></label>
+                            </div>
+                            <div class="small form-text text-muted"><?php echo lang('overwrite_by_dcl_hint')?></div>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <div class="col-md-10">
+                            <div class="form-check-inline">
+                                <input class="form-check-input" type="checkbox" name="ignoreAmbiguous" value="1" id="ignoreAmbiguous" checked>
+                                <label class="form-check-label" for="ignoreAmbiguous"><?php echo lang('ignore_ambiguous')?></label>
+                            </div>
+                            <div class="small form-text text-muted"><?php echo lang('ignore_ambiguous_hint')?></div>
+                        </div>
+                    </div>
+                  <input class="file-input mb-2 mr-sm-2" type="file" name="userfile" size="20" />
+                  <button type="submit" class="btn-sm btn-primary mb-2" value="Upload"><?php echo lang('adif_upload')?></button>
+                </form>
+        </div>
     </div>
     </div>
     </div>


### PR DESCRIPTION
This adds a function to upload an ADIF file which was exported from DARC DCL. This file contains confirmed information about German DOKs. As those are often not exchanged during a QSO one can use the data of his DCL accout to update their Cloudlog log with this information by simply uploading an export of the DCL.