### PR TITLE
correction of default bandgroup as migration

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 145;
+$config['migration_version'] = 146;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/migrations/146_correct_default_bandgroup.php
+++ b/application/migrations/146_correct_default_bandgroup.php
@@ -1,0 +1,26 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/*
+ *
+ * Correction of the default bandgroup of 160m, 23cm and 13cm
+ * 
+ */
+
+ class Migration_correct_default_bandgroup extends CI_Migration {
+
+    public function up()
+    {
+        $this->db->query("UPDATE bands SET bandgroup = 'mf' WHERE band = '160m' AND bandgroup = 'hf';");
+        $this->db->query("UPDATE bands SET bandgroup = 'uhf' WHERE band = '23cm' AND bandgroup = 'shf';");
+        $this->db->query("UPDATE bands SET bandgroup = 'uhf' WHERE band = '13cm' AND bandgroup = 'shf';");
+    }
+
+    public function down()
+    {
+        $this->db->query("UPDATE bands SET bandgroup = 'hf' WHERE band = '160m' AND bandgroup = 'mf';");
+        $this->db->query("UPDATE bands SET bandgroup = 'shf' WHERE band = '23cm' AND bandgroup = 'uhf';");
+        $this->db->query("UPDATE bands SET bandgroup = 'shf' WHERE band = '13cm' AND bandgroup = 'uhf';");
+    }
+}


### PR DESCRIPTION
As mentioned in #2589 this is the migration for the default bandgroup of 160m, 23cm and 13cm