### PR TITLE
Check if grid worked on default band for callbook results

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -919,6 +919,9 @@ function worked_grid_before($gridsquare, $type, $band, $mode)
 						}
 
 						$data['callsign'] = $this->qrz->search($id, $this->session->userdata('qrz_session_key'), $this->config->item('use_fullname'));
+						$CI = &get_instance();
+						$CI->load->model('logbook_model');
+						$data['grid_worked'] = $CI->logbook_model->check_if_grid_worked_in_logbook(strtoupper(substr($data['callsign']['gridsquare'],0,4)), 0, $this->session->userdata('user_default_band'));
 					} /*else {
 						// Lookup using hamli
 						$this->load->library('hamli');

--- a/application/views/search/result.php
+++ b/application/views/search/result.php
@@ -5,7 +5,6 @@
 
 <?php if(isset($callsign['callsign'])) { ?>
 <h3>Callbook Search for <?php echo $id; ?></h3>
-
 <table>
 
 <tr>
@@ -25,7 +24,15 @@
 
 <tr>
 	<td style="padding: 0 0.3em 0 0;" align="left">Gridsquare</td>
-   <td style="padding: 0.3em 0 0.3em 0.5em;" align="left"><?php echo strtoupper($callsign['gridsquare']); ?></td>
+	<td style="padding: 0.3em 0 0.3em 0.5em;" align="left">
+	<?php
+		if ($grid_worked != 0) {
+			echo " <span data-toggle=\"tooltip\" title=\"Worked\" class=\"badge-success\" style=\"padding-left: 0.2em; padding-right: 0.2em;\">".strtoupper($callsign['gridsquare'])."</span>";
+		} else {
+			echo " <span data-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge-danger\" style=\"padding-left: 0.2em; padding-right: 0.2em;\">".strtoupper($callsign['gridsquare'])."</span>";
+		}
+	?>
+	</td>
 </tr>
 
 </table>


### PR DESCRIPTION
Show if (4-char) gridsuquare of callbook result has been worked before.

![Screenshot from 2023-10-24 15-02-40](https://github.com/magicbug/Cloudlog/assets/7112907/ed7694df-7011-45a8-b0cc-2cd910fed25a)
