### PR TITLE
Mark invalid time and date with red border

### DIFF
--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -54,12 +54,12 @@
               <div class="form-row">
                 <div class="form-group col-md-6">
                   <label for="start_date"><?php echo lang('general_word_date'); ?></label>
-                  <input type="text" class="form-control form-control-sm input_date" name="start_date" id="start_date" value="<?php if (($this->session->userdata('start_date') != NULL && ((time() - $this->session->userdata('time_stamp')) < 24 * 60 * 60))) { echo $this->session->userdata('start_date'); } else { echo date('d-m-Y');}?>" <?php echo ($_GET['manual'] == 0 ? "disabled" : "");  ?> >
+                  <input type="text" class="form-control form-control-sm input_date" name="start_date" id="start_date" value="<?php if (($this->session->userdata('start_date') != NULL && ((time() - $this->session->userdata('time_stamp')) < 24 * 60 * 60))) { echo $this->session->userdata('start_date'); } else { echo date('d-m-Y');}?>" <?php echo ($_GET['manual'] == 0 ? "disabled" : "");  ?> required pattern="[0-3][0-9]-[0-1][0-9]-[0-9]{4}">
                 </div>
 
                 <div class="form-group col-md-6">
                   <label for="start_time"><?php echo lang('general_word_time'); ?></label>
-                  <input type="text" class="form-control form-control-sm input_time" name="start_time" id="start_time" value="<?php if (($this->session->userdata('start_time') != NULL && ((time() - $this->session->userdata('time_stamp')) < 24 * 60 * 60))) { echo $this->session->userdata('start_time'); } else {echo date('H:i'); } ?>" size="7" <?php echo ($_GET['manual'] == 0 ? "disabled" : "");  ?>>
+                  <input type="text" class="form-control form-control-sm input_time" name="start_time" id="start_time" value="<?php if (($this->session->userdata('start_time') != NULL && ((time() - $this->session->userdata('time_stamp')) < 24 * 60 * 60))) { echo $this->session->userdata('start_time'); } else {echo date('H:i'); } ?>" size="7" <?php echo ($_GET['manual'] == 0 ? "disabled" : "");  ?> required pattern="[0-2][0-9]:[0-5][0-9]">
                 </div>
 
                 <?php if ( $_GET['manual'] == 0 ) { ?>

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -544,3 +544,7 @@ div#station_logbooks_linked_table_paginate {
 #awardInfoButton h2 {
     margin-right: 30px; 
 }
+
+input:invalid {
+   border-color: red;
+}


### PR DESCRIPTION
Addresses https://github.com/magicbug/Cloudlog/issues/2555 by setting a pattern for date and time and mark input fields if pattern does not match.

![Screenshot from 2023-10-25 09-33-25](https://github.com/magicbug/Cloudlog/assets/7112907/24b81ce5-345e-4db6-96bc-435734828996)

