### PR TITLE
Make rove comment a separate column

### DIFF
--- a/application/views/components/hamsat/table.php
+++ b/application/views/components/hamsat/table.php
@@ -13,6 +13,7 @@
                 <th>Date</th>
                 <th>Time</th>
                 <th>Callsign</th>
+                <th>Comment</th>
                 <th>Satellite</th>
                 <th>Gridsquare(s)</th>
                 <th></th>
@@ -49,13 +50,16 @@
 			$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
                         $CI->load->model('logbook_model');
                         $call_worked = $CI->logbook_model->check_if_callsign_worked_in_logbook($rove['callsign'], $logbooks_locations_array, "SAT");
-                        echo " <span data-toggle=\"tooltip\" title=\"".$rove['comment']."\">";
                         if ($call_worked != 0) {
                             echo "<span class=\"text-success\">".$rove['callsign']."</span>";
                         } else {
                             echo $rove['callsign'];
                         }
-                        echo "</span></td>";
+                        ?>
+                    </td>
+                    <td>
+                        <?php
+                        echo $rove['comment'];
                         ?>
                     </td>
                     <td><span data-toggle="tooltip" title="<?php echo $rove['frequency']; ?> - <?php echo $rove['mode']; ?>"><?= $rove['satellite'] ?></span></td>

--- a/application/views/components/hamsat/table.php
+++ b/application/views/components/hamsat/table.php
@@ -59,7 +59,7 @@
                     </td>
                     <td>
                         <?php
-                        echo $rove['comment'];
+                        echo xss_clean($rove['comment']);
                         ?>
                     </td>
                     <td><span data-toggle="tooltip" title="<?php echo $rove['frequency']; ?> - <?php echo $rove['mode']; ?>"><?= $rove['satellite'] ?></span></td>


### PR DESCRIPTION
Would like to have the comment in a separate column to make it easier to see.

Before (only on hover):

![Screenshot from 2023-11-10 07-31-20](https://github.com/magicbug/Cloudlog/assets/7112907/c78c06dd-cf68-40a1-8ce4-372b9f593e9b)

After:

![Screenshot from 2023-11-10 07-34-46](https://github.com/magicbug/Cloudlog/assets/7112907/fabf6f45-5951-4420-867d-12bf82c18970)
