### PR TITLE
Pass error message given by qrz.com to the user

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -919,9 +919,14 @@ function worked_grid_before($gridsquare, $type, $band, $mode)
 						}
 
 						$data['callsign'] = $this->qrz->search($id, $this->session->userdata('qrz_session_key'), $this->config->item('use_fullname'));
-						$CI = &get_instance();
-						$CI->load->model('logbook_model');
-						$data['grid_worked'] = $CI->logbook_model->check_if_grid_worked_in_logbook(strtoupper(substr($data['callsign']['gridsquare'],0,4)), 0, $this->session->userdata('user_default_band'));
+						if (isset($data['callsign']['gridsquare'])) {
+							$CI = &get_instance();
+							$CI->load->model('logbook_model');
+							$data['grid_worked'] = $CI->logbook_model->check_if_grid_worked_in_logbook(strtoupper(substr($data['callsign']['gridsquare'],0,4)), 0, $this->session->userdata('user_default_band'));
+						}
+						if (isset($data['callsign']['error'])) {
+							$data['error'] = $data['callsign']['error'];
+						}
 					} /*else {
 						// Lookup using hamli
 						$this->load->library('hamli');

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -927,6 +927,8 @@ function worked_grid_before($gridsquare, $type, $band, $mode)
 						if (isset($data['callsign']['error'])) {
 							$data['error'] = $data['callsign']['error'];
 						}
+					} else {
+						$data['error'] = 'No result (qrz not configured)';
 					} /*else {
 						// Lookup using hamli
 						$this->load->library('hamli');

--- a/application/libraries/Qrz.php
+++ b/application/libraries/Qrz.php
@@ -71,7 +71,7 @@ class Qrz {
 
             // Create XML object
             $xml = simplexml_load_string($xml);
-            if (empty($xml)) return;
+            if (!empty($xml->Session->Error)) return $data['error'] = $xml->Session->Error;
 
             // Return Required Fields
             $data['callsign'] = (string)$xml->Callsign->call;

--- a/application/views/search/result.php
+++ b/application/views/search/result.php
@@ -3,8 +3,8 @@
 
 <p>Sorry, but we didn't find any past QSOs with <?php echo $id; ?></p>
 
-<?php if(isset($callsign['callsign'])) { ?>
 <h3>Callbook Search for <?php echo $id; ?></h3>
+<?php if(isset($callsign['callsign'])) { ?>
 <table>
 
 <tr>
@@ -36,6 +36,10 @@
 </tr>
 
 </table>
+
+<?php } else { ?>
+
+<p><?php echo $error; ?></p>
 
 <?php } ?>
 </div>


### PR DESCRIPTION
There is an issue in the qrz lib line 74. This should catch errors with empty results but does not work because qrz.com always gives an XML result. In case of an error or not found callsign this XML contains an error message. But as it is not empty the result page for looking up a non existent callsign looks weird:

![Screenshot from 2023-11-11 21-33-41](https://github.com/magicbug/Cloudlog/assets/7112907/cdf01e14-b67c-4f76-8bc0-8464405ab746)

This PR parses also the error message contained in the XML result an passes it to the user on the results page:

![Screenshot from 2023-11-11 21-34-40](https://github.com/magicbug/Cloudlog/assets/7112907/7d6aaabb-1893-4fb8-8c02-fdc2d5c61d58)
