### PR TITLE
[BUG FIX] Empty results if click on "More QSOs" in QSO Windows

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -924,8 +924,8 @@ function searchButtonPress(){
 
 $(document).ready(function(){
 
-  <?php if($this->input->post('searchBar') != "") { ?>
-        $('#partial_view').load("logbook/search_result/<?php echo str_replace("Ø","0",$this->input->post('searchBar')); ?>", function() {
+  <?php if($this->input->post('callsign') != "") { ?>
+        $('#partial_view').load("logbook/search_result/<?php echo str_replace("Ø","0",$this->input->post('callsign')); ?>", function() {
            $('[data-toggle="tooltip"]').tooltip()
     });
   <?php } ?>

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -244,7 +244,7 @@
 							if (localStorage.getItem("quicklogCallsign") !== "") {
   								localStorage.removeItem("quicklogCallsign");
 							}
-							localStorage.setItem("quicklogCallsign", $("input[name='searchBar']").val());
+							localStorage.setItem("quicklogCallsign", $("input[name='callsign']").val());
 							window.open("<?php echo site_url('qso?manual=0'); ?>", "_self");
 						}
 					</script>
@@ -266,7 +266,7 @@
 						</script>
 					<?php } ?>
 					<form id="quicklog-form" class="form-inline" onsubmit="return false;">
-						<input class="form-control mr-sm-2" id="nav-bar-search-input" type="text" name="searchBar" placeholder="<?php echo lang('menu_search_text_quicklog'); ?>" aria-label="Quicklog" onkeypress="handleKeyPress(event)">
+						<input class="form-control mr-sm-2" id="nav-bar-search-input" type="text" name="callsign" placeholder="<?php echo lang('menu_search_text_quicklog'); ?>" aria-label="Quicklog" onkeypress="handleKeyPress(event)">
 
 						<button title="<?php echo lang('menu_search_button_qicksearch_log'); ?>" class="btn btn-outline-success my-2 my-sm-0" type="button" onclick="logQuicklog()"><i class="fas fa-plus"></i>
 							<div class="d-inline d-lg-none" style="padding-left: 10px"><?php echo lang('menu_search_button_qicksearch_log'); ?></div>
@@ -278,7 +278,7 @@
 					</form>
 				<?php } else { ?>
 					<form method="post" action="<?php echo site_url('search'); ?>" class="form-inline">
-						<input class="form-control mr-sm-2" id="nav-bar-search-input" type="search" name="searchBar" placeholder="<?php echo lang('menu_search_text'); ?>" aria-label="Search">
+						<input class="form-control mr-sm-2" id="nav-bar-search-input" type="search" name="callsign" placeholder="<?php echo lang('menu_search_text'); ?>" aria-label="Search">
 						<button title="<?php echo lang('menu_search_button'); ?>" class="btn btn-outline-success my-2 my-sm-0" type="submit"><i class="fas fa-search"></i>
 							<div class="d-inline d-lg-none" style="padding-left: 10px"><?php echo lang('menu_search_button'); ?></div>
 						</button>

--- a/application/views/search/main.php
+++ b/application/views/search/main.php
@@ -30,7 +30,7 @@
 		  <div class="form-group row">
 		    <label for="callsign" class="col-sm-2 col-form-label">Callsign / Gridsquare</label>
 		    <div class="col-sm-8">
-		      <input type="text" class="form-control" id="callsign" value="<?php if ($this->input->post('searchBar') !== null) { echo htmlspecialchars($this->input->post('searchBar')); }; ?>">
+		      <input type="text" class="form-control" id="callsign" value="<?php if ($this->input->post('callsign') !== null) { echo htmlspecialchars($this->input->post('callsign')); }; ?>">
 		    </div>
 		    <div class="col-sm-2">
 		    	<button onclick="searchButtonPress()" class="btn btn-outline-success my-2 my-sm-0" type="submit"><i class="fas fa-search"></i> Search</button>

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -377,7 +377,7 @@
                     <?php if(($this->config->item('use_auth') && ($this->session->userdata('user_type') >= 2)) || $this->config->item('use_auth') === FALSE) { ?>
                         <br>
                             <div style="display: inline-block;"><p class="editButton"><a class="btn btn-primary" href="<?php echo site_url('qso/edit'); ?>/<?php echo $row->COL_PRIMARY_KEY; ?>" href="javascript:;"><i class="fas fa-edit"></i> <?php echo lang('qso_btn_edit_qso'); ?></a></p></div>
-                            <div style="display: inline-block;"><form method="POST" action="<?php echo site_url('search'); ?>"><input type="hidden" value="<?php echo strtoupper($row->COL_CALL); ?>" name="searchBar"><button class="btn btn-primary" type="submit"><i class="fas fa-eye"></i> <?php echo lang('general_more_qso'); ?></button></form></div>
+                            <div style="display: inline-block;"><form method="POST" action="<?php echo site_url('search'); ?>"><input type="hidden" value="<?php echo strtoupper($row->COL_CALL); ?>" name="callsign"><button class="btn btn-primary" type="submit"><i class="fas fa-eye"></i> <?php echo lang('general_more_qso'); ?></button></form></div>
                     <?php } ?>
 
                     <?php

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -377,7 +377,7 @@
                     <?php if(($this->config->item('use_auth') && ($this->session->userdata('user_type') >= 2)) || $this->config->item('use_auth') === FALSE) { ?>
                         <br>
                             <div style="display: inline-block;"><p class="editButton"><a class="btn btn-primary" href="<?php echo site_url('qso/edit'); ?>/<?php echo $row->COL_PRIMARY_KEY; ?>" href="javascript:;"><i class="fas fa-edit"></i> <?php echo lang('qso_btn_edit_qso'); ?></a></p></div>
-                            <div style="display: inline-block;"><form method="POST" action="<?php echo site_url('search'); ?>"><input type="hidden" value="<?php echo strtoupper($row->COL_CALL); ?>" name="callsign"><button class="btn btn-primary" type="submit"><i class="fas fa-eye"></i> <?php echo lang('general_more_qso'); ?></button></form></div>
+                            <div style="display: inline-block;"><form method="POST" action="<?php echo site_url('search'); ?>"><input type="hidden" value="<?php echo strtoupper($row->COL_CALL); ?>" name="searchBar"><button class="btn btn-primary" type="submit"><i class="fas fa-eye"></i> <?php echo lang('general_more_qso'); ?></button></form></div>
                     <?php } ?>
 
                     <?php


### PR DESCRIPTION
This fixes a bug, if it shows empty results if click on "More QSOs" in the QSO Windows. 

The POST reference was renamed since Quicklog to avoid form fields with the same ID