### PR TITLE
Show latest Migration in Database in the Debug View

### DIFF
--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -14,6 +14,10 @@ class Debug extends CI_Controller {
     {
         $this->load->helper('file');
 
+        $this->load->model('MigrationVersion');
+
+        $data['migration_version'] = $this->MigrationVersion->getMigrationVersion();
+
         // Test writing to backup folder
         $backup_folder = $this->is_really_writable('backup');
         $data['backup_folder'] = $backup_folder;
@@ -29,7 +33,7 @@ class Debug extends CI_Controller {
         $data['page_title'] = "Debug";
 
         $this->load->view('interface_assets/header', $data);
-        $this->load->view('debug/main');
+        $this->load->view('debug/main', $data);
         $this->load->view('interface_assets/footer');
     }
 

--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -33,7 +33,7 @@ class Debug extends CI_Controller {
         $data['page_title'] = "Debug";
 
         $this->load->view('interface_assets/header', $data);
-        $this->load->view('debug/main', $data);
+        $this->load->view('debug/main');
         $this->load->view('interface_assets/footer');
     }
 

--- a/application/models/MigrationVersion.php
+++ b/application/models/MigrationVersion.php
@@ -1,0 +1,20 @@
+<?php
+
+class MigrationVersion extends CI_Model {
+
+	function getMigrationVersion() {
+        $this->db->select_max('version');
+        $query = $this->db->get('migrations');
+        $migration_version = $query->row();
+
+        if ($query->num_rows() == 1) {
+            $migration_version = $query->row()->version;
+            return $migration_version;
+        } else {
+            return null;
+        }
+    }
+
+}
+
+?>

--- a/application/views/debug/main.php
+++ b/application/views/debug/main.php
@@ -21,6 +21,11 @@
                         <td>Base URL</td>
                         <td><span id="baseUrl"><a href="<?php echo $this->config->item('base_url')?>" target="_blank"><?php echo $this->config->item('base_url'); ?></a></span> <span data-toggle="tooltip" data-original-title="<?php echo lang('copy_to_clipboard'); ?>" onclick='copyURL("<?php echo $this->config->item('base_url'); ?>")'><i class="copy-icon fas fa-copy"></span></td>
                     </tr>
+                    <tr>
+                        <td>Migration</td>
+                        <td><?php echo (isset($migration_version) ? $migration_version : "<span class='badge badge-danger'>There is something wrong with your Migration in Database!</span>"); ?></td>
+                    </tr>
+
                 </table>
             </div>
         </div>


### PR DESCRIPTION
This adds a new model and shows the latest run migration (value from the database) in the Debug View.

This could help to debug issues in user installations if we easily know which was the latest migration.

<img width="355" alt="db_migration" src="https://github.com/magicbug/Cloudlog/assets/80885850/24b3adf4-ad32-4167-b4f0-796392594de2">

-- If there is more than one value in the database, there is definitely something wrong. So, show an error.

<img width="392" alt="db_error_warning" src="https://github.com/magicbug/Cloudlog/assets/80885850/ac9560d3-f07a-44a3-aa19-ce9614b8da77">
