### PR TITLE
Focus in QSO Live View if no Quicklog Value is set

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1,7 +1,7 @@
 $( document ).ready(function() {
 	setTimeout(function() {
 		var callsignValue = localStorage.getItem("quicklogCallsign");
-		if (callsignValue !== "") {
+		if (callsignValue !== null && callsignValue !== undefined) {
 		  $("#callsign").val(callsignValue);
 		  $("#mode").focus();
 		  localStorage.removeItem("quicklogCallsign");


### PR DESCRIPTION
In Live QSO View the focus jumps to mode even if no Quicklog Value is set. 

This fixes that