### PR TITLE
Bugfix Resettime

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1000,37 +1000,6 @@ $(document).on('keypress',function(e) {
 					}
 				);
 			});
-			$('#reset_time').click(function() {
-				var now = new Date();
-				var localTime = now.getTime();
-				var utc = localTime + (now.getTimezoneOffset() * 60000);
-				$('#start_time').val(("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2)+':'+("0" + now.getUTCSeconds()).slice(-2));
-				$("[id='start_time']").each(function() {
-					$(this).attr("value", ("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2)+':'+("0" + now.getUTCSeconds()).slice(-2));
-				});
-			});
-			$('#reset_start_time').click(function() {
-				var now = new Date();
-				var localTime = now.getTime();
-				var utc = localTime + (now.getTimezoneOffset() * 60000);
-				$('#start_time').val(("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2));
-				$("[id='start_time']").each(function() {
-					$(this).attr("value", ("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2)+':'+("0" + now.getUTCSeconds()).slice(-2));
-				});
-				$('#end_time').val(("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2));
-				$("[id='end_time']").each(function() {
-					$(this).attr("value", ("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2)+':'+("0" + now.getUTCSeconds()).slice(-2));
-				});
-			});
-			$('#reset_end_time').click(function() {
-				var now = new Date();
-				var localTime = now.getTime();
-				var utc = localTime + (now.getTimezoneOffset() * 60000);
-				$('#end_time').val(("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2));
-				$("[id='end_time']").each(function() {
-					$(this).attr("value", ("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2)+':'+("0" + now.getUTCSeconds()).slice(-2));
-				});
-			});
 		});
 	</script>
 

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -6,7 +6,38 @@ $( document ).ready(function() {
 		  $("#mode").focus();
 		  localStorage.removeItem("quicklogCallsign");
 		}
-	  }, 100);
+	}, 100);
+	$('#reset_time').click(function() {
+		var now = new Date();
+		var localTime = now.getTime();
+		var utc = localTime + (now.getTimezoneOffset() * 60000);
+		$('#start_time').val(("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2)+':'+("0" + now.getUTCSeconds()).slice(-2));
+		$("[id='start_time']").each(function() {
+			$(this).attr("value", ("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2)+':'+("0" + now.getUTCSeconds()).slice(-2));
+		});
+	});
+	$('#reset_start_time').click(function() {
+		var now = new Date();
+		var localTime = now.getTime();
+		var utc = localTime + (now.getTimezoneOffset() * 60000);
+		$('#start_time').val(("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2));
+		$("[id='start_time']").each(function() {
+			$(this).attr("value", ("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2)+':'+("0" + now.getUTCSeconds()).slice(-2));
+		});
+		$('#end_time').val(("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2));
+		$("[id='end_time']").each(function() {
+			$(this).attr("value", ("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2)+':'+("0" + now.getUTCSeconds()).slice(-2));
+		});
+	});
+	$('#reset_end_time').click(function() {
+		var now = new Date();
+		var localTime = now.getTime();
+		var utc = localTime + (now.getTimezoneOffset() * 60000);
+		$('#end_time').val(("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2));
+		$("[id='end_time']").each(function() {
+			$(this).attr("value", ("0" + now.getUTCHours()).slice(-2)+':'+("0" + now.getUTCMinutes()).slice(-2)+':'+("0" + now.getUTCSeconds()).slice(-2));
+		});
+	});
 var favs={};
 	get_fav();
 


### PR DESCRIPTION
There is an Issue that the Reset Time Button in QSO View only works if a dxcluster url is configures. This because of the placement of the javascripts in the particular line of the footer  (inside the brackets `if ($this->optionslib->get_option('dxcache_url') != ''){ ?>`

To reproduce this behaviour:

Delete the dxcluster cache url in the admin menu. Then go back to qso window and enter a callsign and move to the next field to trigger the callsign lookup. After a few seconds try to reset the start time -> doesn't work. 
So if a User does not have configured a dxcluster cache he won't be able to use the reset time button.

Moved the javascript to `assets/js/sections/qso.js` because the reset time buttons are only available in qso window.

@phl0 Can you check this one please? The QSO Timers are your baby.