### PR TITLE
We do not need to (re-)update distances if grids are the same

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4083,6 +4083,7 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
         $this->db->where("((COL_DISTANCE is NULL) or (COL_DISTANCE = 0))");
         $this->db->where("COL_GRIDSQUARE is NOT NULL");
         $this->db->where("COL_GRIDSQUARE != ''");
+        $this->db->where("COL_GRIDSQUARE != station_gridsquare");
         $this->db->trans_start();
         $query = $this->db->get($this->config->item('table_name'));
 


### PR DESCRIPTION
We can skip QSOs where station_gridsquare is the same as the DX'es gridsquare as distance will be 0 anyway. So just exclude these QSOs.