### PR TITLE
Disable debug output (spoiling logs)

### DIFF
--- a/application/libraries/Curl.php
+++ b/application/libraries/Curl.php
@@ -27,7 +27,6 @@ class Curl {
 	function __construct($url = '')
 	{
 		$this->_ci = & get_instance();
-		log_message('debug', 'cURL Class Initialized');
 
 		if ( ! $this->is_enabled())
 		{


### PR DESCRIPTION
It just fills the logs and makes debugging difficult actually because some asynchronous functions keep running in the background causing tons of lines with cURL being loaded.