### PR TITLE
We should only check directories for being writable

### DIFF
--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -52,9 +52,11 @@ class Debug extends CI_Controller {
             // Check if the subdirectories are writable (recursive check)
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
             foreach ($iterator as $item) {
-                if (!is_writable($item->getPathname())) {
-                    return false;
-                }
+               if ($item->isDir() && basename($item->getPathName()) != '..') {
+                  if (!is_writable($item->getRealPath())) {
+                     return false;
+                  }
+               }
             }
 
             return true;


### PR DESCRIPTION
With https://github.com/magicbug/Cloudlog/pull/2675 we implemented a recursive permission check. The current code checks every file if it is writable by the web server. This leads to the case that debug info shows that directories are not writable:

![Screenshot from 2023-11-16 09-37-42](https://github.com/magicbug/Cloudlog/assets/7112907/46d77241-9397-4c6c-a25e-97d1a3b8bf3b)

Where the directories itself are writable indeed. But if the code finds a file that is not writable it returns false and pretends the directory is not writable which in fact is wrong.

So we need to only check directories and sub-directories for permissions but should ignore files here.