### PR TITLE
Fix QSO Start Time gets overwritten when editing a QSO in Live QSO Logging

### DIFF
--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -55,12 +55,12 @@
                                 <div class="form-row">
                                     <div class="form-group col-sm-6">
                                         <label for="start_date">Start Date/Time</label>
-                                        <input type="text" class="form-control form-control-sm input_date" name="time_on" id="time_on" value="<?php echo $qso->COL_TIME_ON; ?>">
+                                        <input type="text" class="form-control form-control-sm" name="time_on" id="time_on" value="<?php echo $qso->COL_TIME_ON; ?>">
                                     </div>
 
                                     <div class="form-group col-sm-6">
                                         <label for="start_time">End Date/Time</label>
-                                        <input type="text" class="form-control form-control-sm input_time" name="time_off" id="time_off" value="<?php echo $qso->COL_TIME_OFF; ?>">
+                                        <input type="text" class="form-control form-control-sm" name="time_off" id="time_off" value="<?php echo $qso->COL_TIME_OFF; ?>">
                                     </div>
                                 </div>
                                 <div class="form-row">


### PR DESCRIPTION
This should fix #2703 

Please test and confirm. Tested different QSO Edits and everything seems still working after removing those classes from the Form Input.