### PR TITLE
Splitted VUCC into real VUCC and SAT-VUCC at Dashboard

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -110,6 +110,7 @@ class Dashboard extends CI_Controller {
 			$data['last_five_qsos'] = $this->logbook_model->get_last_qsos('18', $logbooks_locations_array);
 
 			$data['vucc'] = $this->vucc->fetchVuccSummary();
+			$data['vuccSAT'] = $this->vucc->fetchVuccSummary('SAT');
 
 			$data['page_title'] = "Dashboard";
 

--- a/application/language/bulgarian/awards_lang.php
+++ b/application/language/bulgarian/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/chinese_simplified/awards_lang.php
+++ b/application/language/chinese_simplified/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/czech/awards_lang.php
+++ b/application/language/czech/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/dutch/awards_lang.php
+++ b/application/language/dutch/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/english/awards_lang.php
+++ b/application/language/english/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/finnish/awards_lang.php
+++ b/application/language/finnish/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/french/awards_lang.php
+++ b/application/language/french/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/greek/awards_lang.php
+++ b/application/language/greek/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/italian/awards_lang.php
+++ b/application/language/italian/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/polish/awards_lang.php
+++ b/application/language/polish/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/russian/awards_lang.php
+++ b/application/language/russian/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/spanish/awards_lang.php
+++ b/application/language/spanish/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/swedish/awards_lang.php
+++ b/application/language/swedish/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/language/turkish/awards_lang.php
+++ b/application/language/turkish/awards_lang.php
@@ -156,7 +156,7 @@ ________________________________________________________________________________
 
 $lang['awards_vucc_description_ln1'] = "VUCC - VHF/UHF Century Club Award";
 $lang['awards_vucc_description_ln2'] = "The VHF/UHF Century Club Award is given for a minimum number of worked and confirmed gridsquares on a desired band.";
-$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.amsat.org/gridmaster/' target='_blank'>Click here</a>.";
+$lang['awards_vucc_description_ln3'] = "Official information and the rules can be found in this document: <a href='https://www.arrl.org/vucc' target='_blank'>Click here</a>.";
 $lang['awards_vucc_description_ln4'] = "Only VHF/UHF bands are relevant.";
 
 

--- a/application/models/Vucc.php
+++ b/application/models/Vucc.php
@@ -144,43 +144,44 @@ class VUCC extends CI_Model
      * $confirmationMethod - qsl, lotw or both, use anything else to skip confirmed
      */
     function get_vucc_summary($band, $confirmationMethod) {
-		$CI =& get_instance();
-		$CI->load->model('logbooks_model');
-		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+	    $CI =& get_instance();
+	    $CI->load->model('logbooks_model');
+	    $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-        if (!$logbooks_locations_array) {
-            return null;
-        }
+	    if (!$logbooks_locations_array) {
+		    return null;
+	    }
 
-		$location_list = "'".implode("','",$logbooks_locations_array)."'";
+	    $location_list = "'".implode("','",$logbooks_locations_array)."'";
 
-        $sql = "select distinct upper(substring(col_gridsquare, 1, 4)) gridsquare
-            from " . $this->config->item('table_name') .
-            " where station_id in (" . $location_list . ")" .
-            " and col_gridsquare <> ''";
+	    $sql = "select distinct upper(substring(log.col_gridsquare, 1, 4)) gridsquare
+		    from " . $this->config->item('table_name') . " log".
+		    " inner join bands b on (b.band = log.col_band) ".
+		    " where log.station_id in (" . $location_list . ")" .
+		    " and log.col_gridsquare <> ''".
+		    " and b.bandgroup in ('vhf','uhf','shf','sat')";
 
-        if ($confirmationMethod == 'both') {
-            $sql .= " and (col_qsl_rcvd='Y' or col_lotw_qsl_rcvd='Y')";
-        }
-        else if ($confirmationMethod == 'qsl') {
-            $sql .= " and col_qsl_rcvd='Y'";
-        }
-        else if ($confirmationMethod == 'lotw') {
-            $sql .= " and col_lotw_qsl_rcvd='Y'";
-        }
+	    if ($confirmationMethod == 'both') {
+		    $sql .= " and (log.col_qsl_rcvd='Y' or log.col_lotw_qsl_rcvd='Y')";
+	    } else if ($confirmationMethod == 'qsl') {
+		    $sql .= " and log.col_qsl_rcvd='Y'";
+	    } else if ($confirmationMethod == 'lotw') {
+		    $sql .= " and log.col_lotw_qsl_rcvd='Y'";
+	    }
 
-        if ($band != 'All') {
-            if ($band == 'SAT') {
-                $sql .= " and col_prop_mode ='" . $band . "'";
-            } else {
-                $sql .= " and col_prop_mode !='SAT'";
-                $sql .= " and col_band ='" . $band . "'";
-            }
-        }
+	    if ($band != 'All') {
+		    if ($band == 'SAT') {
+			    $sql .= " and log.col_prop_mode ='" . $band . "'";
+		    } else {
+			    $sql .= " and log.col_prop_mode !='SAT'";
+			    $sql .= " and log.col_band ='" . $band . "'";
+		    }
+	    } else {
+		    $sql .= " and log.col_prop_mode !='SAT'";
+	    }
+	    $query = $this->db->query($sql);
 
-        $query = $this->db->query($sql);
-
-        return $query->result_array();
+	    return $query->result_array();
     }
 
     /*
@@ -333,12 +334,12 @@ class VUCC extends CI_Model
     /*
     * Builds the array to display worked/confirmed vucc on dashboard page
     */
-    function fetchVuccSummary() {
+    function fetchVuccSummary($band = 'All') {
         $totalGridConfirmed = array();
         $totalGridWorked = array();
     
             // Getting all the worked grids
-            $col_gridsquare_worked = $this->get_vucc_summary('All', 'none');
+            $col_gridsquare_worked = $this->get_vucc_summary($band, 'none');
     
             $workedGridArray = array();
             if ($col_gridsquare_worked != null) {
@@ -350,7 +351,7 @@ class VUCC extends CI_Model
                 }
             }
     
-            $col_vucc_grids_worked = $this->get_vucc_summary_col_vucc('All', 'none');
+            $col_vucc_grids_worked = $this->get_vucc_summary_col_vucc($band, 'none');
     
             if ($col_vucc_grids_worked != null) {
                 foreach ($col_vucc_grids_worked as $gridSplit) {
@@ -370,7 +371,7 @@ class VUCC extends CI_Model
             }
     
             // Getting all the confirmed grids
-            $col_gridsquare_confirmed = $this->get_vucc_summary('All', 'both');
+            $col_gridsquare_confirmed = $this->get_vucc_summary($band, 'both');
     
             if ($col_gridsquare_confirmed != null) {
                 $confirmedGridArray = array();
@@ -382,7 +383,7 @@ class VUCC extends CI_Model
                 }
             }
     
-            $col_vucc_grids_confirmed = $this->get_vucc_summary_col_vucc('All', 'both');
+            $col_vucc_grids_confirmed = $this->get_vucc_summary_col_vucc($band, 'both');
     
             if ($col_vucc_grids_confirmed != null) {
                 foreach ($col_vucc_grids_confirmed as $gridSplit) {
@@ -401,8 +402,8 @@ class VUCC extends CI_Model
                 }
             }
     
-        $vuccArray['All']['worked'] = count($totalGridWorked);
-        $vuccArray['All']['confirmed'] = count($totalGridConfirmed);
+        $vuccArray[$band]['worked'] = count($totalGridWorked);
+        $vuccArray[$band]['confirmed'] = count($totalGridConfirmed);
     
         return $vuccArray;
     }

--- a/application/models/Vucc.php
+++ b/application/models/Vucc.php
@@ -158,8 +158,11 @@ class VUCC extends CI_Model
 		    from " . $this->config->item('table_name') . " log".
 		    " inner join bands b on (b.band = log.col_band) ".
 		    " where log.station_id in (" . $location_list . ")" .
-		    " and log.col_gridsquare <> ''".
-		    " and b.bandgroup in ('vhf','uhf','shf','sat')";
+		    " and log.col_gridsquare <> ''";
+		    
+	    if (($band == 'SAT') || ($band == 'All')) {
+		$sql.=" and b.bandgroup in ('vhf','uhf','shf','sat')";
+	    }
 
 	    if ($confirmationMethod == 'both') {
 		    $sql .= " and (log.col_qsl_rcvd='Y' or log.col_lotw_qsl_rcvd='Y')";

--- a/application/views/awards/vucc/index.php
+++ b/application/views/awards/vucc/index.php
@@ -25,13 +25,11 @@
             </thead>
             <tbody>
                 <?php foreach($vucc_array as $band => $vucc) {
-			if ($vucc['worked'] > 0) {
 				echo '<tr>';
 				echo '<td><a href=\'vucc_band?Band="'. $band . '"\'>'. $band .'</td>';
 				echo '<td><a href=\'vucc_band?Band="'. $band . '"&Type="worked"\'>'. $vucc['worked'] .'</td>';
 				echo '<td><a href=\'vucc_band?Band="'. $band . '"&Type="confirmed"\'>'. $vucc['confirmed'] .'</td>';
 				echo '</tr>';
-			}
                 }
                 ?>
             </tbody>

--- a/application/views/awards/vucc/index.php
+++ b/application/views/awards/vucc/index.php
@@ -25,11 +25,13 @@
             </thead>
             <tbody>
                 <?php foreach($vucc_array as $band => $vucc) {
-                    echo '<tr>';
-                    echo '<td><a href=\'vucc_band?Band="'. $band . '"\'>'. $band .'</td>';
-                    echo '<td><a href=\'vucc_band?Band="'. $band . '"&Type="worked"\'>'. $vucc['worked'] .'</td>';
-                    echo '<td><a href=\'vucc_band?Band="'. $band . '"&Type="confirmed"\'>'. $vucc['confirmed'] .'</td>';
-                    echo '</tr>';
+			if ($vucc['worked'] > 0) {
+				echo '<tr>';
+				echo '<td><a href=\'vucc_band?Band="'. $band . '"\'>'. $band .'</td>';
+				echo '<td><a href=\'vucc_band?Band="'. $band . '"&Type="worked"\'>'. $vucc['worked'] .'</td>';
+				echo '<td><a href=\'vucc_band?Band="'. $band . '"&Type="confirmed"\'>'. $vucc['confirmed'] .'</td>';
+				echo '</tr>';
+			}
                 }
                 ?>
             </tbody>

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -308,17 +308,20 @@ function echoQrbCalcLink($mygrid, $grid, $vucc) {
 		<?php if((($this->config->item('use_auth') && ($this->session->userdata('user_type') >= 2)) || $this->config->item('use_auth') === FALSE)) { ?>
     	 <table class="table table-striped">
         <tr class="titles">
-            <td colspan="2"><i class="fas fa-globe-europe"></i> VHF/UHF Century Club (VUCC)</td>
+            <td colspan="2"><i class="fas fa-globe-europe"></i> VUCC-Grids</td>
+            <td colspan="1">SAT</td>
         </tr>
 
         <tr>
             <td width="50%"><?php echo lang('general_word_worked'); ?></td>
-            <td width="50%"><?php echo $vucc['All']['worked']; ?></td>
+            <td width="25%"><?php echo $vucc['All']['worked']; ?></td>
+            <td width="25%"><?php echo $vuccSAT['SAT']['worked'] ?? '0'; ?></td>
         </tr>
 
         <tr>
             <td width="50%"><?php echo lang('general_word_confirmed'); ?></td>
-            <td width="50%"><?php echo $vucc['All']['confirmed']; ?></td>
+            <td width="25%"><?php echo $vucc['All']['confirmed']; ?></td>
+            <td width="25%"><?php echo $vuccSAT['SAT']['confirmed'] ?? '0'; ?></td>
         </tr>
 
     </table>


### PR DESCRIPTION
Should fix #2714 

Old behaviour:
- Every grid was counted at Dashboard (ignore of Band / Mode)

New behaviour:
- Only >6m is counted. It's splitted into two columns:
- All QSOs >6m (except SAT)
- Only SAT

<img width="366" alt="VUCC Dashboard Screenshot" src="https://github.com/magicbug/Cloudlog/assets/1410708/e3295bdb-42d0-42e5-97ae-cb99806ab4ff">
