### PR TITLE
crlf and newline bugfix

### DIFF
--- a/application/controllers/Options.php
+++ b/application/controllers/Options.php
@@ -360,6 +360,8 @@ class Options extends CI_Controller {
 					'smtp_port' => $this->optionslib->get_option('smtpPort'),
 					'smtp_user' => $this->optionslib->get_option('smtpUsername'),
 					'smtp_pass' => $this->optionslib->get_option('smtpPassword'),
+					'crlf' => "\r\n",
+					'newline' => "\r\n"
 				);
 
 				$this->email->initialize($config);

--- a/application/controllers/Oqrs.php
+++ b/application/controllers/Oqrs.php
@@ -174,6 +174,8 @@ class Oqrs extends CI_Controller {
 						'smtp_port' => $this->optionslib->get_option('smtpPort'),
 						'smtp_user' => $this->optionslib->get_option('smtpUsername'),
 						'smtp_pass' => $this->optionslib->get_option('smtpPassword'),
+						'crlf' => "\r\n",
+						'newline' => "\r\n"
 					);
 
 					$this->email->initialize($config);

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -718,6 +718,8 @@ class User extends CI_Controller {
 						'smtp_port' => $this->optionslib->get_option('smtpPort'),
 						'smtp_user' => $this->optionslib->get_option('smtpUsername'),
 						'smtp_pass' => $this->optionslib->get_option('smtpPassword'),
+						'crlf' => "\r\n",
+						'newline' => "\r\n"
 					  );
 
 					  $this->email->initialize($config);


### PR DESCRIPTION
Contrary to my previous assumption CRLF and Newline is needed in the sendmail function