### PR TITLE
no need to press save twice

### DIFF
--- a/application/controllers/Options.php
+++ b/application/controllers/Options.php
@@ -272,7 +272,11 @@ class Options extends CI_Controller {
 				$smtpEncryptionupdate = $this->optionslib->update('smtpEncryption', $this->input->post('smtpEncryption'), 'yes');
 
 				// Update email sender name within the options system
-				$emailSenderNameupdate = $this->optionslib->update('emailSenderName', $this->input->post('emailSenderName'), 'yes');
+				$emailSenderName_value = $this->input->post('emailSenderName');
+				if (empty($emailSenderName_value)) {
+					$emailSenderName_value = 'Cloudlog';
+				}
+				$emailSenderNameupdate = $this->optionslib->update('emailSenderName', $emailSenderName_value, 'yes');
 
 				// Update email address choice within the options system
 				$emailAddressupdate = $this->optionslib->update('emailAddress', $this->input->post('emailAddress'), 'yes');

--- a/application/views/options/email.php
+++ b/application/views/options/email.php
@@ -63,7 +63,7 @@
                         <div class="form-group row">
                             <label for="emailSenderName" class="col-sm-2 col-form-label"><?php echo lang('options_email_sender_name'); ?></label>
                             <div class="col-sm-10">
-                                <input type="text" name="emailSenderName" class="form-control" id="emailSenderName" value="<?php echo ($this->optionslib->get_option('emailSenderName') == "" ? 'Cloudlog' : $this->optionslib->get_option('emailSenderName'));?>">
+                                <input type="text" name="emailSenderName" class="form-control" id="emailSenderName" value="<?php if($this->optionslib->get_option('emailSenderName') != "") { echo $this->optionslib->get_option('emailSenderName'); } ?>">
                                 <small class="form-text text-muted"><?php echo lang('options_email_sender_name_hint'); ?></small>
                             </div>
                         </div>


### PR DESCRIPTION
It's because of the SenderName

Old logic:

If field is empty 
-> save empty string to db 
-> Show Cloudlog in SenderName in View

DB is still empty and sendername is not used. So you need to press save again to write default SenderName to DB


New:

If field is empty
-> set default SenderName to "Cloudlog"
-> write to DB
-> Field in View shows Cloudlog because its already in DB