### PR TITLE
Concat QSO IDs in PHP rather than SQL

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -8,14 +8,15 @@ class Logbookadvanced_model extends CI_Model {
 		$binding = [$searchCriteria['user_id']];
 
 		if ((isset($searchCriteria['dupes'])) && ($searchCriteria['dupes'] !== '')) {
-			$id_sql="select group_concat(x.qsoids separator ',') as QSO_IDs from (
-				select GROUP_CONCAT(col_primary_key separator ',') as qsoids, COL_CALL, COL_MODE, COL_SUBMODE, station_callsign, COL_SAT_NAME, COL_BAND,  min(col_time_on) Mintime, max(col_time_on) Maxtime from " . $this->config->item('table_name') . "
+			$id_sql="select GROUP_CONCAT(col_primary_key separator ',') as qsoids, COL_CALL, COL_MODE, COL_SUBMODE, station_callsign, COL_SAT_NAME, COL_BAND,  min(col_time_on) Mintime, max(col_time_on) Maxtime from " . $this->config->item('table_name') . "
 				 join station_profile on " . $this->config->item('table_name') . ".station_id = station_profile.station_id where station_profile.user_id=?
-				group by col_call, col_mode, COL_SUBMODE, STATION_CALLSIGN, col_band, COL_SAT_NAME having count(*) > 1 and timediff(maxtime, mintime) < 3000) x";
+				group by col_call, col_mode, COL_SUBMODE, STATION_CALLSIGN, col_band, COL_SAT_NAME having count(*) > 1 and timediff(maxtime, mintime) < 3000";
 			$id_query = $this->db->query($id_sql, $searchCriteria['user_id']);
+			$ids2fetch = '';
 			foreach ($id_query->result() as $id) {
-				$ids2fetch=$id->QSO_IDs;
+				$ids2fetch .= ','.$id->qsoids;
 			}
+			$ids2fetch = ltrim($ids2fetch, ',');
 			if ($ids2fetch ?? '' !== '') {
 				$conditions[] = "qsos.COL_PRIMARY_KEY in (".$ids2fetch.")";
 			} else {
@@ -23,8 +24,8 @@ class Logbookadvanced_model extends CI_Model {
 			}
 		}
 
-        if ($searchCriteria['dateFrom'] !== '') {
-            $from = DateTime::createFromFormat('d/m/Y', $searchCriteria['dateFrom']);
+		if ($searchCriteria['dateFrom'] !== '') {
+			$from = DateTime::createFromFormat('d/m/Y', $searchCriteria['dateFrom']);
 			$from = $from->format('Y-m-d');
 			$conditions[] = "date(COL_TIME_ON) >= ?";
 			$binding[] = $from;


### PR DESCRIPTION
The group_concat function of mySQL is limited to 1024 chars (for old(er) DBs). So we should concat all dupe QSO IDs in PHP to prevent this. 