### PR TITLE
Fix SQL errors on migration

### DIFF
--- a/application/migrations/154_create_dxpedition_table.php
+++ b/application/migrations/154_create_dxpedition_table.php
@@ -19,7 +19,8 @@ class Migration_create_dxpedition_table extends CI_Migration
                     'type' => 'INT',
                     'constraint' => 6,
                     'unsigned' => TRUE,
-                    'auto_increment' => TRUE
+                    'auto_increment' => TRUE,
+                    'null' => FALSE
                 ),
                 'start_date' => array(
                     'type' => 'DATE',
@@ -32,7 +33,7 @@ class Migration_create_dxpedition_table extends CI_Migration
                 'callsign' => array(
                     'type' => 'VARCHAR',
                     'constraint' => '255',
-                    'null' => TRUE,
+                    'null' => FALSE,
                 ),
                 'country' => array(
                     'type' => 'VARCHAR',


### PR DESCRIPTION
The current migration 154 throws some SQL errors:

![Screenshot from 2023-11-24 07-43-40](https://github.com/magicbug/Cloudlog/assets/7112907/084d21c8-4791-4c75-96bd-bb41b222b39b)

So we need to set the parts of the primary key to be not null.