### PR TITLE
Allow for callsign selection upon LoTW download

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -746,9 +746,9 @@ class Lotw extends CI_Controller {
 			$lotw_url .= "&qso_qslsince=";
 			$lotw_url .= "$lotw_last_qsl_date";
 
-			// Only pull back entries that belong to this callsign
-			$lotw_call = $this->session->userdata('user_callsign');
-			$lotw_url .= "&qso_owncall=$lotw_call";
+			if ($this->input->post('callsign') != '0') {
+				$lotw_url .= "&qso_owncall=".$this->input->post('callsign');
+			}
 
 			file_put_contents($file, file_get_contents($lotw_url));
 
@@ -761,9 +761,11 @@ class Lotw extends CI_Controller {
 			{
 
 				$data['error'] = $this->upload->display_errors();
+				$this->load->model('Stations');
+				$data['callsigns'] = $this->Stations->callsigns_of_user($this->session->userdata('user_id'));
 
 				$this->load->view('interface_assets/header', $data);
-				$this->load->view('lotw/import');
+				$this->load->view('lotw/import', $data);
 				$this->load->view('interface_assets/footer');
 			}
 			else

--- a/application/language/bulgarian/lotw_lang.php
+++ b/application/language/bulgarian/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Upload the Exported ADIF fi
 $lang['lotw_upload_type_must_be_adi'] = 'Log files must have the file type .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Pull LoTW data for me';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] = 'Cloudlog will use the LoTW username and password stored in your user profile to download a report from LoTW for you. The report Cloudlog downloads will have all confirmations since chosen date, or since your last LoTW confirmation (fetched from your log), up until now.';
 

--- a/application/language/chinese_simplified/lotw_lang.php
+++ b/application/language/chinese_simplified/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = '下载从 LoTW <a href="htt
 $lang['lotw_upload_type_must_be_adi'] = '日志文件的类型必须为 .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = '为我拉取 LoTW 数据';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] ='Cloudlog 将会使用储存在你个人用户信息当中的 LoTW 用户名和密码从 LoTW 上为你下载报告。Cloudlog 下载的这份报告将会包括自你所选之日以来的或者你最后的 LoTW 确认信息（目前日志当中）以来的所有确认。';
 

--- a/application/language/czech/lotw_lang.php
+++ b/application/language/czech/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Nahraj exportovaný soubor 
 $lang['lotw_upload_type_must_be_adi'] = 'Deník musí být ve formátu .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Stáhni data z LoTW';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] ='Cloudlog použije uživatelské jméno a heslo LoTW uložené ve vašem uživatelském profilu, aby vám stáhl datz LoTW.Stažen budu data od nastaveného datumu nebo od posledního stažení až do teď.';
 

--- a/application/language/dutch/lotw_lang.php
+++ b/application/language/dutch/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Upload the Exported ADIF fi
 $lang['lotw_upload_type_must_be_adi'] = 'Log files must have the file type .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Pull LoTW data for me';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] = 'Cloudlog will use the LoTW username and password stored in your user profile to download a report from LoTW for you. The report Cloudlog downloads will have all confirmations since chosen date, or since your last LoTW confirmation (fetched from your log), up until now.';
 

--- a/application/language/english/lotw_lang.php
+++ b/application/language/english/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Upload the Exported ADIF fi
 $lang['lotw_upload_type_must_be_adi'] = 'Log files must have the file type .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Pull LoTW data for me';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] = 'Cloudlog will use the LoTW username and password stored in your user profile to download a report from LoTW for you. The report Cloudlog downloads will have all confirmations since chosen date, or since your last LoTW confirmation (fetched from your log), up until now.';
 

--- a/application/language/finnish/lotw_lang.php
+++ b/application/language/finnish/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Lataa ADIF-tiedosto LoTW:n 
 $lang['lotw_upload_type_must_be_adi'] = 'Lokitiedoston pitää olla ADI-tiedosto --> .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Lataa ja tuo LoTW:n data';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] ='Cloudlog käyttää profiiliisi tallennettuja LoTW:n käyttäjätietoja lokikoosteen lataamiseen. Lokikooste sisältää tähän päivään asti kaikki kuitatut yhteydet, alkaen valitsemastasi päivästä tai siitä päivästä kun olet viimeksi ne palvelusta ladannut .';
 

--- a/application/language/french/lotw_lang.php
+++ b/application/language/french/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = "Envoyer le fichier ADIF exp
 $lang['lotw_upload_type_must_be_adi'] = "Les fichiers de log doivent être au format .adi";
 
 $lang['lotw_pull_lotw_data_for_me'] = "Récuperer mes données LoTW";
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] = "Cloudlog utilisera le nom d'utilisateur et le mot de passe LoTW stockés dans votre profil utilisateur pour télécharger le journal vers LoTW.<br/> Les téléchargements du journal Cloudlog auront toutes les confirmations depuis la date choisie, ou depuis votre dernière confirmation LoTW (récupérée de votre journal), jusqu'à présent.";
 

--- a/application/language/german/lotw_lang.php
+++ b/application/language/german/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Lade die exportierte ADIF-D
 $lang['lotw_upload_type_must_be_adi'] = 'Logdateien müssen den Dateityp .adi haben';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Lade LoTW-Daten für mich';
+$lang['lotw_select_callsign'] = 'Rufzeichen, für das LoTW Bestätigungen geladen werden sollen';
 
 $lang['lotw_report_download_overview_helptext'] = 'Cloudlog nutzt Benutzername und Passwort, welche in Deinem Benutzerprofil gespeichert sind, um einen Report vom LoTW zu laden. Der Report, den Cloudlog lädt, enthält alle Bestätigungen seit dem gewählten Datum oder seit der letzen LoTW-Bestätigung (wird aus Deinem Log extrahiert) bis jetzt.';
 

--- a/application/language/greek/lotw_lang.php
+++ b/application/language/greek/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Μεταφορτώστε τ
 $lang['lotw_upload_type_must_be_adi'] = 'Τα αρχεία καταγραφής πρέπει να έχουν τον τύπο αρχείου .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Τραβήξτε δεδομένα LoTW για μένα';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] = 'Το Cloudlog θα χρησιμοποιήσει το όνομα χρήστη και τον κωδικό πρόσβασης LoTW που είναι αποθηκευμένα στο προφίλ χρήστη σας για να πραγματοποιήσει λήψη μιας αναφοράς από το LoTW για εσάς. Οι λήψεις αναφοράς Cloudlog θα έχουν όλες τις επιβεβαιώσεις από την επιλεγμένη ημερομηνία ή από την τελευταία επιβεβαίωση LoTW (που ελήφθη από το αρχείο καταγραφής σας), μέχρι τώρα.';
 

--- a/application/language/italian/lotw_lang.php
+++ b/application/language/italian/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Carica il file ADIF Esporta
 $lang['lotw_upload_type_must_be_adi'] = 'I file di log devono essere di tipo .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Ottieni dati da LoTW per me';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] ='Cloudlog userà il nome utente e password LoTW memorizzato nel tuo profilo per scaricare un report da LoTW per te. Il report scaricato da Cloudlog avrà tutte le conferme fino alla data scelta, o fino alla ultima conferma su LoTW (recuperato dal tuo log), fino ad ora.';
 

--- a/application/language/polish/lotw_lang.php
+++ b/application/language/polish/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Wyślij pobrany plik ADIF z
 $lang['lotw_upload_type_must_be_adi'] = 'Pliki logu muszą mieć rozszerzenie .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Pobierz dane z LoTW za mnie';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] ='Cloudlog będzie używał loginu i hasła podanego w profilu, aby pobierać raporty z LoTW.Raport będzie zawierał wszystkie potwierdzenia od wybranej daty, lub ostatniej potwierdzonej łączności z LoTW (wybranej z logiu), do teraz.';
 

--- a/application/language/russian/lotw_lang.php
+++ b/application/language/russian/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Загрузить эксп
 $lang['lotw_upload_type_must_be_adi'] = 'Файлы журнала должны быть с расширением .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Подтянуть мои данные из LoTW';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] ='Cloudlog использует логин и пароль для LoTW, сохранённые в вашем профиле, для того чтобы скачивать ваши журналы с LoTW. Журнал, скачанный в Cloudlog будет содержать все подтверждения, начиная с выбранной даты, или начиная с последнего подтверждения в LoTW (загруженного из вашего журнала), до настоящего момента.';
 

--- a/application/language/spanish/lotw_lang.php
+++ b/application/language/spanish/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Suba el archivo ADIF export
 $lang['lotw_upload_type_must_be_adi'] = 'Los archivos de registro deben ser del tipo .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Extraer los datos LoTW por mí';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] ='Cloudlog usará el usuario y contraseña de LoTW guardado en su perfil para descargar un informe de LoTW por usted. El informe contendrá todas las confirmaciones desde la fecha elegida o desde su última confirmación LoTW hasta ahora.';
 

--- a/application/language/swedish/lotw_lang.php
+++ b/application/language/swedish/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'Ladda upp exporterad ADIF f
 $lang['lotw_upload_type_must_be_adi'] = 'Loggfil måste vara av format .adi';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Hämta LoTW data';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] = 'Cloudlog använder LoTW användarnamn och lösenord som är sparat i din användarprofil för att ladda ner repport från LoTW. Rapporten Cloudlog kommer att ladda ner kommer att ha alla bekräftelser sedan valt datum, eller sedan din senaste LoTW-bekräftelse (hämtad från din logg), fram till nu.';
 

--- a/application/language/turkish/lotw_lang.php
+++ b/application/language/turkish/lotw_lang.php
@@ -34,6 +34,7 @@ $lang['lotw_upload_exported_adif_file_from_lotw'] = 'LoTW\'den Dışa Aktarılan
 $lang['lotw_upload_type_must_be_adi'] = 'Günlük dosyaları .adi dosya tipine sahip olmalıdır';
 
 $lang['lotw_pull_lotw_data_for_me'] = 'Benim için LoTW verilerini çek';
+$lang['lotw_select_callsign'] = 'Select callsign to pull LoTW confirmations for';
 
 $lang['lotw_report_download_overview_helptext'] ='Cloudlog, sizin için LoTW\'den bir rapor indirmek için kullanıcı profilinizde kayıtlı LoTW kullanıcı adını ve şifreyi kullanacak. Cloudlog indirmeleri raporu, seçilen tarihten itibaren veya son LoTW onayınızdan (günlüğünüzden alınır) bu yana şimdiye kadarki tüm onaylara sahip olacaktır.';
 

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -24,12 +24,21 @@ class Stations extends CI_Model {
 	}
 
 	function all_of_user($userid = null) {
-		if ($userid == null) { 
+		if ($userid == null) {
 			$userid=$this->session->userdata('user_id'); // Fallback to session-uid, if userid is omitted
 		}
 		$this->db->select('station_profile.*, dxcc_entities.name as station_country, dxcc_entities.end as dxcc_end');
 		$this->db->where('user_id', $userid);
 		$this->db->join('dxcc_entities','station_profile.station_dxcc = dxcc_entities.adif','left outer');
+		return $this->db->get('station_profile');
+	}
+
+	function callsigns_of_user($userid = null) {
+		if ($userid == null) {
+			$userid=$this->session->userdata('user_id'); // Fallback to session-uid, if userid is omitted
+		}
+		$this->db->select('distinct(station_profile.station_callsign) as callsign');
+		$this->db->where('user_id', $userid);
 		return $this->db->get('station_profile');
 	}
 

--- a/application/views/lotw/import.php
+++ b/application/views/lotw/import.php
@@ -36,6 +36,21 @@
           </div>
       </div>
       <br/>
+      <div class="row">
+        <div class="col-md-4">
+          <label class="form-check-label" for="callsign"><?php echo lang('lotw_select_callsign'); ?></label>
+          <?php
+            $options = [];
+            foreach ($callsigns->result() as $call) {
+               $options[$call->callsign] = $call->callsign;
+            }
+            ksort($options);
+            array_unshift($options, 'All');
+            echo form_dropdown('callsign', $options, 'All');
+          ?>
+        </div>
+      </div>
+      <br />
 
       <p class="form-text text-muted"><?php echo lang('lotw_report_download_overview_helptext'); ?></p>
     </div>

--- a/application/views/lotw/import.php
+++ b/application/views/lotw/import.php
@@ -1,9 +1,9 @@
 <div class="container lotw">
 
   <h2><?php echo lang('lotw_title'); ?> - <?php echo lang('lotw_title_adif_import'); ?></h2>
-  
+
 <div class="card">
-	<div class="card-header"><?php echo lang('lotw_title_adif_import_options'); ?></div>
+  <div class="card-header"><?php echo lang('lotw_title_adif_import_options'); ?></div>
   <div class="card-body">
 
     <?php $this->load->view('layout/messages'); ?>
@@ -16,21 +16,16 @@
 
       <p><?php echo lang('lotw_upload_exported_adif_file_from_lotw'); ?></p>
       <p><span class="badge badge-info"><?php echo lang('general_word_important'); ?></span> <?php echo lang('lotw_upload_type_must_be_adi'); ?></p>
-      
+
       <div class="custom-file">
           <input type="file" class="custom-file-input" id="adiffile" name="userfile" size="20" />
         <label class="custom-file-label" for="adiffile"><?php echo lang('general_word_choose_file'); ?></label>
       </div>
 
-    </div>
+      <br><br>
 
-
-		<br><br>
-
-		<div class="custom-control custom-radio">
-			<input type="radio" name="lotwimport" id="fetch" class="custom-control-input" value="fetch" checked="checked" />
-			<label class="custom-control-label" for="fetch"><?php echo lang('lotw_pull_lotw_data_for_me'); ?></label>
-		</div>
+      <input type="radio" name="lotwimport" id="fetch" class="form-check-input" value="fetch" checked="checked" />
+      <label class="form-check-label" for="fetch"><?php echo lang('lotw_pull_lotw_data_for_me'); ?></label>
       <p class="card-text"><?php echo lang('gen_from_date'); ?>:</p>
       <div class="row">
           <div class="input-group date col-md-3" id="datetimepicker1" data-target-input="nearest">
@@ -42,11 +37,12 @@
       </div>
       <br/>
 
-		<p class="form-text text-muted"><?php echo lang('lotw_report_download_overview_helptext'); ?></p>
+      <p class="form-text text-muted"><?php echo lang('lotw_report_download_overview_helptext'); ?></p>
+    </div>
 
-		<input class="btn btn-primary" type="submit" value="<?php echo lang('lotw_btn_import_matches'); ?>" />
+    <input class="btn btn-primary" type="submit" value="<?php echo lang('lotw_btn_import_matches'); ?>" />
 
-	</form>
+    </form>
   </div>
 </div>
 


### PR DESCRIPTION
The GUI function for LoTW imports does not allow to select the callsign the confirmations should be downloaded for. So we add a dropdown and some code that allow to select a specific one or donwload for all user's callsigns if All is selected. The current code only downloads for logged-in user (whereas the cronjob downloads for all which is a bit of a difference).