### PR TITLE
Changing default environment to production

### DIFF
--- a/index.php
+++ b/index.php
@@ -53,8 +53,8 @@
  *
  * NOTE: If you change these, also change the error_reporting() code below
  */
-	#define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development');
-	define('ENVIRONMENT', 'development');
+	define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'production');
+	#define('ENVIRONMENT', 'development');
 
 /*
  *---------------------------------------------------------------


### PR DESCRIPTION
Fixing #2696 

For future reference, if development or testing mode is needed, all you need is to set the `CI_ENV` variable in apache2 by creating a file called `.htaccess` in the root of cloudlog (where the main `index.php` is) containing:

```
SetEnv CI_ENV development
```

And then refresh the page, the new environment should be automatically set. Tested on Ubuntu 22.04

Documentation: https://www.codeigniter.com/user_guide/general/environments.html