### PR TITLE
Add user-selectable 'Name' column

### DIFF
--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -15,6 +15,7 @@ function echo_table_header_col($ctx, $name) {
 		case 'Band': echo '<th>'.$ctx->lang->line('gen_hamradio_band').'</th>'; break;
 		case 'Frequency': echo '<th>'.$ctx->lang->line('gen_hamradio_frequency').'</th>'; break;
 		case 'Operator': echo '<th>'.$ctx->lang->line('gen_hamradio_operator').'</th>'; break;
+		case 'Name': echo '<th>'.$ctx->lang->line('general_word_name').'</th>'; break;
 	}
 }
 
@@ -35,6 +36,7 @@ function echo_table_col($row, $name) {
 		case 'Frequency':    echo '<td>'; if($row->COL_SAT_NAME != null) { echo '<a href="https://db.satnogs.org/search/?q='.$row->COL_SAT_NAME.'" target="_blank">'.$row->COL_SAT_NAME.'</a></td>'; } else { if($row->COL_FREQ != null) { echo $ci->frequency->hz_to_mhz($row->COL_FREQ); } else { echo strtolower($row->COL_BAND); } } echo '</td>'; break;
 		case 'State':   echo '<td>' . ($row->COL_STATE) . '</td>'; break;
 		case 'Operator': echo '<td>' . ($row->COL_OPERATOR) . '</td>'; break;
+		case 'Name': echo '<td>' . ($row->COL_NAME) . '</td>'; break;
 	}
 }
 

--- a/application/views/user/add.php
+++ b/application/views/user/add.php
@@ -355,6 +355,8 @@
                                             <?php echo lang('gen_hamradio_distance'); ?></option>
                                         <option value="Operator">
                                             <?php echo lang('gen_hamradio_operator'); ?></option>
+                                        <option value="Name">
+                                            <?php echo lang('general_word_name'); ?></option>
                                     </select>
                                 </div>
 
@@ -386,6 +388,8 @@
                                             <?php echo lang('gen_hamradio_distance'); ?></option>
                                         <option value="Operator">
                                             <?php echo lang('gen_hamradio_operator'); ?></option>
+                                        <option value="Name">
+                                            <?php echo lang('general_word_name'); ?></option>
                                     </select>
                                 </div>
 
@@ -417,6 +421,8 @@
                                             <?php echo lang('gen_hamradio_distance'); ?></option>
                                         <option value="Operator">
                                             <?php echo lang('gen_hamradio_operator'); ?></option>
+                                        <option value="Name">
+                                            <?php echo lang('general_word_name'); ?></option>
                                     </select>
                                 </div>
 
@@ -448,6 +454,8 @@
                                             <?php echo lang('gen_hamradio_distance'); ?></option>
                                         <option value="Operator">
                                             <?php echo lang('gen_hamradio_operator'); ?></option>
+                                        <option value="Name">
+                                            <?php echo lang('general_word_name'); ?></option>
                                     </select>
                                 </div>
 
@@ -480,6 +488,8 @@
                                             <?php echo lang('gen_hamradio_distance'); ?></option>
                                         <option value="Operator">
                                             <?php echo lang('gen_hamradio_operator'); ?></option>
+                                        <option value="Name">
+                                            <?php echo lang('general_word_name'); ?></option>
                                         <option value="Location">
                                             <?php echo lang('cloudlog_station_profile'); ?></option>
                                     </select>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -399,6 +399,7 @@
 								<option value="Grid" <?php if ($user_column1 == "Grid") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_gridsquare'); ?></option>
 								<option value="Distance" <?php if ($user_column1 == "Distance") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_distance'); ?></option>
 								<option value="Operator" <?php if ($user_column1 == "Operator") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_operator'); ?></option>
+								<option value="Name" <?php if ($user_column1 == "Name") { echo " selected =\"selected\""; } ?>><?php echo lang('general_word_name'); ?></option>
 							</select>
 						</div>
 
@@ -419,6 +420,7 @@
 								<option value="Grid" <?php if ($user_column2 == "Grid") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_gridsquare'); ?></option>
 								<option value="Distance" <?php if ($user_column2 == "Distance") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_distance'); ?></option>
 								<option value="Operator" <?php if ($user_column2 == "Operator") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_operator'); ?></option>
+								<option value="Name" <?php if ($user_column2 == "Name") { echo " selected =\"selected\""; } ?>><?php echo lang('general_word_name'); ?></option>
 							</select>
 							</div>
 
@@ -439,6 +441,7 @@
 								<option value="Grid" <?php if ($user_column3 == "Grid") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_gridsquare'); ?></option>
 								<option value="Distance" <?php if ($user_column3 == "Distance") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_distance'); ?></option>
 								<option value="Operator" <?php if ($user_column3 == "Operator") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_operator'); ?></option>
+								<option value="Name" <?php if ($user_column3 == "Name") { echo " selected =\"selected\""; } ?>><?php echo lang('general_word_name'); ?></option>
 							</select>
 							</div>
 
@@ -459,6 +462,7 @@
 								<option value="Grid" <?php if ($user_column4 == "Grid") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_gridsquare'); ?></option>
 								<option value="Distance" <?php if ($user_column4 == "Distance") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_distance'); ?></option>
 								<option value="Operator" <?php if ($user_column4 == "Operator") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_operator'); ?></option>
+								<option value="Name" <?php if ($user_column4 == "Name") { echo " selected =\"selected\""; } ?>><?php echo lang('general_word_name'); ?></option>
 							</select>
 						</div>
 							<div class="mb-3 col-md-12">
@@ -479,6 +483,7 @@
 									<option value="Grid" <?php if ($user_column5 == "Grid") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_gridsquare'); ?></option>
 									<option value="Distance" <?php if ($user_column5 == "Distance") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_distance'); ?></option>
 									<option value="Operator" <?php if ($user_column5 == "Operator") { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_operator'); ?></option>
+									<option value="Name" <?php if ($user_column5 == "Name") { echo " selected =\"selected\""; } ?>><?php echo lang('general_word_name'); ?></option>
 									<option value="Location" <?php if ($user_column5 == "Location") { echo " selected =\"selected\""; } ?>><?php echo lang('cloudlog_station_profile'); ?></option>
 								</select>
 							</div>

--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -16,6 +16,7 @@ function echo_table_header_col($ctx, $name) {
 		case 'Frequency': echo '<th>'.$ctx->lang->line('gen_hamradio_frequency').'</th>'; break;
 		case 'Operator': echo '<th>'.$ctx->lang->line('gen_hamradio_operator').'</th>'; break;
 		case 'Location': echo '<th>'.$ctx->lang->line('cloudlog_station_profile').'</th>'; break;
+		case 'Name': echo '<th>'.$ctx->lang->line('general_word_name').'</th>'; break;
 	}
 }
 
@@ -37,6 +38,7 @@ function echo_table_col($row, $name) {
 		case 'State':   echo '<td>' . ($row->COL_STATE) . '</td>'; break;
 		case 'Operator':echo '<td>' . ($row->COL_OPERATOR) . '</td>'; break;
 		case 'Location':echo '<td>' . ($row->station_profile_name) . '</td>'; break;
+		case 'Name':echo '<td>' . ($row->COL_NAME) . '</td>'; break;
 	}
 }
 


### PR DESCRIPTION
This commit adds a user selectable 'Name' column to the 4 (5) user-configurable columns. There had been an 'operator'-option, which shows the operator name of the "own station", so with this change, there's also a way to show the remote operators name.

I put the option behind the 'operator'-entry and reused the 'general_word_name'-localization field.

Feedback appreciated :).