### PR TITLE
Activated Grids were calculated by whole instance QSOs, not by owner

### DIFF
--- a/application/models/Activated_gridmap_model.php
+++ b/application/models/Activated_gridmap_model.php
@@ -15,7 +15,8 @@ class Activated_gridmap_model extends CI_Model {
 
         $sql = 'SELECT DISTINCT station_gridsquare AS GRID_SQUARES, COL_BAND FROM '
            . 'station_profile JOIN '.$this->config->item('table_name').' on '.$this->config->item('table_name').'.station_id = station_profile.station_id '
-           . 'WHERE station_profile.station_gridsquare != "" ';
+           . 'WHERE station_profile.station_gridsquare != "" '
+	   . 'AND station_profile.station_id in ('.$location_list.')';
 
         if ($band != 'All') {
             if ($band == 'SAT') {
@@ -35,7 +36,6 @@ class Activated_gridmap_model extends CI_Model {
         }
 
         $sql .= $this->addQslToQuery($qsl, $lotw, $eqsl);
-
 		return $this->db->query($sql);
 	}
 
@@ -52,7 +52,8 @@ class Activated_gridmap_model extends CI_Model {
 
         $sql = 'SELECT DISTINCT station_gridsquare AS GRID_SQUARES, COL_BAND FROM '
            . 'station_profile JOIN '.$this->config->item('table_name').' on '.$this->config->item('table_name').'.station_id = station_profile.station_id '
-           . 'WHERE station_profile.station_gridsquare != "" ';
+           . 'WHERE station_profile.station_gridsquare != "" '
+	   . 'AND station_profile.station_id in ('.$location_list.')';
 
         if ($band != 'All') {
             if ($band == 'SAT') {


### PR DESCRIPTION
Before patch: All Grids anybody on the instance has activated were shown
After Patch: Only Grids which were activated by logged in User are shown