### PR TITLE
Fix some issues in LoTW controller

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -631,6 +631,12 @@ class Lotw extends CI_Controller {
 
 		if ($query->num_rows() >= 1) {
 			$result = '';
+
+			// Get URL for downloading LoTW
+			$url_query = $this->db->query('SELECT lotw_download_url FROM config');
+			$q = $url_query->row();
+			$lotw_url = $q->lotw_download_url;
+
 			foreach ($query->result() as $user) {
 				if ( ($sync_user_id != null) && ($sync_user_id != $user->user_id) ) { continue; }
 
@@ -651,11 +657,6 @@ class Lotw extends CI_Controller {
 				// Get credentials for LoTW
 		    	$data['user_lotw_name'] = urlencode($user->user_lotw_name);
 				$data['user_lotw_password'] = urlencode($user->user_lotw_password);
-
-				// Get URL for downloading LoTW
-				$query = $query = $this->db->query('SELECT lotw_download_url FROM config');
-				$q = $query->row();
-				$lotw_url = $q->lotw_download_url;
 
 				$lotw_last_qsl_date = date('Y-m-d', strtotime($this->logbook_model->lotw_last_qsl_date($user->user_id)));
 
@@ -680,9 +681,6 @@ class Lotw extends CI_Controller {
 
 				ini_set('memory_limit', '-1');
 				$result = $this->loadFromFile($file, false);
-			}
-			if ($result == '') {
-				$result = "You have not defined your ARRL LoTW credentials!";
 			}
 			return $result;
 		} else {


### PR DESCRIPTION
Fixes some issues in LoTW controller:

- Wrong error message about credentials removed (addresses https://github.com/magicbug/Cloudlog/issues/2736)
- Moved the lookup of LoTW upload URL outside the for loop as the lookup is required only once
- Removed double variable assignment of $query.