### PR TITLE
[MAP Custom] custom qso plot (renew)

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -145,6 +145,8 @@ class Dashboard extends CI_Controller {
 		echo "{\"markers\": [";
 		$count = 1;
 		foreach ($qsos->result() as $row) {
+			// check if qso is confirmed //
+			if (($row->COL_EQSL_QSL_RCVD=='Y') || ($row->COL_LOTW_QSL_RCVD=='Y') || ($row->COL_QSL_RCVD=='Y')) { $row->_is_confirmed = 'Y'; } else { $row->_is_confirmed = 'N'; }
 			//print_r($row);
 			if($row->COL_GRIDSQUARE != null) {
 				$stn_loc = $this->qra->qra2latlong($row->COL_GRIDSQUARE);
@@ -155,11 +157,11 @@ class Dashboard extends CI_Controller {
 				if($row->COL_SAT_NAME != null) {
 					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ";
 					echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE;
-					echo "\",\"label\":\"".$row->COL_CALL."\"}";
+					echo "\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				} else {
 					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ";
 					echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE;
-					echo "\",\"label\":\"".$row->COL_CALL."\"}";
+					echo "\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				}
 
 				$count++;
@@ -196,11 +198,11 @@ class Dashboard extends CI_Controller {
 				if($row->COL_SAT_NAME != null) {
 					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ";
 					echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE;
-					echo "\",\"label\":\"".$row->COL_CALL."\"}";
+					echo "\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				} else {
 					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ";
 					echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE;
-					echo "\",\"label\":\"".$row->COL_CALL."\"}";
+					echo "\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				}
 
 				$count++;
@@ -215,12 +217,18 @@ class Dashboard extends CI_Controller {
 				}
 				echo "{\"lat\":\"".$lat."\",\"lng\":\"".$lng."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ";
 				echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE;
-				echo "\",\"label\":\"".$row->COL_CALL."\"}";
+				echo "\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				$count++;
 			}
 
 		}
 		echo "]";
+		
+		// [MAP Custom] ADD Station //
+		$this->load->model('Stations');
+		$station_json = $this->Stations->get_station_json_for_map();
+		echo (!empty($station_json))?', '.$station_json:'';
+
 		echo "}";
 
 	}

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -575,6 +575,9 @@ function worked_grid_before($gridsquare, $type, $band, $mode)
 		echo "{\"markers\": [";
 		$count = 1;
 		foreach ($data['qsos']->result() as $row) {
+			// check if qso is confirmed //
+			if (($row->COL_EQSL_QSL_RCVD=='Y') || ($row->COL_LOTW_QSL_RCVD=='Y') || ($row->COL_QSL_RCVD=='Y')) { $row->_is_confirmed = 'Y'; } else { $row->_is_confirmed = 'N'; }
+
 			if($row->COL_GRIDSQUARE != null) {
 				$stn_loc = $this->qra->qra2latlong($row->COL_GRIDSQUARE);
 				if($count != 1) {
@@ -584,11 +587,11 @@ function worked_grid_before($gridsquare, $type, $band, $mode)
 				if($row->COL_SAT_NAME != null) {
 						echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ";
 						echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE;
-						echo "\",\"label\":\"".$row->COL_CALL."\"}";
+						echo "\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				} else {
 						echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ";
 						echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE;
-						echo "\",\"label\":\"".$row->COL_CALL."\"}";
+						echo "\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				}
 
 				$count++;
@@ -625,11 +628,11 @@ function worked_grid_before($gridsquare, $type, $band, $mode)
 				if($row->COL_SAT_NAME != null) {
 					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ";
 					echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE;
-					echo "\",\"label\":\"".$row->COL_CALL."\"}";
+					echo "\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				} else {
 					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ";
 					echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE;
-					echo "\",\"label\":\"".$row->COL_CALL."\"}";
+					echo "\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				}
 
 				$count++;
@@ -647,12 +650,18 @@ function worked_grid_before($gridsquare, $type, $band, $mode)
 				}
 				echo "{\"lat\":\"".$lat."\",\"lng\":\"".$lng."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ";
 				echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE;
-				echo "\",\"label\":\"".$row->COL_CALL."\"}";
+				echo "\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				$count++;
 			}
 
 		}
 		echo "]";
+		
+		// [MAP Custom] ADD Station //
+		$this->load->model('Stations');
+		$station_json = $this->Stations->get_station_json_for_map();
+		echo (!empty($station_json))?', '.$station_json:'';
+
 		echo "}";
 	}
 

--- a/application/controllers/Map.php
+++ b/application/controllers/Map.php
@@ -115,6 +115,9 @@ class Map extends CI_Controller {
 		$count = 1;
 		if ($qsos) {
 			foreach ($qsos->result() as $row) {
+				// check if qso is confirmed //
+				if (($row->COL_EQSL_QSL_RCVD=='Y') || ($row->COL_LOTW_QSL_RCVD=='Y') || ($row->COL_QSL_RCVD=='Y')) { $row->_is_confirmed = 'Y'; } else { $row->_is_confirmed = 'N'; }
+
 				//print_r($row);
 				if($row->COL_GRIDSQUARE != null) {
 					$stn_loc = $this->qra->qra2latlong($row->COL_GRIDSQUARE);
@@ -123,9 +126,9 @@ class Map extends CI_Controller {
 					}
 	
 					if($row->COL_SAT_NAME != null) {
-							echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
+							echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 					} else {
-							echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
+							echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 					}
 	
 					$count++;
@@ -160,9 +163,9 @@ class Map extends CI_Controller {
 					}
 		
 					if($row->COL_SAT_NAME != null) { 
-						echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
+						echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 					} else {
-					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
+					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 					}
 		
 					$count++;
@@ -176,13 +179,19 @@ class Map extends CI_Controller {
 						$lng = $row->long;
 					}
 					
-					echo "{\"lat\":\"".$lat."\",\"lng\":\"".$lng."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
+					echo "{\"lat\":\"".$lat."\",\"lng\":\"".$lng."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 					$count++;
 				}
 		}
 
 		}
 		echo "]";
+
+		// [MAP Custom] ADD Station //
+		$this->load->model('Stations');
+		$station_json = $this->Stations->get_station_json_for_map();
+		echo (!empty($station_json))?', '.$station_json:'';
+
 		echo "}";
 
 	}
@@ -203,6 +212,9 @@ class Map extends CI_Controller {
 		echo "{\"markers\": [";
 		$count = 1;
 		foreach ($qsos->result() as $row) {
+			// check if qso is confirmed //
+			if (($row->COL_EQSL_QSL_RCVD=='Y') || ($row->COL_LOTW_QSL_RCVD=='Y') || ($row->COL_QSL_RCVD=='Y')) { $row->_is_confirmed = 'Y'; } else { $row->_is_confirmed = 'N'; }
+
 			//print_r($row);
 			if($row->COL_GRIDSQUARE != null) {
 				$stn_loc = $this->qra->qra2latlong($row->COL_GRIDSQUARE);
@@ -211,9 +223,9 @@ class Map extends CI_Controller {
 				} 
 
 				if($row->COL_SAT_NAME != null) {
-						echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
+						echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				} else {
-						echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
+						echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				}
 
 				$count++;
@@ -249,9 +261,9 @@ class Map extends CI_Controller {
 				}
 	
 				if($row->COL_SAT_NAME != null) { 
-					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
+					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />SAT: ".$row->COL_SAT_NAME."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				} else {
-					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
+					echo "{\"lat\":\"".$stn_loc[0]."\",\"lng\":\"".$stn_loc[1]."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 				}
 	
 				$count++;
@@ -268,13 +280,19 @@ class Map extends CI_Controller {
 					if($count != 1) {
 					echo ",";
 						}
-					echo "{\"lat\":\"".$dxcc->lat."\",\"lng\":\"".$dxcc->long."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\"}";
+					echo "{\"lat\":\"".$dxcc->lat."\",\"lng\":\"".$dxcc->long."\", \"html\":\"Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />Band: ".$row->COL_BAND."<br />Mode: ".$row->COL_MODE."\",\"label\":\"".$row->COL_CALL."\", \"confirmed\":\"".$row->_is_confirmed."\"}";
 					$count++;
 				}
 			}
 
 		}
 		echo "]";
+
+		// [MAP Custom] ADD Station //
+		$this->load->model('Stations');
+		$station_json = $this->Stations->get_station_json_for_map();
+		echo (!empty($station_json))?', '.$station_json:'';
+
 		echo "}";
 
 	}

--- a/application/controllers/User_options.php
+++ b/application/controllers/User_options.php
@@ -46,6 +46,18 @@ class User_Options extends CI_Controller {
 		header('Content-Type: application/json');
 		echo json_encode($jsonout);
 	}
+
+	// [MAP Custom] //
+	public function get_map_custom() {
+		$result=$this->user_options_model->get_options('map_custom');
+		$jsonout=[];
+		foreach($result->result() as $options) {
+			if ($options->option_name=='icon') $jsonout[$options->option_key]=json_decode($options->option_value,true);
+				else $jsonout[$options->option_name.'_'.$options->option_key]=$options->option_value;
+		}
+		header('Content-Type: application/json');
+		echo json_encode($jsonout);
+	}
 }
 
 

--- a/application/language/bulgarian/account_lang.php
+++ b/application/language/bulgarian/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/bulgarian/general_words_lang.php
+++ b/application/language/bulgarian/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Дата';
 $lang['general_word_startdate'] = "Start Date";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = 'Gridsquare';
 $lang['gen_hamradio_get_gridsquare'] = 'Get Gridsquare';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Bearing";

--- a/application/language/chinese_simplified/account_lang.php
+++ b/application/language/chinese_simplified/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Cloudlog 中对 Winkeyer 的支持是实验性的，请在开启前先阅读 <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a>。";
 $lang['account_winkeyer_enabled'] = "启用 Winkeyer 功能";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/chinese_simplified/general_words_lang.php
+++ b/application/language/chinese_simplified/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "导出";
 $lang['general_word_import'] = "导入";
 $lang['general_word_count'] = "数量";
 $lang['general_word_filtering_on'] = "筛选打开";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = '日期';
 $lang['general_word_startdate'] = "Start Date";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = '网格';
 $lang['gen_hamradio_get_gridsquare'] = '获取网格座标';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "纬度";
 $lang['gen_hamradio_longitude'] = "经度";
 $lang['gen_hamradio_bearing'] = "方位角";

--- a/application/language/czech/account_lang.php
+++ b/application/language/czech/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/czech/general_words_lang.php
+++ b/application/language/czech/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Datum';
 $lang['general_word_startdate'] = "Start Date";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = 'Lokátor';
 $lang['gen_hamradio_get_gridsquare'] = 'Get Gridsquare';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Bearing";

--- a/application/language/dutch/account_lang.php
+++ b/application/language/dutch/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/dutch/general_words_lang.php
+++ b/application/language/dutch/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Datum';
 $lang['general_word_startdate'] = "Start Date";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = 'Gridsquare';
 $lang['gen_hamradio_get_gridsquare'] = 'Get Gridsquare';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Bearing";

--- a/application/language/english/account_lang.php
+++ b/application/language/english/account_lang.php
@@ -115,7 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
-$lang['account_map_params'] = "Paramètre de la carte";
+$lang['account_map_params'] = "Settings for map";
 $lang['account_map_qso_by_default'] = "QSO (by default)";
 $lang['account_map_qso_confirm'] = "QSO (confirmed)";
 $lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/english/account_lang.php
+++ b/application/language/english/account_lang.php
@@ -115,3 +115,8 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
+$lang['account_map_params'] = "Paramètre de la carte";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";
+

--- a/application/language/english/general_words_lang.php
+++ b/application/language/english/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Date';
 $lang['general_word_startdate'] = "Start Date";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = 'Gridsquare';
 $lang['gen_hamradio_get_gridsquare'] = 'Get Gridsquare';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Bearing";

--- a/application/language/finnish/account_lang.php
+++ b/application/language/finnish/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/finnish/general_words_lang.php
+++ b/application/language/finnish/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Päivä';
 $lang['general_word_startdate'] = "Start Date";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = 'Gridsquare';
 $lang['gen_hamradio_get_gridsquare'] = 'Get Gridsquare';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Bearing";

--- a/application/language/french/account_lang.php
+++ b/application/language/french/account_lang.php
@@ -114,3 +114,8 @@ $lang['account_qsl_settings'] = "Méthode QSL";
 $lang['account_winkeyer'] = "Winkeyer";
 $lang['account_winkeyer_hint'] = "REMARQUE : La prise en charge de Winkeyer dans Cloudlog est très expérimentale, lisez d'abord le wiki avant de l'activer  <a href=\"https://github.com/magicbug/Cloudlog/wiki/Winkey\" target=\"_blank\">https://github.com/magicbug/Cloudlog/wiki/Winkey</a>";
 $lang['account_winkeyer_enabled'] = "Activer Winkeyer";
+
+$lang['account_map_params'] = "Paramètre de la carte";
+$lang['account_map_qso_by_default'] = "QSO (par défaut)";
+$lang['account_map_qso_confirm'] = "QSO (confirmé)";
+$lang['account_map_qso_confirm_same_qso'] = "(Si 'Non', sera affiché comme ".$lang['account_map_qso_by_default'].")";

--- a/application/language/french/general_words_lang.php
+++ b/application/language/french/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_count'] = "Nombre";
 $lang['general_word_filtering_on'] = "Filtré sur";
+$lang['general_word_not_display'] = "Ne pas afficher";
+$lang['general_word_icon'] = "Icône";
 
 $lang['general_word_date'] = "Date";
 $lang['general_word_startdate'] = "Date début";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = "WWFF";
 $lang['gen_hamradio_pota'] = "POTA";
 $lang['gen_hamradio_gridsquare'] = "Locator";
 $lang['gen_hamradio_get_gridsquare'] = "Trouver le Locator";
+$lang['gen_hamradio_gridsquare_show'] = "Afficher les Locator";
 $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Azimut";

--- a/application/language/german/account_lang.php
+++ b/application/language/german/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Die Winkeyer Unterstützung in Cloudlog ist sehr experimentell. Lese zuerst den Wikieintrag auf <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> bevor du ihn einschaltest.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Eingeschaltet";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/german/general_words_lang.php
+++ b/application/language/german/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Exportieren";
 $lang['general_word_import'] = "Importieren";
 $lang['general_word_count'] = "Zähler";
 $lang['general_word_filtering_on'] = "Filtern auf";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Datum';
 $lang['general_word_startdate'] = "Start Datum";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = 'Planquadrat';
 $lang['gen_hamradio_get_gridsquare'] = 'Orte mein Planquadrat';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Breitengrad";
 $lang['gen_hamradio_longitude'] = "Längengrad";
 $lang['gen_hamradio_bearing'] = "Peilung";

--- a/application/language/greek/account_lang.php
+++ b/application/language/greek/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/greek/general_words_lang.php
+++ b/application/language/greek/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Ημερομηνία';
 $lang['general_word_startdate'] = "Start Date";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = 'Gridsquare';
 $lang['gen_hamradio_get_gridsquare'] = 'Get Gridsquare';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Bearing";

--- a/application/language/italian/account_lang.php
+++ b/application/language/italian/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/italian/general_words_lang.php
+++ b/application/language/italian/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Data';
 $lang['general_word_startdate'] = "Start Date";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = 'Quadratone';
 $lang['gen_hamradio_get_gridsquare'] = 'Get Gridsquare';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Bearing";

--- a/application/language/polish/account_lang.php
+++ b/application/language/polish/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/polish/general_words_lang.php
+++ b/application/language/polish/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Data';
 $lang['general_word_startdate'] = "Start Date";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = 'Lokator';
 $lang['gen_hamradio_get_gridsquare'] = 'Get Gridsquare';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Bearing";

--- a/application/language/russian/account_lang.php
+++ b/application/language/russian/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Поддержка Winkeyer в Cloudlog в стадии эксперимента, прочитайте сначала вики (<a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a>) перед включением.";
 $lang['account_winkeyer_enabled'] = "Функционал Winkeyer включен";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/russian/general_words_lang.php
+++ b/application/language/russian/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Экспорт";
 $lang['general_word_import'] = "Импорт";
 $lang['general_word_count'] = "Счётчик";
 $lang['general_word_filtering_on'] = "Отфильтровано по";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Дата';
 $lang['general_word_startdate'] = "Дата начала";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_sota'] = 'SOTA';
 $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_get_gridsquare'] = 'Получить квадрат';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Широта";
 $lang['gen_hamradio_longitude'] = "Долгота";
 $lang['gen_hamradio_bearing'] = "Направление";

--- a/application/language/spanish/account_lang.php
+++ b/application/language/spanish/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/spanish/general_words_lang.php
+++ b/application/language/spanish/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Fecha';
 $lang['general_word_startdate'] = "Start Date";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = 'Gridsquare';
 $lang['gen_hamradio_get_gridsquare'] = 'Get Gridsquare';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Bearing";

--- a/application/language/swedish/account_lang.php
+++ b/application/language/swedish/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/swedish/general_words_lang.php
+++ b/application/language/swedish/general_words_lang.php
@@ -15,6 +15,8 @@ $lang['general_word_info'] = 'Info';
 $lang['general_word_choose_file'] = 'Välj fil';
 $lang['general_word_next'] = 'Next';
 $lang['general_word_previous'] = 'Previous';
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_cancel'] = "Cancel";
 $lang['general_word_ok'] = "OK";
@@ -171,6 +173,7 @@ $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Bearing";
 $lang['gen_hamradio_get_gridsquare'] = 'Get Gridsquare';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_distance'] = 'Distance';
 $lang['gen_hamradio_operator'] = 'Operatör';
 

--- a/application/language/turkish/account_lang.php
+++ b/application/language/turkish/account_lang.php
@@ -115,3 +115,7 @@ $lang['account_winkeyer'] = 'Winkeyer';
 $lang['account_winkeyer_hint'] = "Winkeyer support in Cloudlog is very experimental read the wiki first at <a href='https://github.com/magicbug/Cloudlog/wiki/Winkey' target='_blank'>https://github.com/magicbug/Cloudlog/wiki/Winkey</a> before enabling.";
 $lang['account_winkeyer_enabled'] = "Winkeyer Features Enabled";
 
+$lang['account_map_params'] = "Settings for map";
+$lang['account_map_qso_by_default'] = "QSO (by default)";
+$lang['account_map_qso_confirm'] = "QSO (confirmed)";
+$lang['account_map_qso_confirm_same_qso'] = "(If 'No', displayed as ".$lang['account_map_qso_by_default'].")";

--- a/application/language/turkish/general_words_lang.php
+++ b/application/language/turkish/general_words_lang.php
@@ -23,6 +23,8 @@ $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
+$lang['general_word_not_display'] = "Not display";
+$lang['general_word_icon'] = "Icon";
 
 $lang['general_word_date'] = 'Tarih';
 $lang['general_word_startdate'] = "Start Date";
@@ -167,6 +169,7 @@ $lang['gen_hamradio_wwff'] = 'WWFF';
 $lang['gen_hamradio_pota'] = 'POTA';
 $lang['gen_hamradio_gridsquare'] = 'Pafta';
 $lang['gen_hamradio_get_gridsquare'] = 'Get Gridsquare';
+$lang['gen_hamradio_gridsquare_show'] = "Show Locator";
 $lang['gen_hamradio_latitude'] = "Latitude";
 $lang['gen_hamradio_longitude'] = "Longitude";
 $lang['gen_hamradio_bearing'] = "Bearing";

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -512,6 +512,16 @@ class Stations extends CI_Model {
 		}
 		return false;
 	}
+
+	// [MAP Custom] get json structure (for map) about info's station  //
+	public function get_station_json_for_map() {
+		$_jsonresult = array();
+		list($station_lat, $station_lng) = array(0,0);
+		$station_active = $this->profile($this->find_active())->row();
+		if (!empty($station_active)) { list($station_lat, $station_lng) = $this->qra->qra2latlong($station_active->station_gridsquare); }
+		if (($station_lat!=0)&&($station_lng!=0)) { $_jsonresult = array('lat'=>$station_lat,'lng'=>$station_lng,'html'=>$station_active->station_gridsquare,'label'=>$station_active->station_profile_name,'icon'=>'stationIcon'); }
+		return (count($_jsonresult)>0)?("\"station\":".json_encode($_jsonresult)):'';
+	}
 }
 
 ?>

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -3048,6 +3048,31 @@ function viewEqsl(picture, callsign) {
     <?php } ?>
 <?php } ?>
 
+<?php if (($this->uri->segment(1) == "user") && ($this->uri->segment(2) == "edit")) { ?>
+    <!-- [MAP Custom] select list with icons -->
+    <script>
+        $(document).ready(function(){
+            $('.icon_selectBox').off('click').on('click', function(){
+                var boxcontent = $(this).attr('data-boxcontent');
+                if ($('.icon_selectBox_data[data-boxcontent="'+boxcontent+'"]').is(":hidden")) { $('.icon_selectBox_data[data-boxcontent="'+boxcontent+'"]').show(); } else { $('.icon_selectBox_data[data-boxcontent="'+boxcontent+'"]').hide(); }
+            });
+            $('.icon_selectBox_data').off('mouseleave').on('mouseleave', function(){ if ($(this).is(":visible")) { $(this).hide(); } });
+            $('.icon_selectBox_data label').off('click').on('click', function(){ 
+                var boxcontent = $(this).closest('.icon_selectBox_data').attr('data-boxcontent');
+                $('input[name="user_map_'+boxcontent+'_icon"]').attr('value',$(this).attr('data-value'));
+                if ($(this).attr('data-value') != "0") { 
+                    $('.user_icon_color[data-icon="'+boxcontent+'"]').show();
+                    $('.icon_selectBox[data-boxcontent="'+boxcontent+'"] .icon_overSelect').html($(this).html());
+                } else {
+                    $('.user_icon_color[data-icon="'+boxcontent+'"]').hide();
+                    $('.icon_selectBox[data-boxcontent="'+boxcontent+'"] .icon_overSelect').html($(this).html().substring(0,10)+'.');
+                }
+                $('.icon_selectBox_data[data-boxcontent="'+boxcontent+'"]').hide();
+            }); 
+        });
+    </script>
+<?php } ?> 
+
 <?php
 if (isset($scripts) && is_array($scripts)){
 	foreach($scripts as $script){

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -621,6 +621,88 @@
 					</div>
 				</div>
 			</div>
+
+			<?php if ($this->session->userdata('user_id') == $this->uri->segment(3)) { ?>
+			<!-- [MAP Custom] -->
+			<div class="col-md">
+				<div class="card">
+		    		<div class="card-header">
+					   	 <?php echo $this->lang->line('account_map_params'); ?>
+					</div>
+					<div class="card-body">
+				        <div class="row"> <!-- Station -->
+				        	<div class="mb-3 col-md-4">
+				        		<label>&nbsp;</label><br/><label><?php echo $this->lang->line('gen_hamradio_station'); ?></label>
+				        	</div>
+							<div class="mb-3 col-md-3">
+								<label><?php echo $this->lang->line('general_word_icon'); ?></label><br/>
+	                            <div class="icon_selectBox" data-boxcontent="station">
+    	                            <input type="hidden" name="user_map_station_icon" value="<?php echo $user_map_station_icon; ?>">
+        	                        <div class="form-select icon_overSelect"><?php echo (($user_map_station_icon=="0")?substr($this->lang->line('general_word_not_display'),0,10).'.':("<i class='".$user_map_station_icon."'></i>")); ?></div>
+            	                </div>
+                	            <div class="col-md-3 icon_selectBox_data" data-boxcontent="station"> 
+				    	            <?php foreach($map_icon_select['station'] as $val) {
+				        	        	echo "<label data-value='".$val."'>".(($val=="0")?$this->lang->line('general_word_not_display'):("<i class='".$val."'></i>"))."</label>";
+				            	   	} ?>
+                            	</div>
+				            </div>
+							<div class="mb-3 col-md-2">
+								<label><?php echo $this->lang->line('general_word_colors'); ?></label><br/><input type="color" class="form-control user_icon_color" name="user_map_station_color" id="user_map_station_color" value="<?php echo $user_map_station_color; ?>" style="padding:initial;<?php echo ($user_map_station_icon=="0")?'display:none;':''; ?>" data-icon="station" /></div>
+						</div>
+						<div class="row"> <!-- QSO (default) -->
+				        	<div class="mb-3 col-md-4">
+				        		<label><?php echo $this->lang->line('account_map_qso_by_default'); ?></label>
+				        	</div>
+							<div class="mb-3 col-md-3">
+	                            <div class="icon_selectBox" data-boxcontent="qso">
+    	                            <input type="hidden" name="user_map_qso_icon" value="<?php echo $user_map_qso_icon; ?>">
+        	                        <div class="form-select icon_overSelect"><?php echo "<i class='".$user_map_qso_icon."'></i>"; ?></div>
+            	                </div>
+                	            <div class="col-md-3 icon_selectBox_data" data-boxcontent="qso"> 
+				    	            <?php foreach($map_icon_select['qso'] as $val) {
+				        	        	echo "<label data-value='".$val."'><i class='".$val."'></i></label>";
+				            	   	} ?>
+                            	</div>
+				            </div>
+							<div class="mb-3 col-md-2">
+								<input type="color" class="form-control user_icon_color" name="user_map_qso_color" id="user_map_qso_color" value="<?php echo $user_map_qso_color; ?>" style="padding:initial;" data-icon="qso" />
+							</div>
+						</div>
+						<div class="row"> <!-- QSO (confirmed) -->
+				        	<div class="mb-3 col-md-4">
+				        		<label><?php echo $this->lang->line('account_map_qso_confirm'); ?></label>
+				        		<div class="small form-text text-muted"><?php echo lang('account_map_qso_confirm_same_qso'); ?></div>
+				        	</div>
+							<div class="mb-3 col-md-3">
+	                            <div class="icon_selectBox" data-boxcontent="qsoconfirm">
+    	                            <input type="hidden" name="user_map_qsoconfirm_icon" value="<?php echo $user_map_qsoconfirm_icon; ?>">
+        	                        <div class="form-select icon_overSelect"><?php echo (($user_map_qsoconfirm_icon=="0")?$this->lang->line('general_word_no'):("<i class='".$user_map_qsoconfirm_icon."'></i>")); ?></div>
+            	                </div>
+                	            <div class="col-md-3 icon_selectBox_data" data-boxcontent="qsoconfirm"> 
+				    	            <?php foreach($map_icon_select['qsoconfirm'] as $val) {
+				        	        	echo "<label data-value='".$val."'>".(($val=="0")?$this->lang->line('general_word_no'):("<i class='".$val."'></i>"))."</label>";
+				            	   	} ?>
+                            	</div>
+				            </div>
+							<div class="md-3 col-md-2">
+								<input type="color" class="form-control user_icon_color" name="user_map_qsoconfirm_color" id="user_map_qsoconfirm_color" value="<?php echo $user_map_qsoconfirm_color; ?>" style="padding:initial;<?php echo ($user_map_qsoconfirm_icon=="0")?'display:none;':''; ?>" data-icon="qsoconfirm" />
+							</div>
+						</div>
+						<div class="row">
+							<div class="md-3 col-md-4">
+								<label><?php echo $this->lang->line('gen_hamradio_gridsquare_show'); ?></label>
+							</div>
+							<div class="md-3 col-md-3">
+								<select class="form-select" id="user_map_gridsquare_show" name="user_map_gridsquare_show">
+									<option value="1" <?php if ($user_map_gridsquare_show == 1) { echo " selected =\"selected\""; } ?>><?php echo lang('general_word_yes'); ?></option>
+									<option value="0" <?php if ($user_map_gridsquare_show == 0) { echo " selected =\"selected\""; } ?>><?php echo lang('general_word_no'); ?></option>
+								</select>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<?php } ?>
 		</div>
 
 		<br>

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -629,3 +629,26 @@ table.dataTable tfoot td {
     cursor: pointer;
     margin-left: 10px;
 }
+
+.icon_selectBox { 
+	position: relative; 
+}
+.icon_selectBox_data { 
+	display: none; 
+	position:absolute; 
+	z-index:50; 
+	left:initial; 
+	border:1px solid var(--bs-border-color); 
+	padding:5px; 
+	top:initial;
+	background-color:var(--bs-card-bg); 
+	color:var(--bs-body-color); 
+}
+.icon_selectBox_data label { 
+	display:block; 
+	margin-bottom:0px!important; 
+	text-align:center; cursor:pointer; 
+}
+.icon_selectBox_data label:hover { 
+	background-color:var(--bs-primary); 
+}

--- a/assets/js/leaflet/leafembed.js
+++ b/assets/js/leaflet/leafembed.js
@@ -1,28 +1,17 @@
-
-
 var map;
-var ajaxRequest;
-var plotlist;
 var plotlayers=[];
+var iconsList={'qso':{'color':'#FF0000','icon':'fas fa-dot-circle'}};
 
-var greenIcon = L.icon({
-    iconUrl: icon_dot_url,
-    iconSize:     [10, 10], // size of the icon
-});
+var stationIcon = L.divIcon({className:'cspot_station'});
+var qsoIcon = L.divIcon({className:'cspot_qso'}); //default (fas fa-dot-circle red)
+var qsoconfirmIcon = L.divIcon({className:'cspot_qsoconfirm'});
+var redIconImg = L.icon({ iconUrl: icon_dot_url, iconSize: [10, 10] }); // old //
 
 var osmUrl = $('#leafembed').attr("tileUrl");
 
-function initmap(ShowGrid = 'No', MapTag = 'map') {
-    // set up AJAX request
-    ajaxRequest=getXmlHttpObject();
-    if (ajaxRequest==null) {
-        alert ("This browser does not support HTTP Request");
-        return;
-    }
-    
+function initmap(ShowGrid='No', MapTag='map', options={}) {
     // set up the map
     map = new L.Map(MapTag);
-
     // create the tile layer with correct attribution
     var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
     var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 12, attribution: osmAttrib});        
@@ -35,54 +24,64 @@ function initmap(ShowGrid = 'No', MapTag = 'map') {
 		hideControlContainer: true
 	}).addTo(map);
 
-    // start the map in South-East England
-    map.setView(new L.LatLng(q_lat, q_lng), q_zoom);
-	
+	// new synthaxe, use array by function argument //
+	if (typeof options.q_lat!=="undefined") { _q_lat = options.q_lat; } else { if (typeof q_lat!=="undefined") { _q_lat = q_lat; } else { _q_lat = 0; } }
+	if (typeof options.q_lng!=="undefined") { _q_lng = options.q_lng; } else { if (typeof q_lng!=="undefined") { _q_lng = q_lng; } else { _q_lng = 0; } }
+	if (typeof options.q_zoom!=="undefined") { _q_zoom = options.q_zoom; } else { if (typeof q_zoom!=="undefined") { _q_zoom = q_zoom; } else { _q_zoom = 1; } }
+	if (typeof options.url_qso!=="undefined") { _url_qso = options.url_qso; } else { if (typeof qso_loc!=="undefined") { _url_qso = qso_loc; } else { _url_qso = ''; console.log('[ERROR] url with qso location not defined.'); } }
+	options.map_id = '#'+MapTag;
+
+    // start the map in center of word, it nothing is defined
+    map.setView(new L.LatLng(_q_lat, _q_lng), _q_zoom);
 	map.addLayer(osm);
-	askForPlots();
+	//map.on('moveend', onMapMove); // all data load directecty, without interest in recharging during a movement
+	var layerControl = new L.Control.Layers(null, { 'Gridsquares': maidenhead = L.maidenhead() }).addTo(map);
+	if(ShowGrid == "Yes") { maidenhead.addTo(map); }
 
-	map.on('moveend', onMapMove);
+	// get map custon infos //
+    $.ajax({
+        url: base_url+'index.php/user_options/get_map_custom', type: 'GET', dataType: 'json',
+        error: function() { console.log('[ERROR] ajax get_map_custom() function return error.'); },
+        success: function(json_mapinfo) {
+        	if (typeof json_mapinfo.qso !== "undefined") { iconsList = json_mapinfo; }
+			if(json_mapinfo.gridsquare_show == "1") { maidenhead.addTo(map); }
+			//console.log(_url_qso);
+			askForPlots(_url_qso, options);
+        }
+    });
+}
 
-	if(ShowGrid == "Yes") {
-		var maidenhead = L.maidenhead().addTo(map);
+function askForPlots(_url_qso, options={}) {
+	removeMarkers();
+    $.ajax({
+        url: _url_qso, type: 'GET', dataType: 'json',
+        error: function() { console.log('[ERROR] ajax askForPlots() function return error.'); },
+        success: function(plotjson) {
+        	if ((typeof plotjson['markers'] !== "undefined")&&(plotjson['markers'].length>0)) {
+				for (i=0;i<plotjson['markers'].length;i++) { createPlots(plotjson['markers'][i]); }
+        	}
+        	if ((typeof plotjson['station']!=="undefined")&&(plotjson['station'].icon!="0")) {
+        		createPlots(plotjson['station']);
+        	}
+        	$.each(iconsList, function(icon, data){
+        		$(options.map_id+' .cspot_'+icon).addClass(data.icon).css("color",data.color);
+        	});
+        }
+    });
+}
+
+function createPlots(_plot) {
+	var plotll = new L.LatLng(_plot.lat,_plot.lng, true);
+	if (typeof _plot.icon==="undefined") { _plot.icon = 'qsoIcon'; }
+	if ((typeof iconsList.qsoconfirm!=="undefined")&&(typeof iconsList.qsoconfirm.icon!=="undefined")&&(iconsList.qsoconfirm.icon!="0")&&(typeof _plot.confirmed!=="undefined")&&(_plot.confirmed=='Y')) { _plot.icon = 'qsoconfirmIcon'; }
+	eval('var plotmark = new L.Marker(plotll, {icon: '+_plot.icon+' })');
+	plotmark.data=_plot;
+	map.addLayer(plotmark);
+	if ((typeof _plot.label!=="undefined")&&(typeof _plot.html!=="undefined")) {
+		_plot.label = (_plot.label!="")?("<h3>"+_plot.label+"</h3>"):"";
+		if ((_plot.label+_plot.html)!="") { plotmark.bindPopup(_plot.label+_plot.html); }
 	}
-
-	var layerControl = new L.Control.Layers(null, {
-    'Gridsquares': maidenhead = L.maidenhead()
-	}).addTo(map);
-}
-
-function getXmlHttpObject() {
-	if (window.XMLHttpRequest) { return new XMLHttpRequest(); }
-	if (window.ActiveXObject)  { return new ActiveXObject("Microsoft.XMLHTTP"); }
-	return null;
-}
-
-function askForPlots() {
-    // request the marker info with AJAX for the current bounds
-    ajaxRequest.onreadystatechange = stateChanged;
-    ajaxRequest.open('GET', qso_loc, true);
-    ajaxRequest.send(null);
-}
-
-function stateChanged() {
-	// if AJAX returned a list of markers, add them to the map
-	if (ajaxRequest.readyState==4) {
-		//use the info here that was returned
-		if (ajaxRequest.status==200) {
-            plotlist=eval("(" + ajaxRequest.responseText + ")");
-            plotlist = plotlist['markers'];
-			removeMarkers();
-			for (i=0;i<plotlist.length;i++) {
-				var plotll = new L.LatLng(plotlist[i].lat,plotlist[i].lng, true);
-				var plotmark = new L.Marker(plotll, {icon: greenIcon});
-				plotmark.data=plotlist[i];
-				map.addLayer(plotmark);
-				plotmark.bindPopup("<h3>"+plotlist[i].label+"</h3>"+plotlist[i].html);
-				plotlayers.push(plotmark);
-			}
-		}
-	}
+	plotlayers.push(plotmark);
 }
 
 function removeMarkers() {
@@ -90,8 +89,4 @@ function removeMarkers() {
 		map.removeLayer(plotlayers[i]);
 	}
 	plotlayers=[];
-}
-
-function onMapMove(e) {
-    askForPlots();
 }

--- a/assets/js/leaflet/leafembed.js
+++ b/assets/js/leaflet/leafembed.js
@@ -38,17 +38,23 @@ function initmap(ShowGrid='No', MapTag='map', options={}) {
 	var layerControl = new L.Control.Layers(null, { 'Gridsquares': maidenhead = L.maidenhead() }).addTo(map);
 	if(ShowGrid == "Yes") { maidenhead.addTo(map); }
 
+	//console.log(_url_qso);
 	// get map custon infos //
-    $.ajax({
-        url: base_url+'index.php/user_options/get_map_custom', type: 'GET', dataType: 'json',
-        error: function() { console.log('[ERROR] ajax get_map_custom() function return error.'); },
-        success: function(json_mapinfo) {
-        	if (typeof json_mapinfo.qso !== "undefined") { iconsList = json_mapinfo; }
-			if(json_mapinfo.gridsquare_show == "1") { maidenhead.addTo(map); }
-			//console.log(_url_qso);
-			askForPlots(_url_qso, options);
-        }
-    });
+	var _visitor = (typeof visitor==="undefined")?false:visitor;
+	if (_visitor) {
+		askForPlots(_url_qso, options);
+	} else {
+		$.ajax({
+			url: base_url+'index.php/user_options/get_map_custom', type: 'GET', dataType: 'json',
+			error: function() { askForPlots(_url_qso, options); console.log('[ERROR] ajax get_map_custom() function return error.'); },
+			success: function(json_mapinfo) {
+				if (typeof json_mapinfo.qso !== "undefined") { iconsList = json_mapinfo; }
+				if(json_mapinfo.gridsquare_show == "1") { maidenhead.addTo(map); }
+				askForPlots(_url_qso, options);
+			}
+		});
+	}
+
 }
 
 function askForPlots(_url_qso, options={}) {


### PR DESCRIPTION
Version 1 of this new proposal functionality : 
* on user editor page (current user only) ; not available for other user (data are save on user_options, and this table use only  curent user)
* user can : 
   * add icon (house) for curent active station , and change color
   * change icon / color of QSO (default is the same like now (red spot)
   * change icon / color of QSO confirmed (qsl / lotw / eqsl)
   * active display gridsquare

If user not configure this feature (user options table empty for this feature), default spot is the red spot

this change is available for : 
* map on dashboard
* map on custom view
* map on qso logbook

if this feature is validate, i will make evolution for have color by band / mode (like on PSKreportor)

**some picture :** 
- edit user by default
![config by default](https://github.com/magicbug/Cloudlog/assets/13674762/d828278e-812f-4516-aef9-741ea26d9b01)
- icon list for "station"
![icon list for home](https://github.com/magicbug/Cloudlog/assets/13674762/f4c3b7a8-e384-40d5-af8b-34c8336f9a76)
- different selection for 3 icon
![config for 3](https://github.com/magicbug/Cloudlog/assets/13674762/eb3dc15b-2b0d-4944-ae3b-747d5351b45b)
- default map view (with station, and confirmed qso display in default view)
![map red dot](https://github.com/magicbug/Cloudlog/assets/13674762/ba30094e-2b2c-485a-a812-80750f92278f)
- view with qso confirmed colored
![map with qso confirmed](https://github.com/magicbug/Cloudlog/assets/13674762/e9c44a40-3219-4ee6-b833-e62dbd3e60e7)