### PR TITLE
[eQSL] fix for qslmsg with not accepted character

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -295,6 +295,7 @@ class eqsl extends CI_Controller {
 			"_" = 5F
 			"-" = 2D
 			"." = 2E
+			"&" = 26
 		*/
 		
 		$adif .= "%3C";
@@ -422,12 +423,13 @@ class eqsl extends CI_Controller {
 
 		// adding qslmsg if it isn't blank
 		if ($qsl['COL_QSLMSG'] != ''){
+			$qsl['COL_QSLMSG'] = str_replace(array(chr(10),chr(13)),array(' ',' '),$qsl['COL_QSLMSG']);
 			$adif .= "%3C";
 			$adif .= "QSLMSG";
 			$adif .= "%3A";
 			$adif .= strlen($qsl['COL_QSLMSG']);
 			$adif .= "%3E";
-			$adif .= $qsl['COL_QSLMSG'];
+			$adif .= str_replace('&','%26',$qsl['COL_QSLMSG']);
 			$adif .= "%20";
 		}
 

--- a/application/language/bulgarian/station_lang.php
+++ b/application/language/bulgarian/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/chinese_simplified/station_lang.php
+++ b/application/language/chinese_simplified/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/czech/station_lang.php
+++ b/application/language/czech/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/dutch/station_lang.php
+++ b/application/language/dutch/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/english/station_lang.php
+++ b/application/language/english/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/finnish/station_lang.php
+++ b/application/language/finnish/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/french/station_lang.php
+++ b/application/language/french/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Message (QSLMSG) par défaut";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "Vous pouvez définir un message par défaut qui sera renseigné et envoyé pour chaque QSO pour ce lieu station. Taille max:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Vous pouvez définir un message par défaut qui sera renseigné et envoyé pour chaque QSO pour ce lieu station.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/german/qso_lang.php
+++ b/application/language/german/qso_lang.php
@@ -26,7 +26,7 @@ $lang['qso_dok_helptext'] = 'Zum Beispiel: Q03';
 $lang['qso_notes_helptext'] = 'Notizeninhalt wird nur innerhalb von Cloudlog genutzt und nicht an andere Dienste weitergegeben.';
 $lang['qsl_notes_helptext'] = 'Dieser Notizeninhalt wird an QSL Services wie eqsl.cc exportiert.';
 
-$lang['qso_eqsl_qslmsg_helptext'] = "Get the default message for eQSL, for this station.";
+$lang['qso_eqsl_qslmsg_helptext'] = "Setze die eQSL Nachricht auf den Standardtext zurück.";
 
 // Button Text on /qso Display
 

--- a/application/language/german/station_lang.php
+++ b/application/language/german/station_lang.php
@@ -94,8 +94,8 @@ $lang['station_location_signature_name_hint'] = "Signatur/Referenz der Station (
 $lang['station_location_signature_info'] = "Signatur Information";
 $lang['station_location_signature_info_hint'] = "Signatur/Referenz Information der Station (z.B. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = "Der 'QTH Nickname' wie er in deinem eQSL Profil konfiguriert ist.";
-$lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg'] = "Standard QSLMSG";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Definiere eine Standard-Nachricht, welche für jedes QSO in diesem Stationsstandort an eQSL übertragen wird.";
 $lang['station_location_qrz_subscription'] = 'Abonnement erforderlich';
 $lang['station_location_qrz_hint'] = "Finde deinen 'QRZ Logbook API Key' in den <a href='https://logbook.qrz.com/logbook' target='_blank'>QRZ.com Logbuch Einstellungen";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbuch Echtzeit Upload';

--- a/application/language/greek/station_lang.php
+++ b/application/language/greek/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/italian/station_lang.php
+++ b/application/language/italian/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/polish/station_lang.php
+++ b/application/language/polish/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/russian/station_lang.php
+++ b/application/language/russian/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Информация о подпис
 $lang['station_location_signature_info_hint'] = "Информация о подписис станции (т.е. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'Название профиля, который сконфигурирован в eQSL для данного QTH';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Требуется подписка';
 $lang['station_location_qrz_hint'] = "Ваш ключ API находится на  <a href='https://logbook.qrz.com/logbook' target='_blank'>странице настроек журнала QRZ.com";
 $lang['station_location_qrz_realtime_upload'] = 'Загрузка в журнал QRZ.com в реальном времени';

--- a/application/language/spanish/station_lang.php
+++ b/application/language/spanish/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/swedish/station_lang.php
+++ b/application/language/swedish/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/language/turkish/station_lang.php
+++ b/application/language/turkish/station_lang.php
@@ -95,7 +95,7 @@ $lang['station_location_signature_info'] = "Signature Information";
 $lang['station_location_signature_info_hint'] = "Station Signature Info (e.g. DA/NW-357).";
 $lang['station_location_eqsl_hint'] = 'The QTH Nickname which is configured in your eQSL Profile';
 $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
-$lang['station_location_eqsl_defaultqslmsg_hint'] = "You can define a default message that will be populated and sent for each QSO for this station location. Max length:";
+$lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
 $lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -45,6 +45,7 @@
 <script src="<?php echo base_url(); ?>assets/js/bootstrapdialog/js/bootstrap-dialog.min.js"></script>
 <script type="text/javascript" src="<?php echo base_url() ;?>assets/js/easyprint.js"></script>
 <script type="text/javascript" src="<?php echo base_url() ;?>assets/js/sections/common.js"></script>
+<script type="text/javascript" src="<?php echo base_url() ;?>assets/js/sections/eqslcharcounter.js"></script>
 
 <script src="https://unpkg.com/htmx.org@1.6.1"></script>
 
@@ -1242,7 +1243,10 @@ $(document).on('keypress',function(e) {
         qso_set_eqsl_qslmsg(stationProfile,false,'.qso_panel');
 	});
     // [eQSL default msg] change value on clic //
-    $('.qso_panel .qso_eqsl_qslmsg_update').off('click').on('click',function() { qso_set_eqsl_qslmsg($('.qso_panel #stationProfile').val(),true,'.qso_panel'); });
+    $('.qso_panel .qso_eqsl_qslmsg_update').off('click').on('click',function() { 
+        qso_set_eqsl_qslmsg($('.qso_panel #stationProfile').val(),true,'.qso_panel');
+        $('#charsLeft').text(" ");
+    });
 
 <?php if ($this->session->userdata('user_qth_lookup') == 1) { ?>
     $('#qth').focusout(function() {

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -22,7 +22,6 @@
     <script src="<?php echo base_url(); ?>assets/js/popper.min.js"></script>
     <script src="<?php echo base_url(); ?>assets/js/jquery.fancybox.min.js"></script>
     <script src="<?php echo base_url(); ?>assets/js/bootstrap.min.js"></script>
-
 </head>
 
 <body class="container-fluid qso-edit-box">
@@ -510,16 +509,17 @@
                                                 </select></div>
                                         </div>
                                         <div class="mb-3 row">
-                                             <div class="col-sm-9">
-                                                 <label for="qslmsg"><?php echo lang('general_word_notes'); ?><span class="qso_eqsl_qslmsg_update" title="<?php echo lang('qso_eqsl_qslmsg_helptext'); ?>"><i class="fas fa-redo-alt"></i></span></label>
-                                                 <div class="alert alert-info" role="alert">
-                                                     <span class="badge text-bg-info"><?php echo lang('general_word_info'); ?></span> <?php echo lang('qsl_notes_helptext'); ?>
-                                                 </div>
-                                             </div>
-                                             <div class="col-sm-9">
+                                            <div>
+                                                <div class="alert alert-info" role="alert">
+                                                    <span class="badge text-bg-info"><?php echo lang('general_word_info'); ?></span> <?php echo lang('qsl_notes_helptext'); ?>
+                                                </div>
+                                            </div>
+                                            <div>
+                                                <label for="qslmsg"><?php echo lang('general_word_notes'); ?><span class="qso_eqsl_qslmsg_update" title="<?php echo lang('qso_eqsl_qslmsg_helptext'); ?>"><i class="fas fa-redo-alt"></i></span></label>
+						                        <label class="position-absolute end-0 mb-2 me-3" for="qslmsg" id="charsLeft"> </label>
                                                 <textarea  type="text" class="form-control" id="qslmsg" name="qslmsg" rows="5" maxlength="240"><?php echo $qso->COL_QSLMSG; ?></textarea>
                                                 <div id="qslmsg_hide" style="display:none;"><?php echo $qso->COL_QSLMSG; ?></div>
-                                             </div>
+                                            </div>
                                         </div>
 
                                     </div>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -532,9 +532,10 @@
               <span class="badge text-bg-info"><?php echo lang('general_word_info'); ?></span> <?php echo lang('qsl_notes_helptext'); ?>
             </div>
            <div class="mb-3">
-           <label for="qslmsg"><?php echo lang('general_word_notes'); ?><span class="qso_eqsl_qslmsg_update" title="<?php echo lang('qso_eqsl_qslmsg_helptext'); ?>"><i class="fas fa-redo-alt"></i></span></label>
-              <textarea  type="text" class="form-control" id="qslmsg" name="qslmsg" rows="5" maxlength="240"><?php echo $qslmsg; ?></textarea>
-              <div id="qslmsg_hide" style="display:none;"><?php echo $qslmsg; ?></div>
+            <label for="qslmsg"><?php echo lang('general_word_notes'); ?><span class="qso_eqsl_qslmsg_update" title="<?php echo lang('qso_eqsl_qslmsg_helptext'); ?>"><i class="fas fa-redo-alt"></i></span></label>
+						<label class="position-absolute end-0 mb-2 me-3" for="qslmsg" id="charsLeft"> </label>
+            <textarea  type="text" class="form-control" id="qslmsg" name="qslmsg" rows="5" maxlength="240"><?php echo $qslmsg; ?></textarea>
+            <div id="qslmsg_hide" style="display:none;"><?php echo $qslmsg; ?></div>
             </div>
           </div>
         </div>

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -251,17 +251,18 @@
 
 			<div class="mb-3">
 				<label for="eqslDefaultQSLMsg"><?php echo lang("station_location_eqsl_defaultqslmsg"); ?></label>
-		    	<textarea class="form-control" name="eqsl_default_qslmsg" id="eqslDefaultQSLMsg" aria-describedby="eqsldefaultqslmsghelp" maxlength="240" rows="2" style="width:100%;"></textarea>
-		    	<small id="eqsldefaultqslmsghelp" class="form-text text-muted"><?php echo lang("station_location_eqsl_defaultqslmsg_hint"); ?> 240.</small>
-		  	</div>
+				<label class="position-absolute end-0 mb-2 me-3" for="eqslDefaultQSLMsg" id="charsLeft"> </label>
+				<textarea class="form-control" name="eqsl_default_qslmsg" id="eqslDefaultQSLMsg" aria-describedby="eqsldefaultqslmsghelp" maxlength="240" rows="2" style="width:100%;"></textarea>
+				<small id="eqsldefaultqslmsghelp" class="form-text text-muted"><?php echo lang("station_location_eqsl_defaultqslmsg_hint"); ?></small>
+			</div>
 
-                <div class="mb-3">
-			<label for="clublogrealtime"><?php echo lang("station_location_clublog_realtime_upload"); ?></label>
-			<select class="form-select" id="clublogrealtime" name="clublogrealtime">
-				<option value="1"><?php echo lang("general_word_yes"); ?></option>
-				<option value="0" selected><?php echo lang("general_word_no"); ?></option>
-			</select>
-		</div>
+            <div class="mb-3">
+				<label for="clublogrealtime"><?php echo lang("station_location_clublog_realtime_upload"); ?></label>
+				<select class="form-select" id="clublogrealtime" name="clublogrealtime">
+					<option value="1"><?php echo lang("general_word_yes"); ?></option>
+					<option value="0" selected><?php echo lang("general_word_no"); ?></option>
+				</select>
+			</div>
 
             <div class="row">
                 <div class="mb-3 col-sm-6">                                                                                                                                                    

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -354,9 +354,10 @@
 		  			</div>
 					<div class="mb-3">
 		    			<label for="eqslDefaultQSLMsg"><?php echo lang("station_location_eqsl_defaultqslmsg"); ?></label>
+						<label class="position-absolute end-0 mb-2 me-3" for="eqslDefaultQSLMsg" id="charsLeft"> </label>
 		    			<?php $eqsl_default_qslmsg = (set_value('eqsl_default_qslmsg') != "")?set_value('eqsl_default_qslmsg'):$eqsl_default_qslmsg; ?>
 		    			<textarea class="form-control" name="eqsl_default_qslmsg" id="eqslDefaultQSLMsg" aria-describedby="eqsldefaultqslmsghelp" maxlength="240" rows="2" style="width:100%;" value="<?php echo $eqsl_default_qslmsg; ?>"><?php echo $eqsl_default_qslmsg; ?></textarea>
-		    			<small id="eqsldefaultqslmsghelp" class="form-text text-muted"><?php echo lang("station_location_eqsl_defaultqslmsg_hint"); ?> 240.</small>
+		    			<small id="eqsldefaultqslmsghelp" class="form-text text-muted"><?php echo lang("station_location_eqsl_defaultqslmsg_hint"); ?></small>
 		  			</div>
 				</div>
 			</div>

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -295,8 +295,16 @@ function qso_edit(id) {
                         }
                     });
                     // [eQSL default msg] change value (for qso edit page) //
-                    $('.modal-content #stationProfile').change(function() { qso_set_eqsl_qslmsg($('.modal-content #stationProfile').val(),false,'.modal-content'); });
-                    $('.modal-content .qso_eqsl_qslmsg_update').off('click').on('click',function() { qso_set_eqsl_qslmsg($('.modal-content #stationProfile').val(),true,'.modal-content'); });
+                    $('.modal-content #stationProfile').change(function() { 
+                        qso_set_eqsl_qslmsg($('.modal-content #stationProfile').val(),false,'.modal-content'); 
+                    });
+                    $('.modal-content .qso_eqsl_qslmsg_update').off('click').on('click',function() { 
+                        qso_set_eqsl_qslmsg($('.modal-content #stationProfile').val(),true,'.modal-content');
+                        $('.modal-content #charsLeft').text(" ");
+                    });
+                    $('.modal-content #qslmsg').keyup(function(event) {
+                        calcRemainingChars(event, '.modal-content');
+                    });
                 },
             });
         }

--- a/assets/js/sections/eqslcharcounter.js
+++ b/assets/js/sections/eqslcharcounter.js
@@ -1,0 +1,18 @@
+$('#eqslDefaultQSLMsg').keyup(function(event) {
+    calcRemainingChars(event);
+});
+
+$('.qso_panel #qslmsg').keyup(function(event) {
+    calcRemainingChars(event, '.qso_panel');
+});
+
+function calcRemainingChars(event, object = '') {
+    var remainingChars = 240 - $(event.target).val().length;
+    $(object + ' #charsLeft').text(remainingChars + "/240");
+
+    if (remainingChars < 5) {
+        $(object + ' #charsLeft').css('color', 'red');
+    } else {
+        $(object + ' #charsLeft').css('color', '');
+    }
+}


### PR DESCRIPTION
in textarea qslmsg zone, if user use : 
- "&" : not accepted in url (error in send) --> convert in %26
- "Carriage Return" : not accepted (not error but not send) --> convert in space character