### PR TITLE
[MAP] reduce highlight map line on dark theme

### DIFF
--- a/assets/css/blue/overrides.css
+++ b/assets/css/blue/overrides.css
@@ -47,7 +47,10 @@ path.grid-worked {
 }
 
 #map,
-#qsomap {
+#qsomap,
+#mapqso,
+#gridsquare_map,
+#custommap {
 	background-color: #2e3e50;
 }
 

--- a/assets/css/cyborg/overrides.css
+++ b/assets/css/cyborg/overrides.css
@@ -41,8 +41,11 @@ path.grid-worked {
 }
 
 #map,
-#qsomap {
-	background-color: #000;
+#qsomap,
+#mapqso,
+#gridsquare_map,
+#custommap {
+	background-color: #2d3537;
 }
 
 .leaflet-popup-content h3 {

--- a/assets/css/darkly/overrides.css
+++ b/assets/css/darkly/overrides.css
@@ -59,8 +59,11 @@ path.grid-worked {
 }
 
 #map,
-#qsomap {
-	background-color: #222;
+#qsomap,
+#mapqso,
+#gridsquare_map,
+#custommap {
+	background-color: #343d3f;
 }
 
 /* 

--- a/assets/css/superhero/overrides.css
+++ b/assets/css/superhero/overrides.css
@@ -47,8 +47,11 @@ path.grid-worked {
 }
 
 #map,
-#qsomap {
-	background-color: #2e3e50;
+#qsomap,
+#mapqso,
+#gridsquare_map,
+#custommap {
+	background-color: #353c4a;
 }
 
 /* 


### PR DESCRIPTION
This fix is available for page : 
- qso edit
- analytics (gridsquare, activated, custom)

For the 4 dark theme. 

Example before : 
![global map KO](https://github.com/magicbug/Cloudlog/assets/13674762/64464e9a-4238-4be4-acbc-7bbd17722208)
![qso edit map KO](https://github.com/magicbug/Cloudlog/assets/13674762/00b0d31c-0186-4cf0-a7ae-b772312f31ce)

After : 
![global map OK](https://github.com/magicbug/Cloudlog/assets/13674762/73f1a0e2-37c5-4ae3-b9de-e8e96ce3b14e)
![qso edit map OK](https://github.com/magicbug/Cloudlog/assets/13674762/d1aea4e5-4770-402c-ba02-8e9af6646a93)


By the way, i think we can reduce the ID map at only 3 (map, qso edit, gridsquare), ... but it's a other exchange...