### PR TITLE
Catch empty QRZ.com response when downloading qrz-confirmations

### DIFF
--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -358,10 +358,11 @@ class Qrz extends CI_Controller {
 			}
 		}
 
-		if ($table != "")
-		{
+		if ($table != "") {
 			$data['tableheaders'] = $tableheaders;
 			$data['table'] = $table;
+		} else {
+			$data['table'] = '';
 		}
 
 		unlink($filepath);


### PR DESCRIPTION
Fixes small issue, when qrz-download is empty.