### PR TITLE
Check for empty LoTW/eQSL dates and catch the error

### DIFF
--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -359,12 +359,12 @@
                     <br /><p><?php echo lang('lotw_user'); ?> <a href="https://lotw.arrl.org/lotwuser/act?act=<?php echo $row->COL_CALL;?>" target="_blank"><?php echo lang('lotw_last_upload').'</a>: '; ?><?php $timestamp = strtotime($row->lastupload); echo date($custom_date_format, $timestamp); $timestamp = strtotime($row->lastupload); echo " ".date('H:i', $timestamp);?> UTC.</p>
                     <?php } ?>
 
-                    <?php if($row->COL_LOTW_QSL_RCVD == "Y") { ?>
+                    <?php if($row->COL_LOTW_QSL_RCVD == "Y" && $row->COL_LOTW_QSLRDATE != null) { ?>
                     <h3><?php echo lang('lotw_short'); ?></h3>
                     <p><?php echo lang('gen_this_qso_was_confirmed_on'); ?> <?php $timestamp = strtotime($row->COL_LOTW_QSLRDATE); echo date($custom_date_format, $timestamp); ?>.</p>
                     <?php } ?>
 
-                    <?php if($row->COL_EQSL_QSL_RCVD == "Y") { ?>
+                    <?php if($row->COL_EQSL_QSL_RCVD == "Y" && $row->COL_EQSL_QSLRDATE != null) { ?>
                     <h3>eQSL</h3>
                         <p><?php echo lang('gen_this_qso_was_confirmed_on'); ?> <?php $timestamp = strtotime($row->COL_EQSL_QSLRDATE); echo date($custom_date_format, $timestamp); ?>.</p>
                     <?php } ?>


### PR DESCRIPTION
Catches a PHP (8) error if LoTW/eQSL date is empty but cnfm is set to 'Y'. Reported by @AndreasK79 though we do not know yet how the date can be empty ...

![signal-2023-12-12-092836_002](https://github.com/magicbug/Cloudlog/assets/7112907/5a8d04ae-82dc-4c2f-8673-662f31d08244)