### PR TITLE
Fix empty QRZ QSL stats on fresh install

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2539,6 +2539,8 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
 	    $QSLBreakdown['eQSL_Received'] =  0;
 	    $QSLBreakdown['LoTW_Sent'] =  0;
 	    $QSLBreakdown['LoTW_Received'] = 0;
+	    $QSLBreakdown['QRZ_Sent'] = 0;
+	    $QSLBreakdown['QRZ_Received'] = 0;
 	    $QSLBreakdown['QSL_Sent_today'] = 0;
 	    $QSLBreakdown['QSL_Received_today'] =  0;
 	    $QSLBreakdown['QSL_Requested_today'] =  0;
@@ -2546,6 +2548,8 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
 	    $QSLBreakdown['eQSL_Received_today'] =  0;
 	    $QSLBreakdown['LoTW_Sent_today'] =  0;
 	    $QSLBreakdown['LoTW_Received_today'] = 0;
+	    $QSLBreakdown['QRZ_Sent_today'] = 0;
+	    $QSLBreakdown['QRZ_Received_today'] = 0;
 
 	    return $QSLBreakdown;
 	}
@@ -2557,6 +2561,8 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
 	    $QSLBreakdown['eQSL_Received'] =  0;
 	    $QSLBreakdown['LoTW_Sent'] =  0;
 	    $QSLBreakdown['LoTW_Received'] = 0;
+	    $QSLBreakdown['QRZ_Sent'] = 0;
+	    $QSLBreakdown['QRZ_Received'] = 0;
 	    $QSLBreakdown['QSL_Sent_today'] = 0;
 	    $QSLBreakdown['QSL_Received_today'] =  0;
 	    $QSLBreakdown['QSL_Requested_today'] =  0;
@@ -2564,6 +2570,8 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
 	    $QSLBreakdown['eQSL_Received_today'] =  0;
 	    $QSLBreakdown['LoTW_Sent_today'] =  0;
 	    $QSLBreakdown['LoTW_Received_today'] = 0;
+	    $QSLBreakdown['QRZ_Sent_today'] = 0;
+	    $QSLBreakdown['QRZ_Received_today'] = 0;
 
 	    return $QSLBreakdown;
       }


### PR DESCRIPTION
QRZ QSL stats are empty on fresh install and stats array values are not set to zero in that case. Result:

![Screenshot from 2023-12-15 21-18-10](https://github.com/magicbug/Cloudlog/assets/7112907/5c3e3340-e6e7-441f-a97b-b1c36b7106fa)

Fixes https://github.com/magicbug/Cloudlog/discussions/2842