### PR TITLE
Sometimes JA prefs are one digit only...

### DIFF
--- a/application/models/Waja.php
+++ b/application/models/Waja.php
@@ -215,7 +215,7 @@ class WAJA extends CI_Model {
      * $postdata contains data from the form, in this case Lotw or QSL are used
      */
     function getWajaWorked($location_list, $band, $postdata) {
-        $sql = "SELECT distinct col_state FROM " . $this->config->item('table_name') . " thcv
+        $sql = "SELECT distinct LPAD(col_state, 2, '0') AS col_state FROM " . $this->config->item('table_name') . " thcv
         where station_id in (" . $location_list . ")";
 
 		if ($postdata['mode'] != 'All') {
@@ -252,7 +252,7 @@ class WAJA extends CI_Model {
      * $postdata contains data from the form, in this case Lotw or QSL are used
      */
     function getWajaConfirmed($location_list, $band, $postdata) {
-        $sql = "SELECT distinct col_state FROM " . $this->config->item('table_name') . " thcv
+        $sql = "SELECT distinct LPAD(col_state, 2, '0') AS col_state FROM " . $this->config->item('table_name') . " thcv
             where station_id in (" . $location_list . ")";
 
 		if ($postdata['mode'] != 'All') {


### PR DESCRIPTION
DK9JC reported that WAJA award fails on his machine. Analysis showed that some QSOs had state Nos < 10 with one digit only. But the code relies on two digits (i.e. 0-padded for < 10). 

![photo_2023-12-18_23-48-49](https://github.com/magicbug/Cloudlog/assets/7112907/c2ea74e8-3a95-4130-ba55-94eca7d68665)

The code fails to count 8 and 08 as the same state. So we need some padding here. Please test if this is compatible among the various databases.