### PR TITLE
[THEME] Standardize get_theme function + fix display arrow on select list on dark theme

### DIFF
--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -4,14 +4,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <!-- Bootstrap CSS -->
-    <?php if($this->session->userdata('user_stylesheet')) { ?>
-		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $this->session->userdata('user_stylesheet');?>/bootstrap.min.css">
+    <?php if($this->optionslib->get_theme()) { ?>
+		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $this->optionslib->get_theme();?>/bootstrap.min.css">
 		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/general.css">
-		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $this->session->userdata('user_stylesheet');?>/overrides.css">
-	<?php } else { ?>
-		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/default/bootstrap.min.css">
-		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/general.css">
-		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/default/overrides.css">
+		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $this->optionslib->get_theme();?>/overrides.css">
 	<?php } ?>
 
     <link rel="stylesheet" href="<?php echo base_url(); ?>assets/fontawesome/css/all.css">

--- a/assets/css/cyborg/overrides.css
+++ b/assets/css/cyborg/overrides.css
@@ -101,6 +101,9 @@ path.grid-worked {
 	color: #eeeeee;
 	border: 1px solid #333;
 }
+.form-select {
+	--bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23FFFFFF' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+}
 
 .bootstrap-dialog.type-primary .modal-header {
 	background-color: #131313;
@@ -184,6 +187,7 @@ path.grid-worked {
 	--bs-accordion-btn-focus-border-color: #FFFFFF;
 	--bs-accordion-btn-focus-box-shadow: initial;
 	--bs-accordion-border-color: #2c2c2c;
+	--bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23FFFFFF'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
 }
 .accordion-button.collapsed {
 	border-bottom: 1px solid var(--bs-body-bg);

--- a/assets/css/cyborg_wide/overrides.css
+++ b/assets/css/cyborg_wide/overrides.css
@@ -101,6 +101,9 @@ path.grid-worked {
 	color: #eeeeee;
 	border: 1px solid #333;
 }
+.form-select {
+	--bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23FFFFFF' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+}
 
 .bootstrap-dialog.type-primary .modal-header {
 	background-color: #131313;
@@ -239,6 +242,7 @@ path.grid-worked {
 	--bs-accordion-btn-focus-border-color: #FFFFFF;
 	--bs-accordion-btn-focus-box-shadow: initial;
 	--bs-accordion-border-color: #2c2c2c;
+	--bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23FFFFFF'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
 }
 .accordion-button.collapsed {
 	border-bottom: 1px solid var(--bs-body-bg);

--- a/assets/css/darkly/overrides.css
+++ b/assets/css/darkly/overrides.css
@@ -115,6 +115,9 @@ path.grid-worked {
 	background-color: rgba(20, 20, 20, 0.5);
 	color: #eee;
 }
+.form-select {
+	--bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23FFFFFF' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+}
 
 select optgroup,
 select option {
@@ -195,6 +198,7 @@ div.alert-danger {
 	--bs-accordion-btn-bg: #444444;
 	--bs-accordion-active-bg: #444444;
 	--bs-accordion-border-color: #444444;
+	--bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23FFFFFF'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
 }
 .accordion-button.collapsed {
 	border-bottom:1px solid var(--bs-body-bg);

--- a/assets/css/darkly_wide/overrides.css
+++ b/assets/css/darkly_wide/overrides.css
@@ -115,6 +115,9 @@ path.grid-worked {
 	background-color: rgba(20, 20, 20, 0.5);
 	color: #eee;
 }
+.form-select {
+	--bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23FFFFFF' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+}
 
 select optgroup,
 select option {
@@ -251,6 +254,7 @@ div.alert-danger {
 	--bs-accordion-btn-bg: #444444;
 	--bs-accordion-active-bg: #444444;
 	--bs-accordion-border-color: #444444;
+	--bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23FFFFFF'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
 }
 .accordion-button.collapsed {
 	border-bottom:1px solid var(--bs-body-bg);

--- a/assets/css/superhero/overrides.css
+++ b/assets/css/superhero/overrides.css
@@ -104,6 +104,9 @@ path.grid-worked {
 	background-color: rgba(20, 41, 62, 0.6);
 	color: #fff;
 }
+.form-select {
+	--bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23FFFFFF' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+}
 
 div.alert-danger {
 	color: #ffffff;
@@ -184,6 +187,7 @@ div.alert-danger {
 	--bs-accordion-bg: var(--cl-bg);
 	--bs-accordion-btn-bg: #4e5e6c;
 	--bs-accordion-active-bg: #4e5e6c;
+	--bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23FFFFFF'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
 }
 .accordion-button.collapsed {
 	border-bottom: 1px solid var(--cl-bg);

--- a/assets/css/superhero_wide/overrides.css
+++ b/assets/css/superhero_wide/overrides.css
@@ -113,6 +113,9 @@ path.grid-worked {
 .navbar-light .navbar-nav .nav-link:hover {
 	color: #fff;
 }
+.form-select {
+	--bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23FFFFFF' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+}
 
 /* Hamburger Menu */
 
@@ -238,6 +241,7 @@ div.alert-danger {
 	--bs-accordion-bg: var(--cl-bg);
 	--bs-accordion-btn-bg: #4e5e6c;
 	--bs-accordion-active-bg: #4e5e6c;
+	--bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23FFFFFF'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
 }
 .accordion-button.collapsed {
 	border-bottom: 1px solid var(--cl-bg);


### PR DESCRIPTION
get_theme function not used on edit_ajax.php file

Question for Team :
Why an "if get_theme()" is make on edit_ajax.php and header.php view ? get_theme() return always something
OK for simplify (remove if) ?
![if gettheme()](https://github.com/magicbug/Cloudlog/assets/13674762/04b90480-a4f3-491f-8bd1-a44f9f60bb28)
