### PR TITLE
Fixes query so that only qsos from your station_id is shown

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -209,7 +209,7 @@ class Logbook extends CI_Controller {
 		if(!empty($logbooks_locations_array)) {
 			$extrawhere='';
 			if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'Q') !== false) {
-				$extrawhere="COL_QSL_RCVD='Y'"; 
+				$extrawhere="COL_QSL_RCVD='Y'";
 			}
 			if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'L') !== false) {
 				if ($extrawhere!='') {
@@ -336,10 +336,10 @@ class Logbook extends CI_Controller {
 			$return['workedBefore'] = true;
 		}
 
-		
+
 		$extrawhere='';
 		if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'Q') !== false) {
-			$extrawhere="COL_QSL_RCVD='Y'"; 
+			$extrawhere="COL_QSL_RCVD='Y'";
 		}
 		if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'L') !== false) {
 			if ($extrawhere!='') {
@@ -427,7 +427,7 @@ class Logbook extends CI_Controller {
 
 			$extrawhere='';
 			if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'Q') !== false) {
-				$extrawhere="COL_QSL_RCVD='Y'"; 
+				$extrawhere="COL_QSL_RCVD='Y'";
 			}
 			if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'L') !== false) {
 				if ($extrawhere!='') {
@@ -528,7 +528,7 @@ class Logbook extends CI_Controller {
 
 			$extrawhere='';
 			if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'Q') !== false) {
-				$extrawhere="COL_QSL_RCVD='Y'"; 
+				$extrawhere="COL_QSL_RCVD='Y'";
 			}
 			if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'L') !== false) {
 				if ($extrawhere!='') {
@@ -683,7 +683,7 @@ class Logbook extends CI_Controller {
 
 		}
 		echo "]";
-		
+
 		// [MAP Custom] ADD Station //
 		$this->load->model('Stations');
 		$station_json = $this->Stations->get_station_json_for_map();
@@ -737,15 +737,18 @@ class Logbook extends CI_Controller {
 
 			$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
 			$this->db->where_in('station_profile.station_id', $logbooks_locations_array);
-			$this->db->order_by(''.$this->config->item('table_name').'.COL_TIME_ON', "desc");
 
+			$this->db->group_start();
 			$this->db->where($this->config->item('table_name').'.COL_CALL', $id);
 			$this->db->or_like($this->config->item('table_name').'.COL_CALL', '/'.$id,'before');
 			$this->db->or_like($this->config->item('table_name').'.COL_CALL', $id.'/','after');
 			$this->db->or_like($this->config->item('table_name').'.COL_CALL', '/'.$id.'/');
+			$this->db->group_end();
 
 			$this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "desc");
 			$this->db->limit(5);
+
+			$c = $this->db->get_compiled_select();
 
 			$query = $this->db->get();
 		}

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -748,8 +748,6 @@ class Logbook extends CI_Controller {
 			$this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "desc");
 			$this->db->limit(5);
 
-			$c = $this->db->get_compiled_select();
-
 			$query = $this->db->get();
 		}
 


### PR DESCRIPTION
The previous QSOs query in the logging window was broken, and fetched QSOs from other station id's