### PR TITLE
Add "times worked" to QSO-Page

### DIFF
--- a/application/language/bulgarian/qso_lang.php
+++ b/application/language/bulgarian/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('Не е разрешен директен дост�
 $lang['qso_title_qso_map'] = 'Карта на QSO';
 $lang['qso_title_suggestions'] = 'Предложения';
 $lang['qso_title_previous_contacts'] = 'Предишни контакти';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Profile Picture';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/chinese_simplified/qso_lang.php
+++ b/application/language/chinese_simplified/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['qso_title_qso_map'] = 'QSO 地图';
 $lang['qso_title_suggestions'] = '建议';
 $lang['qso_title_previous_contacts'] = '先前通联';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = '操作员照片';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG 输入呼号';

--- a/application/language/czech/qso_lang.php
+++ b/application/language/czech/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['qso_title_qso_map'] = 'Mapa spojení';
 $lang['qso_title_suggestions'] = 'Návrhy';
 $lang['qso_title_previous_contacts'] = 'Předchozí spojení';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Profile Picture';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/dutch/qso_lang.php
+++ b/application/language/dutch/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('Directe toegang tot scripts is niet toegestaan');
 $lang['qso_title_qso_map'] = 'QSO Kaart';
 $lang['qso_title_suggestions'] = 'Suggesties';
 $lang['qso_title_previous_contacts'] = 'Eerdere verbindingen';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Profile Picture';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/english/qso_lang.php
+++ b/application/language/english/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['qso_title_qso_map'] = 'QSO Map';
 $lang['qso_title_suggestions'] = 'Suggestions';
 $lang['qso_title_previous_contacts'] = 'Previous Contacts';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Profile Picture';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/finnish/qso_lang.php
+++ b/application/language/finnish/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['qso_title_qso_map'] = 'Vasta-aseman sijainti kartalla';
 $lang['qso_title_suggestions'] = 'Kutsumerkkiehdotukset';
 $lang['qso_title_previous_contacts'] = 'Edelliset yhteydet';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Profiilikuva';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/french/qso_lang.php
+++ b/application/language/french/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['qso_title_qso_map'] = 'Carte QSO';
 $lang['qso_title_suggestions'] = 'Suggestions';
 $lang['qso_title_previous_contacts'] = 'Contacts précédents';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Profile Picture';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/german/qso_lang.php
+++ b/application/language/german/qso_lang.php
@@ -6,7 +6,7 @@ defined('BASEPATH') OR exit('Direkter Zugriff auf Skripte ist nicht erlaubt');
 $lang['qso_title_qso_map'] = 'QSO-Karte';
 $lang['qso_title_suggestions'] = 'Vorschläge';
 $lang['qso_title_previous_contacts'] = 'Vorherige Kontakte';
-$lang['qso_title_times_worked_before'] = " mal vorher gearbeitet";
+$lang['qso_title_times_worked_before'] = "mal vorher gearbeitet";
 $lang['qso_title_image'] = 'Profilbild';
 $lang['qso_previous_max_shown'] = "Es werden maximal 5 Kontakte angezeigt.";
 

--- a/application/language/german/qso_lang.php
+++ b/application/language/german/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('Direkter Zugriff auf Skripte ist nicht erlaubt');
 $lang['qso_title_qso_map'] = 'QSO-Karte';
 $lang['qso_title_suggestions'] = 'Vorschläge';
 $lang['qso_title_previous_contacts'] = 'Vorherige Kontakte';
+$lang['qso_title_times_worked_before'] = " mal vorher gearbeitet";
 $lang['qso_title_image'] = 'Profilbild';
+$lang['qso_previous_max_shown'] = "Es werden maximal 5 Kontakte angezeigt.";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Rufzeichen';

--- a/application/language/greek/qso_lang.php
+++ b/application/language/greek/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['qso_title_qso_map'] = 'Χάρτης QSO';
 $lang['qso_title_suggestions'] = 'Εισήγησης';
 $lang['qso_title_previous_contacts'] = 'Προηγούμενες Επαφές';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Εικόνα προφίλ';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/italian/qso_lang.php
+++ b/application/language/italian/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('Non è permesso l\'accesso diretto allo script');
 $lang['qso_title_qso_map'] = 'Mappa QSO';
 $lang['qso_title_suggestions'] = 'Suggerimenti';
 $lang['qso_title_previous_contacts'] = 'Contatti Precedenti';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Immagine Profilo';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/polish/qso_lang.php
+++ b/application/language/polish/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['qso_title_qso_map'] = 'Mapa łączności';
 $lang['qso_title_suggestions'] = 'Sugestie';
 $lang['qso_title_previous_contacts'] = 'Poprzednie łączności';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Profile Picture';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/russian/qso_lang.php
+++ b/application/language/russian/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['qso_title_qso_map'] = 'Карта QSO';
 $lang['qso_title_suggestions'] = 'Предложения';
 $lang['qso_title_previous_contacts'] = 'Предыдущие контакты';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Profile Picture';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/spanish/qso_lang.php
+++ b/application/language/spanish/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['qso_title_qso_map'] = 'Mapa de QSO';
 $lang['qso_title_suggestions'] = 'Sugerencias';
 $lang['qso_title_previous_contacts'] = 'Contactos previos';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Profile Picture';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/swedish/qso_lang.php
+++ b/application/language/swedish/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['qso_title_qso_map'] = 'QSO-karta';
 $lang['qso_title_suggestions'] = 'Förslag';
 $lang['qso_title_previous_contacts'] = 'Föregående QSOn';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Profilbild';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/language/turkish/qso_lang.php
+++ b/application/language/turkish/qso_lang.php
@@ -6,7 +6,9 @@ defined('BASEPATH') OR exit('Doğrudan komut dosyası erişimine izin verilmez')
 $lang['qso_title_qso_map'] = 'QSO Haritası';
 $lang['qso_title_suggestions'] = 'Öneriler';
 $lang['qso_title_previous_contacts'] = 'Önceki Görüşmeler';
+$lang['qso_title_times_worked_before'] = "times worked before";
 $lang['qso_title_image'] = 'Profil Resmi';
+$lang['qso_previous_max_shown'] = "Max. 5 previous contacts are shown";
 
 // Quicklog on Dashboard
 $lang['qso_quicklog_enter_callsign'] = 'QUICKLOG Enter Callsign';

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1347,6 +1347,28 @@ class Logbook_model extends CI_Model {
 		return $name;
 	}
 
+	function times_worked($callsign) {
+		$this->db->select('count(1) as TWKED');
+		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+		$this->db->group_start();
+		$this->db->where($this->config->item('table_name').'.COL_CALL', $callsign);
+		$this->db->or_like($this->config->item('table_name').'.COL_CALL', '/'.$callsign,'before');
+		$this->db->or_like($this->config->item('table_name').'.COL_CALL', $callsign.'/','after');
+		$this->db->or_like($this->config->item('table_name').'.COL_CALL', '/'.$callsign.'/');
+		$this->db->group_end();
+		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
+		$this->db->limit(1);
+		$query = $this->db->get($this->config->item('table_name'));
+		$name = "";
+		if ($query->num_rows() > 0)
+		{
+			$data = $query->row();
+			$times_worked = $data->TWKED;
+		}
+
+		return $times_worked;
+	}
+
 	function call_qslvia($callsign) {
 		$this->db->select('COL_CALL, COL_QSL_VIA, COL_TIME_ON');
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -637,7 +637,7 @@
     <?php } ?>
 
     <div class="card previous-qsos">
-      <div class="card-header"><h4 class="card-title" style="font-size: 16px; font-weight: bold;"><?php echo lang('qso_title_previous_contacts'); ?></h4></div>
+      <div class="card-header"><h4 class="card-title" style="font-size: 16px; font-weight: bold;"><span id="timesWorked"></span><?php echo lang('qso_title_previous_contacts'); ?></h4></div>
 
         <div id="partial_view" style="font-size: 0.95rem;"></div>
 

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -2,6 +2,8 @@
 <script language="javascript">
   var qso_manual  = "<?php echo $_GET['manual']; ?>";
   var text_error_timeoff_less_timeon = "<?php echo lang('qso_error_timeoff_less_timeon'); ?>";
+  var lang_qso_title_previous_contacts = "<?php echo lang('qso_title_previous_contacts'); ?>";
+  var lang_qso_title_times_worked_before = "<?php echo lang('qso_title_times_worked_before'); ?>";
 </script>
 
 <div class="row qsopane">
@@ -637,7 +639,7 @@
     <?php } ?>
 
     <div class="card previous-qsos">
-      <div class="card-header"><h4 class="card-title" style="font-size: 16px; font-weight: bold;"><span id="timesWorked"></span><?php echo lang('qso_title_previous_contacts'); ?></h4></div>
+      <div class="card-header"><h4 class="card-title" id="timesWorked" style="font-size: 16px; font-weight: bold;"><?php echo lang('qso_title_previous_contacts'); ?></h4></div>
 
         <div id="partial_view" style="font-size: 0.95rem;"></div>
 
@@ -645,6 +647,7 @@
 
         </div>
       </div>
+      <small class="mt-0.5" style="float: right;"><?php echo lang('qso_previous_max_shown'); ?></small>
     </div>
   </div>
 

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -758,6 +758,7 @@ $("#callsign").focusout(function() {
 					county_selectize.setValue(result.callsign_us_county, false);
 				}
 
+				$('#timesWorked').html(result.timesWorked + ' ');
 				if($('#iota_ref').val() == "") {
 					$('#iota_ref').val(result.callsign_iota);
 				}

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -528,7 +528,7 @@ function reset_fields() {
 	mymap.removeLayer(markers);
 	$('.callsign-suggest').hide();
 	$('.dxccsummary').remove();
-	$('#timesWorked').html('');
+	$('#timesWorked').html(lang_qso_title_previous_contacts);
 }
 
 function resetTimers(manual) {
@@ -759,7 +759,11 @@ $("#callsign").focusout(function() {
 					county_selectize.setValue(result.callsign_us_county, false);
 				}
 
-				$('#timesWorked').html(result.timesWorked + ' ');
+				if(result.timesWorked != "") {
+					$('#timesWorked').html(result.timesWorked + lang_qso_title_times_worked_before);
+				} else {
+					$('#timesWorked').html(lang_qso_title_previous_contacts);
+				}
 				if($('#iota_ref').val() == "") {
 					$('#iota_ref').val(result.callsign_iota);
 				}
@@ -1050,7 +1054,7 @@ function resetDefaultQSOFields() {
 	$('#callsign-image').attr('style', 'display: none;');
 	$('#callsign-image-content').text("");
 	$('.dxccsummary').remove();
-	$('#timesWorked').html('');
+	$('#timesWorked').html(lang_qso_title_previous_contacts);
 }
 
 function closeModal() {

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -760,7 +760,7 @@ $("#callsign").focusout(function() {
 				}
 
 				if(result.timesWorked != "") {
-					$('#timesWorked').html(result.timesWorked + lang_qso_title_times_worked_before);
+					$('#timesWorked').html(result.timesWorked + ' ' + lang_qso_title_times_worked_before);
 				} else {
 					$('#timesWorked').html(lang_qso_title_previous_contacts);
 				}

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -528,6 +528,7 @@ function reset_fields() {
 	mymap.removeLayer(markers);
 	$('.callsign-suggest').hide();
 	$('.dxccsummary').remove();
+	$('#timesWorked').html('');
 }
 
 function resetTimers(manual) {
@@ -1049,6 +1050,7 @@ function resetDefaultQSOFields() {
 	$('#callsign-image').attr('style', 'display: none;');
 	$('#callsign-image-content').text("");
 	$('.dxccsummary').remove();
+	$('#timesWorked').html('');
 }
 
 function closeModal() {


### PR DESCRIPTION
At the qso-page you can see the last 5 QSOs, but you cannot see how often you worked the station.
This PR adds the information at the top of the table (See Screenshot)

<img width="1143" alt="image of qso-prev-window" src="https://github.com/magicbug/Cloudlog/assets/1410708/0928049b-530b-47c4-a3d6-51279dbdfa2f">

QSO-Count is calculated on the BASE-Call.
e.g.: DF2ET counts "TF/DF2ET/p" as well as "DF2ET" and "DF2ET/mm"