### PR TITLE
Added time of "Worked before" in Contest-Section

### DIFF
--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -189,10 +189,10 @@ class Contesting extends CI_Controller {
 		
 		header('Content-Type: application/json');
 		if ($result && $result->num_rows()) {
-			$timeb4=$result->row()->b4;
+			$timeb4=substr($result->row()->b4,0,5);
         		$custom_date_format = $this->session->userdata('user_date_format');
 			$abstimeb4=date($custom_date_format, strtotime($result->row()->COL_TIME_OFF)).' '.date('H:i',strtotime($result->row()->COL_TIME_OFF));
-			echo json_encode(array('message' => 'Worked at '.$abstimeb4.' ('.$timeb4.') before'));
+			echo json_encode(array('message' => 'Worked at '.$abstimeb4.' ('.$timeb4.' ago) before'));
 		}
 		return;
 	}

--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -189,7 +189,8 @@ class Contesting extends CI_Controller {
 		
 		header('Content-Type: application/json');
 		if ($result && $result->num_rows()) {
-			echo json_encode(array('message' => 'Worked before'));
+			$timeb4=$result->row()->b4;
+			echo json_encode(array('message' => 'Worked '.$timeb4.' before'));
 		}
 		return;
 	}

--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -190,7 +190,9 @@ class Contesting extends CI_Controller {
 		header('Content-Type: application/json');
 		if ($result && $result->num_rows()) {
 			$timeb4=$result->row()->b4;
-			echo json_encode(array('message' => 'Worked '.$timeb4.' before'));
+        		$custom_date_format = $this->session->userdata('user_date_format');
+			$abstimeb4=date($custom_date_format, strtotime($result->row()->COL_TIME_OFF)).' '.date('H:i',strtotime($result->row()->COL_TIME_OFF));
+			echo json_encode(array('message' => 'Worked at '.$abstimeb4.' ('.$timeb4.') before'));
 		}
 		return;
 	}

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -219,7 +219,8 @@ class Contesting_model extends CI_Model {
 	
 			$date = DateTime::createFromFormat('d-m-Y H:i:s', $qsoarray[0]);
 			$date = $date->format('Y-m-d H:i:s');
-	
+
+			$this->db->select('timediff(UTC_TIMESTAMP(),col_time_on) b4');
 			$this->db->where('STATION_ID', $station_id);
 			$this->db->where('COL_CALL', xss_clean($call));
 			$this->db->where("COL_BAND", xss_clean($band));
@@ -229,6 +230,7 @@ class Contesting_model extends CI_Model {
 			$this->db->where("COL_MODE", xss_clean($mode));
 			$this->db->or_where("COL_SUBMODE", xss_clean($mode));
 			$this->db->group_end();
+        		$this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "DESC");
 			$query = $this->db->get($this->config->item('table_name'));
 	
 			return $query;

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -220,7 +220,7 @@ class Contesting_model extends CI_Model {
 			$date = DateTime::createFromFormat('d-m-Y H:i:s', $qsoarray[0]);
 			$date = $date->format('Y-m-d H:i:s');
 
-			$this->db->select('timediff(UTC_TIMESTAMP(),col_time_on) b4');
+			$this->db->select('timediff(UTC_TIMESTAMP(),col_time_off) b4, COL_TIME_OFF');
 			$this->db->where('STATION_ID', $station_id);
 			$this->db->where('COL_CALL', xss_clean($call));
 			$this->db->where("COL_BAND", xss_clean($band));

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -241,8 +241,8 @@ function checkIfWorkedBefore() {
 				'contest': $("#contestname").val()
 			},
 			success: function (result) {
-				if (result.message == 'Worked before') {
-					$('#callsign_info').text("Worked before!");
+				if (result.message.substr(0,6) == 'Worked') {
+					$('#callsign_info').text(result.message);
 				}
 			}
 		});


### PR DESCRIPTION
In some contest you are permitted to work a station again on the next day, or after a specified time.
To see the last-worked timediff quickly i added this patch.

Behaviour of everything else is still the same.

<img width="298" alt="image of wked b4" src="https://github.com/magicbug/Cloudlog/assets/1410708/b7634620-2e6b-4e22-be83-aca19a0e53a9">
