### PR TITLE
[Admin User Menu] Show Callsign in List and Option to send Passwort Reset Link

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 166;
+$config['migration_version'] = 167;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -804,6 +804,84 @@ class User extends CI_Controller {
 		}
 	}
 
+	function admin_send_passwort_reset() {
+
+		$this->load->model('user_model');
+		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+		$query = $this->user_model->get_by_id($this->uri->segment(3));
+
+		$this->load->library('form_validation');
+
+		$this->form_validation->set_rules('id', 'user_id', 'required');
+
+		$data = $query->row();
+
+		if ($this->form_validation->run() != FALSE)
+		{
+			$this->session->set_flashdata('notice', 'Something went wrong! User has no user_id.');
+			redirect('user');
+		}
+		else
+		{
+			// Check email address exists
+			$this->load->model('user_model');
+
+			$check_email = $this->user_model->check_email_address($data->user_email);
+
+			if($check_email == TRUE) {
+				// Generate password reset code 50 characters long
+				$this->load->helper('string');
+				$reset_code = random_string('alnum', 50);
+				$user_first_name = $data->user_firstname;
+				$this->user_model->set_password_reset_code(($data->user_email), $reset_code);
+
+				// Send email with reset code and first Name of the User
+
+				$this->data['reset_code'] = $reset_code;
+				$this->data['user_first_name'] = $user_first_name;
+				$this->load->library('email');
+
+				if($this->optionslib->get_option('emailProtocol') == "smtp") {
+					$config = Array(
+						'protocol' => $this->optionslib->get_option('emailProtocol'),
+						'smtp_crypto' => $this->optionslib->get_option('smtpEncryption'),
+						'smtp_host' => $this->optionslib->get_option('smtpHost'),
+						'smtp_port' => $this->optionslib->get_option('smtpPort'),
+						'smtp_user' => $this->optionslib->get_option('smtpUsername'),
+						'smtp_pass' => $this->optionslib->get_option('smtpPassword'),
+						'crlf' => "\r\n",
+						'newline' => "\r\n"
+					  );
+
+					  $this->email->initialize($config);
+				}
+
+				$message = $this->load->view('email/admin_reset_password', $this->data,  TRUE);
+
+				$this->email->from($this->optionslib->get_option('emailAddress'), $this->optionslib->get_option('emailSenderName'));
+				$this->email->to($data->user_email);
+				$this->email->set_mailtype("html");
+				$this->email->subject('Cloudlog Account Password Reset');
+				$this->email->message($message);
+
+				if (! $this->email->send())
+				{
+					// Redirect to user page with message
+					$this->session->set_flashdata('notice', 'Email settings are incorrect.');
+					redirect('user');
+				} else {
+					// Redirect to user page with message
+					$this->session->set_flashdata('notice', 'Password Reset Processed.');
+					redirect('user');
+				}
+			} else {
+				// No account found just return to user page
+				$this->session->set_flashdata('notice', 'Nothing done. No user found.');
+				redirect('user');
+			}
+		}
+	}
+
 	function reset_password($reset_code = NULL)
 	{
 		$data['reset_code'] = $reset_code;

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -834,13 +834,14 @@ class User extends CI_Controller {
 				// Generate password reset code 50 characters long
 				$this->load->helper('string');
 				$reset_code = random_string('alnum', 50);
-				$user_first_name = $data->user_firstname;
 				$this->user_model->set_password_reset_code(($data->user_email), $reset_code);
 
 				// Send email with reset code and first Name of the User
 
 				$this->data['reset_code'] = $reset_code;
-				$this->data['user_first_name'] = $user_first_name;  // We can call the user by his first name in the E-Mail
+				$this->data['user_firstname'] = $data->user_firstname; // We can call the user by his first name in the E-Mail
+				$this->data['user_callsign'] = $data->user_callsign;
+				$this->data['user_name'] = $data->user_name;
 				$this->load->library('email');
 
 				if($this->optionslib->get_option('emailProtocol') == "smtp") {
@@ -862,7 +863,6 @@ class User extends CI_Controller {
 
 				$this->email->from($this->optionslib->get_option('emailAddress'), $this->optionslib->get_option('emailSenderName'));
 				$this->email->to($data->user_email);
-				$this->email->set_mailtype("html");
 				$this->email->subject('Cloudlog Account Password Reset');
 				$this->email->message($message);
 

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -695,6 +695,7 @@ class User extends CI_Controller {
 			if($this->user_model->login() == 1) {
 				$this->session->set_flashdata('notice', 'User logged in');
 				$this->user_model->update_session($data['user']->user_id);
+				$this->user_model->set_last_login($data['user']->user_id);
 				$cookie= array(
 
 					'name'   => 'language',

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -805,6 +805,7 @@ class User extends CI_Controller {
 		}
 	}
 
+	// Send an E-Mail to the user. Function is similar to forgot_password()
 	function admin_send_passwort_reset() {
 
 		$this->load->model('user_model');

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -838,7 +838,7 @@ class User extends CI_Controller {
 				// Send email with reset code and first Name of the User
 
 				$this->data['reset_code'] = $reset_code;
-				$this->data['user_first_name'] = $user_first_name;
+				$this->data['user_first_name'] = $user_first_name;  // We can call the user by his first name in the E-Mail
 				$this->load->library('email');
 
 				if($this->optionslib->get_option('emailProtocol') == "smtp") {
@@ -867,16 +867,16 @@ class User extends CI_Controller {
 				if (! $this->email->send())
 				{
 					// Redirect to user page with message
-					$this->session->set_flashdata('notice', 'Email settings are incorrect.');
+					$this->session->set_flashdata('danger', lang('admin_email_settings_incorrect'));
 					redirect('user');
 				} else {
 					// Redirect to user page with message
-					$this->session->set_flashdata('notice', 'Password Reset Processed.');
+					$this->session->set_flashdata('success', lang('admin_password_reset_processed'));
 					redirect('user');
 				}
 			} else {
 				// No account found just return to user page
-				$this->session->set_flashdata('notice', 'Nothing done. No user found.');
+				$this->session->set_flashdata('danger', 'Nothing done. No user found.');
 				redirect('user');
 			}
 		}

--- a/application/language/bulgarian/admin_lang.php
+++ b/application/language/bulgarian/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('Не е разрешен директен дост�
 $lang['admin_user_line1'] = 'Cloudlog needs at least one user configured in order to operate.';
 $lang['admin_user_line2'] = 'Users can be assigned roles which give them different permissions, such as adding QSOs to the logbook and accessing Cloudlog APIs.';
 $lang['admin_user_line3'] = 'The currently logged-in user is displayed at the upper-right of each page.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'User List';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'User Accounts';
 $lang['admin_danger'] = 'DANGER!';
 $lang['admin_experimental'] = "Experimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/bulgarian/admin_lang.php
+++ b/application/language/bulgarian/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'User List';
 $lang['admin_user'] = 'User';
 $lang['admin_email'] = 'E-mail';
 $lang['admin_type'] = 'Type';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Options';
 
 $lang['admin_create_user'] = 'Create user';

--- a/application/language/bulgarian/general_words_lang.php
+++ b/application/language/bulgarian/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = 'Дата';
 $lang['general_word_startdate'] = "Start Date";

--- a/application/language/chinese_simplified/admin_lang.php
+++ b/application/language/chinese_simplified/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['admin_user_line1'] = 'Cloudlog至少需要配置一个用户才能运行。';
 $lang['admin_user_line2'] = '用户可以被分配不同的角色，这些角色赋予他们不同的权限，例如向日志簿添加 QSO 和访问Cloudlog API。';
 $lang['admin_user_line3'] = '页面右上方显示当前登录的用户。';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = '用户列表';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = '关闭';
 $lang['admin_user_accounts'] = '用户账户';
 $lang['admin_danger'] = '危险!';
 $lang['admin_experimental'] = "实验性功能";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/chinese_simplified/admin_lang.php
+++ b/application/language/chinese_simplified/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = '用户列表';
 $lang['admin_user'] = '用户名';
 $lang['admin_email'] = '电子邮件';
 $lang['admin_type'] = '用户类型';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = '设置';
 
 $lang['admin_create_user'] = '创建用户';

--- a/application/language/chinese_simplified/general_words_lang.php
+++ b/application/language/chinese_simplified/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "数量";
 $lang['general_word_filtering_on'] = "筛选打开";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = '日期';
 $lang['general_word_startdate'] = "开始时间";

--- a/application/language/czech/admin_lang.php
+++ b/application/language/czech/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'Seznam uživatelů';
 $lang['admin_user'] = 'Uživatel';
 $lang['admin_email'] = 'E-mail';
 $lang['admin_type'] = 'Typ';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Možnosti';
 
 $lang['admin_create_user'] = 'Vytvořit uživatele';

--- a/application/language/czech/admin_lang.php
+++ b/application/language/czech/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['admin_user_line1'] = 'Cloudlog potřebuje alespoň jednoho uživatele nastaveného pro svůj provoz.';
 $lang['admin_user_line2'] = 'Uživatelům mohou být přiděleny role, které jim udělují různá oprávnění, jako je přidávání QSO do logu a přístup k Cloudlog API.';
 $lang['admin_user_line3'] = 'Nyní přihlášený uživatel je zobrazen v pravém horním rohu každé stránky.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'Seznam uživatelů';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'User Accounts';
 $lang['admin_danger'] = 'DANGER!';
 $lang['admin_experimental'] = "Experimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/czech/general_words_lang.php
+++ b/application/language/czech/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = 'Datum';
 $lang['general_word_startdate'] = "Start Date";

--- a/application/language/dutch/admin_lang.php
+++ b/application/language/dutch/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'User List';
 $lang['admin_user'] = 'User';
 $lang['admin_email'] = 'E-mail';
 $lang['admin_type'] = 'Type';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Options';
 
 $lang['admin_create_user'] = 'Create user';

--- a/application/language/dutch/admin_lang.php
+++ b/application/language/dutch/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('Directe toegang tot scripts is niet toegestaan');
 $lang['admin_user_line1'] = 'Cloudlog needs at least one user configured in order to operate.';
 $lang['admin_user_line2'] = 'Users can be assigned roles which give them different permissions, such as adding QSOs to the logbook and accessing Cloudlog APIs.';
 $lang['admin_user_line3'] = 'The currently logged-in user is displayed at the upper-right of each page.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'User List';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'User Accounts';
 $lang['admin_danger'] = 'DANGER!';
 $lang['admin_experimental'] = "Experimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/dutch/general_words_lang.php
+++ b/application/language/dutch/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = 'Datum';
 $lang['general_word_startdate'] = "Start Date";

--- a/application/language/english/admin_lang.php
+++ b/application/language/english/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'User List';
 $lang['admin_user'] = 'User';
 $lang['admin_email'] = 'E-mail';
 $lang['admin_type'] = 'Type';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Options';
 
 $lang['admin_create_user'] = 'Create user';

--- a/application/language/english/admin_lang.php
+++ b/application/language/english/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['admin_user_line1'] = 'Cloudlog needs at least one user configured in order to operate.';
 $lang['admin_user_line2'] = 'Users can be assigned roles which give them different permissions, such as adding QSOs to the logbook and accessing Cloudlog APIs.';
 $lang['admin_user_line3'] = 'The currently logged-in user is displayed at the upper-right of each page.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'User List';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'User Accounts';
 $lang['admin_danger'] = 'DANGER!';
 $lang['admin_experimental'] = "Experimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/english/general_words_lang.php
+++ b/application/language/english/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = 'Date';
 $lang['general_word_startdate'] = "Start Date";

--- a/application/language/finnish/admin_lang.php
+++ b/application/language/finnish/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'Käyttäjälista';
 $lang['admin_user'] = 'Käyttäjä';
 $lang['admin_email'] = 'E-mail';
 $lang['admin_type'] = 'Rooli';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Valinnat';
 
 $lang['admin_create_user'] = 'Luo käyttäjä';

--- a/application/language/finnish/admin_lang.php
+++ b/application/language/finnish/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['admin_user_line1'] = 'Cloudlog tarvitsee toimiakseen vähintään yhden luodun käyttäjän.';
 $lang['admin_user_line2'] = 'Käyttäjille voidaan määrittää rooleja, jotka antavat heille erilaisia käyttöoikeuksia, kuten QSO:n lisääminen lokikirjaan ja pääsy Cloudlog-sovellusliittymiin (API).';
 $lang['admin_user_line3'] = 'Tällä hetkellä kirjautunut käyttäjä näkyy jokaisen sivun oikeassa yläkulmassa.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'Käyttäjälista';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'User Accounts';
 $lang['admin_danger'] = 'DANGER!';
 $lang['admin_experimental'] = "Experimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/finnish/general_words_lang.php
+++ b/application/language/finnish/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = 'Päivä';
 $lang['general_word_startdate'] = "Start Date";

--- a/application/language/french/admin_lang.php
+++ b/application/language/french/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['admin_user_line1'] = "Cloudlog a besoin d'au moins un utilisateur configuré pour fonctionner.";
 $lang['admin_user_line2'] = "Les utilisateurs peuvent se voir attribuer des rôles qui leur donnent différentes autorisations, telles que l'ajout de QSO au journal de trafic et l'accès aux API Cloudlog.";
 $lang['admin_user_line3'] = "L'utilisateur actuellement connecté est affiché en haut à droite de chaque page.";
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = "Liste des utilisateurs";
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = "Fermer";
 $lang['admin_user_accounts'] = "Compte des utilisateurs";
 $lang['admin_danger'] = "DANGER!";
 $lang['admin_experimental'] = "Expérimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/french/admin_lang.php
+++ b/application/language/french/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = "Liste des utilisateurs";
 $lang['admin_user'] = "Utilisateur";
 $lang['admin_email'] = "E-mail";
 $lang['admin_type'] = "Type";
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = "Options";
 
 $lang['admin_create_user'] = "Création d'un utilisateur";

--- a/application/language/french/general_words_lang.php
+++ b/application/language/french/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Nombre";
 $lang['general_word_filtering_on'] = "Filtré sur";
 $lang['general_word_not_display'] = "Ne pas afficher";
 $lang['general_word_icon'] = "Icône";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = "Date";
 $lang['general_word_startdate'] = "Date début";

--- a/application/language/german/admin_lang.php
+++ b/application/language/german/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('Direkter Zugriff auf Skripte ist nicht erlaubt');
 $lang['admin_user_line1'] = 'Es muss mindestens ein Benutzer konfiguriert sein, damit Cloudlog funktioniert.';
 $lang['admin_user_line2'] = 'Benutzer können verschiedene Rollen zugewiesen bekommen, die ihnen unterschiedliche Rechte geben wie QSOs zum Logbuch hinzuzufügen und die APIs von Cloudlog zu benutzen';
 $lang['admin_user_line3'] = 'Der aktuell angemeldete Benutzer wird oben rechts auf jeder Seite angezeigt.';
+$lang['admin_user_line4'] = "Mit dem Passwort Reset Knopf kannst du dem Benutzer eine E-Mail mit einem Passwort-Reset Link zuschicken. Dafür müssen die E-Mail Einstellungen in den globalen Optionen korrekt eingerichtet sein.";
 
 $lang['admin_user_list'] = 'Benutzer Liste';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Schliessen';
 $lang['admin_user_accounts'] = 'Benutzerkonten';
 $lang['admin_danger'] = 'ACHTUNG!';
 $lang['admin_experimental'] = "Experimentell";
+$lang['admin_password_reset'] = "Passwort zurücksetzen";
 
+$lang['admin_email_settings_incorrect'] = "E-Mail Einstellungen sind nicht korrekt.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail verschickt.";
 
 
 // Contest Menu

--- a/application/language/german/admin_lang.php
+++ b/application/language/german/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'Benutzer Liste';
 $lang['admin_user'] = 'Benutzer';
 $lang['admin_email'] = 'E-Mail';
 $lang['admin_type'] = 'Typ';
+$lang['admin_last_login'] = "Letzter Login";
 $lang['admin_options'] = 'Optionen';
 
 $lang['admin_create_user'] = 'Benutzer anlegen';

--- a/application/language/german/general_words_lang.php
+++ b/application/language/german/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Zähler";
 $lang['general_word_filtering_on'] = "Filtern auf";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Nie";
 
 $lang['general_word_date'] = 'Datum';
 $lang['general_word_startdate'] = "Start Datum";

--- a/application/language/greek/admin_lang.php
+++ b/application/language/greek/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'User List';
 $lang['admin_user'] = 'User';
 $lang['admin_email'] = 'E-mail';
 $lang['admin_type'] = 'Type';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Options';
 
 $lang['admin_create_user'] = 'Create user';

--- a/application/language/greek/admin_lang.php
+++ b/application/language/greek/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['admin_user_line1'] = 'Cloudlog needs at least one user configured in order to operate.';
 $lang['admin_user_line2'] = 'Users can be assigned roles which give them different permissions, such as adding QSOs to the logbook and accessing Cloudlog APIs.';
 $lang['admin_user_line3'] = 'The currently logged-in user is displayed at the upper-right of each page.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'User List';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'User Accounts';
 $lang['admin_danger'] = 'DANGER!';
 $lang['admin_experimental'] = "Experimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/greek/general_words_lang.php
+++ b/application/language/greek/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = 'Ημερομηνία';
 $lang['general_word_startdate'] = "Start Date";

--- a/application/language/italian/admin_lang.php
+++ b/application/language/italian/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'User List';
 $lang['admin_user'] = 'User';
 $lang['admin_email'] = 'E-mail';
 $lang['admin_type'] = 'Type';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Options';
 
 $lang['admin_create_user'] = 'Create user';

--- a/application/language/italian/admin_lang.php
+++ b/application/language/italian/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['admin_user_line1'] = 'Cloudlog needs at least one user configured in order to operate.';
 $lang['admin_user_line2'] = 'Users can be assigned roles which give them different permissions, such as adding QSOs to the logbook and accessing Cloudlog APIs.';
 $lang['admin_user_line3'] = 'The currently logged-in user is displayed at the upper-right of each page.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'User List';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'User Accounts';
 $lang['admin_danger'] = 'DANGER!';
 $lang['admin_experimental'] = "Experimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/italian/general_words_lang.php
+++ b/application/language/italian/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = 'Data';
 $lang['general_word_startdate'] = "Start Date";

--- a/application/language/polish/admin_lang.php
+++ b/application/language/polish/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'User List';
 $lang['admin_user'] = 'User';
 $lang['admin_email'] = 'E-mail';
 $lang['admin_type'] = 'Type';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Options';
 
 $lang['admin_create_user'] = 'Create user';

--- a/application/language/polish/admin_lang.php
+++ b/application/language/polish/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['admin_user_line1'] = 'Cloudlog needs at least one user configured in order to operate.';
 $lang['admin_user_line2'] = 'Users can be assigned roles which give them different permissions, such as adding QSOs to the logbook and accessing Cloudlog APIs.';
 $lang['admin_user_line3'] = 'The currently logged-in user is displayed at the upper-right of each page.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'User List';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'User Accounts';
 $lang['admin_danger'] = 'DANGER!';
 $lang['admin_experimental'] = "Experimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/polish/general_words_lang.php
+++ b/application/language/polish/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = 'Data';
 $lang['general_word_startdate'] = "Start Date";

--- a/application/language/russian/admin_lang.php
+++ b/application/language/russian/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'Список пользователей';
 $lang['admin_user'] = 'Пользователь';
 $lang['admin_email'] = 'Емэйл';
 $lang['admin_type'] = 'Роль';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Опции';
 
 $lang['admin_create_user'] = 'Создать пользователя';

--- a/application/language/russian/admin_lang.php
+++ b/application/language/russian/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['admin_user_line1'] = 'Для работы Cloudlog требуется хотя наличие хотя бы одного пользовательского аккаунта.';
 $lang['admin_user_line2'] = 'Пользователям могут быть назначены роли, которые предоставляют им различные права, например, добавление QSO в журнал и доступ к API Cloudlog.';
 $lang['admin_user_line3'] = 'Текущий вошедший в систему пользователь отображается в правом верхнем углу каждой страницы.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'Список пользователей';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'Аккаунты пользователей';
 $lang['admin_danger'] = 'ОПАСНО!';
 $lang['admin_experimental'] = "Экспериментально";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/russian/general_words_lang.php
+++ b/application/language/russian/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Счётчик";
 $lang['general_word_filtering_on'] = "Отфильтровано по";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = 'Дата';
 $lang['general_word_startdate'] = "Дата начала";

--- a/application/language/spanish/admin_lang.php
+++ b/application/language/spanish/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'User List';
 $lang['admin_user'] = 'User';
 $lang['admin_email'] = 'E-mail';
 $lang['admin_type'] = 'Type';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Options';
 
 $lang['admin_create_user'] = 'Create user';

--- a/application/language/spanish/admin_lang.php
+++ b/application/language/spanish/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['admin_user_line1'] = 'Cloudlog needs at least one user configured in order to operate.';
 $lang['admin_user_line2'] = 'Users can be assigned roles which give them different permissions, such as adding QSOs to the logbook and accessing Cloudlog APIs.';
 $lang['admin_user_line3'] = 'The currently logged-in user is displayed at the upper-right of each page.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'User List';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'User Accounts';
 $lang['admin_danger'] = 'DANGER!';
 $lang['admin_experimental'] = "Experimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/spanish/general_words_lang.php
+++ b/application/language/spanish/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = 'Fecha';
 $lang['general_word_startdate'] = "Start Date";

--- a/application/language/swedish/admin_lang.php
+++ b/application/language/swedish/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'Användarlista';
 $lang['admin_user'] = 'Användare';
 $lang['admin_email'] = 'E-post';
 $lang['admin_type'] = 'Typ';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Alternativ';
 
 $lang['admin_create_user'] = 'Skapa användare';

--- a/application/language/swedish/admin_lang.php
+++ b/application/language/swedish/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $lang['admin_user_line1'] = 'Cloudlog behöver minst en användare konfigurerad för att fungera.';
 $lang['admin_user_line2'] = 'Användare kan tilldelas roller som ger dem olika behörigheter, som att lägga till QSO:er i loggboken och komma åt Cloudlog API:er.';
 $lang['admin_user_line3'] = 'Den för närvarande inloggade användaren visas uppe till höger på varje sida.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'Användarlista';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'User Accounts';
 $lang['admin_danger'] = 'DANGER!';
 $lang['admin_experimental'] = "Experimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/swedish/general_words_lang.php
+++ b/application/language/swedish/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_enabled'] = "Enabled";
 $lang['general_word_disabled'] = "Disabled";
 $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
+$lang['general_word_never'] = "Never";
 $lang['general_word_export'] = "Export";
 $lang['general_word_import'] = "Import";
 $lang['general_word_startdate'] = "Start Date";

--- a/application/language/turkish/admin_lang.php
+++ b/application/language/turkish/admin_lang.php
@@ -12,6 +12,7 @@ $lang['admin_user_list'] = 'User List';
 $lang['admin_user'] = 'User';
 $lang['admin_email'] = 'E-mail';
 $lang['admin_type'] = 'Type';
+$lang['admin_last_login'] = "Last Login";
 $lang['admin_options'] = 'Options';
 
 $lang['admin_create_user'] = 'Create user';

--- a/application/language/turkish/admin_lang.php
+++ b/application/language/turkish/admin_lang.php
@@ -5,6 +5,7 @@ defined('BASEPATH') OR exit('Doğrudan komut dosyası erişimine izin verilmez')
 $lang['admin_user_line1'] = 'Cloudlog needs at least one user configured in order to operate.';
 $lang['admin_user_line2'] = 'Users can be assigned roles which give them different permissions, such as adding QSOs to the logbook and accessing Cloudlog APIs.';
 $lang['admin_user_line3'] = 'The currently logged-in user is displayed at the upper-right of each page.';
+$lang['admin_user_line4'] = "With the password reset button, you can send a user an email containing a link to reset their password. To achieve this, ensure that the email settings in the global options are configured correctly.";
 
 $lang['admin_user_list'] = 'User List';
 
@@ -25,7 +26,10 @@ $lang['admin_close'] = 'Close';
 $lang['admin_user_accounts'] = 'User Accounts';
 $lang['admin_danger'] = 'DANGER!';
 $lang['admin_experimental'] = "Experimental";
+$lang['admin_password_reset'] = "Password Reset";
 
+$lang['admin_email_settings_incorrect'] = "Email settings are incorrect.";
+$lang['admin_password_reset_processed'] = "Password Reset E-Mail sent.";
 
 
 // Contest Menu

--- a/application/language/turkish/general_words_lang.php
+++ b/application/language/turkish/general_words_lang.php
@@ -25,6 +25,7 @@ $lang['general_word_count'] = "Count";
 $lang['general_word_filtering_on'] = "Filtering on";
 $lang['general_word_not_display'] = "Not display";
 $lang['general_word_icon'] = "Icon";
+$lang['general_word_never'] = "Never";
 
 $lang['general_word_date'] = 'Tarih';
 $lang['general_word_startdate'] = "Start Date";

--- a/application/migrations/167_add_last_login.php
+++ b/application/migrations/167_add_last_login.php
@@ -2,6 +2,8 @@
 
 defined('BASEPATH') or exit('No direct script access allowed');
 
+// Adding a column to users table for the timestamp of the last login
+
 class Migration_add_last_login extends CI_Migration
 {
 

--- a/application/migrations/167_add_last_login.php
+++ b/application/migrations/167_add_last_login.php
@@ -1,0 +1,22 @@
+<?php
+
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_add_last_login extends CI_Migration
+{
+
+  public function up()
+  {
+    if (!$this->db->field_exists('last_login_date', 'users')) {
+      $fields = array(
+        'last_login_date TIMESTAMP NULL DEFAULT NULL AFTER `reset_password_date`',
+      );
+      $this->dbforge->add_column('users', $fields);
+    }
+  }
+
+  public function down()
+  {
+    $this->dbforge->drop_column('users', 'last_login_date');
+  }
+}

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -423,6 +423,16 @@ class User_Model extends CI_Model {
 		return 0;
 	}
 
+	// FUNCTION: set's the last-login timestamp in user table
+	function set_last_login($user_id) {
+		$data = array(
+			'last_login_date' => date('Y-m-d H:i:s')
+		);
+		
+		$this->db->where('user_id', $user_id);
+		$this->db->update('users', $data);
+	}
+
 	// FUNCTION: bool authorize($level)
 	// Checks a user's level of access against the given $level
 	function authorize($level) {

--- a/application/views/email/admin_reset_password.php
+++ b/application/views/email/admin_reset_password.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Password Reset</title>
+</head>
+<body>
+    <p>Hello <?php echo $user_first_name; ?>,</p>
+    
+    <p>An admin initiated a password reset for your Cloudlog account.</p>
+    
+    <p>Click <a href="<?php echo site_url('user/reset_password/').$reset_code; ?>">here</a> to reset your password.</p>
+
+    <p>Or copy this link into a browser:
+    <?php echo site_url('user/reset_password/').$reset_code; ?></p>
+    
+    <p>If you didn't request any password reset, just ignore this email and talk to an admin of your Cloudlog instance.</p>
+    
+    <p>Regards,<br>
+    Cloudlog</p>
+</body>
+</html>

--- a/application/views/email/admin_reset_password.php
+++ b/application/views/email/admin_reset_password.php
@@ -1,24 +1,15 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Password Reset</title>
-</head>
-<body>
-    <p>Hello <?php echo $user_first_name; ?>,</p>
-    
-    <p>An admin initiated a password reset for your Cloudlog account.</p>
-    
-    <p>Click <a href="<?php echo site_url('user/reset_password/').$reset_code; ?>">here</a> to reset your password.</p>
+Hello <?php echo $user_firstname . ", " . $user_callsign ?>
 
-    <p>Or copy this link into a browser:
-    <?php echo site_url('user/reset_password/').$reset_code; ?></p>
-    
-    <p>If you didn't request any password reset, just ignore this email and talk to an admin of your Cloudlog instance.</p>
-    
-    <p>Regards,<br>
-    Cloudlog</p>
-</body>
-</html>
+
+An admin initiated a password reset for your Cloudlog account.
+
+Your username is:    <?php echo $user_name; ?>
+
+
+Click here to reset your password: <?php echo site_url('user/reset_password/').$reset_code; ?>
+
+
+If you didn't request any password reset, just ignore this email and talk to an admin of your Cloudlog instance.
+
+Regards,
+Cloudlog

--- a/application/views/user/main.php
+++ b/application/views/user/main.php
@@ -1,63 +1,73 @@
 <div class="container">
 
-<br>
+	<br>
 
-<h2><?php echo $page_title; ?></h2>
+	<h2><?php echo $page_title; ?></h2>
 
-<?php if($this->session->flashdata('notice')) { ?>
+	<?php if ($this->session->flashdata('notice')) { ?>
 		<!-- Display Message -->
 		<div class="alert alert-info" role="alert">
 			<?php echo $this->session->flashdata('notice'); ?>
 		</div>
 
-<?php } ?>
+	<?php } ?>
 
-<div class="card">
-  <div class="card-header">
-    <?php echo lang('admin_user_list'); ?>
-  </div>
-  <div class="card-body">
-    <p class="card-text"><?php echo lang('admin_user_line1'); ?></p>
-    <p class="card-text"><?php echo lang('admin_user_line2'); ?></p>
-    <p class="card-text"><?php echo lang('admin_user_line3'); ?></p>
-    <div class="table-responsive">
-		<table class="table table-striped">
-		  <thead>
-		    <tr>
-		      <th scope="col"><?php echo lang('admin_user'); ?></th>
-		      <th scope="col"><?php echo lang('admin_email'); ?></th>
-		      <th scope="col"><?php echo lang('admin_type'); ?></th>
-		      <th scope="col"><?php echo lang('admin_options'); ?></th>
-		    </tr>
-		  </thead>
-		  <tbody>
+	<div class="card">
+		<div class="card-header">
+			<?php echo lang('admin_user_list'); ?>
+		</div>
+		<div class="card-body">
+			<p class="card-text"><?php echo lang('admin_user_line1'); ?></p>
+			<p class="card-text"><?php echo lang('admin_user_line2'); ?></p>
+			<p class="card-text"><?php echo lang('admin_user_line3'); ?></p>
+			<p><a class="btn btn-primary" href="<?php echo site_url('user/add'); ?>"><i class="fas fa-user-plus"></i> <?php echo lang('admin_create_user'); ?></a></p>
 
-				<?php
+			<div class="table-responsive">
+				<table class="table table-striped">
+					<thead>
+						<tr>
+							<th scope="col"><?php echo lang('admin_user'); ?></th>
+							<th scope="col"><?php echo lang('gen_hamradio_callsign'); ?></th>
+							<th scope="col"><?php echo lang('admin_email'); ?></th>
+							<th scope="col"><?php echo lang('admin_type'); ?></th>
+							<th style="text-align: center; vertical-align: middle;" scope="col"><?php echo lang('admin_edit'); ?></th>
+							<th style="text-align: center; vertical-align: middle;" scope="col">Password Reset</th>
+							<th style="text-align: center; vertical-align: middle;" scope="col"><?php echo lang('admin_delete'); ?></th>
+						</tr>
+					</thead>
+					<tbody>
 
-				$i = 0;
-				foreach ($results->result() as $row) { ?>
-				<?php  echo '<tr class="tr'.($i & 1).'">'; ?>
-					<td><a href="<?php echo site_url('user/edit')."/".$row->user_id; ?>"><?php echo $row->user_name; ?></a></td>
-					<td><?php echo $row->user_email; ?></td>
-					<td><?php $l = $this->config->item('auth_level'); echo $l[$row->user_type]; ?></td>
-					<td>
-						<a href="<?php echo site_url('user/edit')."/".$row->user_id; ?>" class="btn btn-outline-primary btn-sm"><i class="fas fa-user-edit"></i> <?php echo lang('admin_edit'); ?></a>
 						<?php
-						if ($_SESSION['user_id'] != $row->user_id) {
-							echo "<a href=" . site_url('user/delete'). "/" . $row->user_id . " class=\"btn btn-danger btn-sm\"><i class=\"fas fa-user-minus\"></i> ".lang('admin_delete')."</a>";
-						}
-						?>
-					</td>
-				</tr>
-				<?php $i++; } ?>
-			</tbody>
-		</table>
+
+						$i = 0;
+						foreach ($results->result() as $row) { ?>
+							<?php echo '<tr class="tr' . ($i & 1) . '">'; ?>
+							<td><a href="<?php echo site_url('user/edit') . "/" . $row->user_id; ?>"><?php echo $row->user_name; ?></a></td>
+							<td><?php echo $row->user_callsign; ?></td>
+							<td><?php echo $row->user_email; ?></td>
+							<td><?php $l = $this->config->item('auth_level');
+								echo $l[$row->user_type]; ?></td>
+							<td style="text-align: center; vertical-align: middle;"><a href="<?php echo site_url('user/edit') . "/" . $row->user_id; ?>" class="btn btn-outline-primary btn-sm"><i class="fas fa-user-edit"></i></a>
+							<td style="text-align: center; vertical-align: middle;">
+								<?php
+								if ($_SESSION['user_id'] != $row->user_id) {
+									echo "<a href=" . site_url('user/admin_send_passwort_reset') . "/" . $row->user_id . " class=\"btn btn-primary btn-sm ms-1\"><i class=\"fas fa-key\"></i></a>";
+								}
+								?></td>
+							<td style="text-align: center; vertical-align: middle;">
+								<?php
+								if ($_SESSION['user_id'] != $row->user_id) {
+									echo "<a href=" . site_url('user/delete') . "/" . $row->user_id . " class=\"btn btn-danger btn-sm\"><i class=\"fas fa-user-minus\"></i></a>";
+								}
+								?></td>
+							</td>
+							</tr>
+						<?php $i++;
+						} ?>
+					</tbody>
+				</table>
+			</div>
+
+		</div>
 	</div>
-		<p>
-			<a class="btn btn-primary" href="<?php echo site_url('user/add'); ?>"><i class="fas fa-user-plus"></i> <?php echo lang('admin_create_user'); ?></a>
-		</p>
-  </div>
-</div>
-
-
 </div>

--- a/application/views/user/main.php
+++ b/application/views/user/main.php
@@ -47,7 +47,7 @@
 							<th scope="col"><?php echo lang('gen_hamradio_callsign'); ?></th>
 							<th scope="col"><?php echo lang('admin_email'); ?></th>
 							<th scope="col"><?php echo lang('admin_type'); ?></th>
-							<th scope="col">Last login</th>
+							<th scope="col"><?php echo lang('admin_last_login'); ?></th>
 							<th style="text-align: center; vertical-align: middle;" scope="col"><?php echo lang('admin_edit'); ?></th>
 							<th style="text-align: center; vertical-align: middle;" scope="col"><?php echo lang('admin_password_reset'); ?></th>
 							<th style="text-align: center; vertical-align: middle;" scope="col"><?php echo lang('admin_delete'); ?></th>
@@ -66,7 +66,7 @@
 							<td><?php $l = $this->config->item('auth_level');
 								echo $l[$row->user_type]; ?></td>
 							<td><?php 
-								if ($row->last_login_date != null) {
+								if ($row->last_login_date != null) { // if the user never logged in before the value is null. We can show "never" then.
 									echo $row->last_login_date;
 								} else {
 									echo lang('general_word_never');

--- a/application/views/user/main.php
+++ b/application/views/user/main.php
@@ -12,6 +12,22 @@
 
 	<?php } ?>
 
+	<?php if ($this->session->flashdata('success')) { ?>
+		<!-- Display Message -->
+		<div class="alert alert-success" role="alert">
+			<?php echo $this->session->flashdata('success'); ?>
+		</div>
+
+	<?php } ?>
+
+	<?php if ($this->session->flashdata('danger')) { ?>
+		<!-- Display Message -->
+		<div class="alert alert-danger" role="alert">
+			<?php echo $this->session->flashdata('danger'); ?>
+		</div>
+
+	<?php } ?>
+
 	<div class="card">
 		<div class="card-header">
 			<?php echo lang('admin_user_list'); ?>
@@ -20,6 +36,7 @@
 			<p class="card-text"><?php echo lang('admin_user_line1'); ?></p>
 			<p class="card-text"><?php echo lang('admin_user_line2'); ?></p>
 			<p class="card-text"><?php echo lang('admin_user_line3'); ?></p>
+			<p class="card-text"><?php echo lang('admin_user_line4'); ?></p>
 			<p><a class="btn btn-primary" href="<?php echo site_url('user/add'); ?>"><i class="fas fa-user-plus"></i> <?php echo lang('admin_create_user'); ?></a></p>
 
 			<div class="table-responsive">
@@ -31,7 +48,7 @@
 							<th scope="col"><?php echo lang('admin_email'); ?></th>
 							<th scope="col"><?php echo lang('admin_type'); ?></th>
 							<th style="text-align: center; vertical-align: middle;" scope="col"><?php echo lang('admin_edit'); ?></th>
-							<th style="text-align: center; vertical-align: middle;" scope="col">Password Reset</th>
+							<th style="text-align: center; vertical-align: middle;" scope="col"><?php echo lang('admin_password_reset'); ?></th>
 							<th style="text-align: center; vertical-align: middle;" scope="col"><?php echo lang('admin_delete'); ?></th>
 						</tr>
 					</thead>

--- a/application/views/user/main.php
+++ b/application/views/user/main.php
@@ -47,6 +47,7 @@
 							<th scope="col"><?php echo lang('gen_hamradio_callsign'); ?></th>
 							<th scope="col"><?php echo lang('admin_email'); ?></th>
 							<th scope="col"><?php echo lang('admin_type'); ?></th>
+							<th scope="col">Last login</th>
 							<th style="text-align: center; vertical-align: middle;" scope="col"><?php echo lang('admin_edit'); ?></th>
 							<th style="text-align: center; vertical-align: middle;" scope="col"><?php echo lang('admin_password_reset'); ?></th>
 							<th style="text-align: center; vertical-align: middle;" scope="col"><?php echo lang('admin_delete'); ?></th>
@@ -64,6 +65,13 @@
 							<td><?php echo $row->user_email; ?></td>
 							<td><?php $l = $this->config->item('auth_level');
 								echo $l[$row->user_type]; ?></td>
+							<td><?php 
+								if ($row->last_login_date != null) {
+									echo $row->last_login_date;
+								} else {
+									echo lang('general_word_never');
+								}?>
+							</td>
 							<td style="text-align: center; vertical-align: middle;"><a href="<?php echo site_url('user/edit') . "/" . $row->user_id; ?>" class="btn btn-outline-primary btn-sm"><i class="fas fa-user-edit"></i></a>
 							<td style="text-align: center; vertical-align: middle;">
 								<?php


### PR DESCRIPTION
The first PR in 2024 🎉 Happy New Year to everybody 🎊

This introduces a slightly new admin user list. Not the same but similar to the Station Locations Table. 

Also new is the option to send a passwort reset link to an user. For the first time we use HTML E-Mails which are way more nicer than just plain text. 

<img width="858" alt="email" src="https://github.com/magicbug/Cloudlog/assets/80885850/af525666-4c1b-4f67-b1aa-466d72ee18ca">
