### PR TITLE
Fix details for grids with DXCC none

### DIFF
--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -217,7 +217,7 @@ class Timeline_model extends CI_Model
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
-		$this->db->join('dxcc_entities', 'dxcc_entities.adif = '.$this->config->item('table_name').'.COL_DXCC');
+		$this->db->join('dxcc_entities', 'dxcc_entities.adif = '.$this->config->item('table_name').'.COL_DXCC', 'left outer');
 		$this->db->join('lotw_users', 'lotw_users.callsign = '.$this->config->item('table_name').'.col_call', 'left outer');
 
         if ($band != 'All') {


### PR DESCRIPTION
Fixes an error where QSO details for grids without DXCC are not shown (e.g. IN41 by UT1FG/MM). But reported by @int2001.