### PR TITLE
Fix migration

### DIFF
--- a/application/migrations/044_add_key_to_lotw_certs.php
+++ b/application/migrations/044_add_key_to_lotw_certs.php
@@ -7,15 +7,18 @@ class Migration_add_key_to_lotw_certs extends CI_Migration {
     public function up()
     {
         $fields = array(
-            'cert_key TEXT',  
+            'cert_key TEXT',
         );
 
-
-        $this->dbforge->add_column('lotw_certs', $fields);
+        if (!$this->db->field_exists('cert_key', 'lotw_certs')) {
+            $this->dbforge->add_column('lotw_certs', $fields);
+        }
     }
 
     public function down()
     {
-        $this->dbforge->drop_column('lotw_certs', 'cert_key');
+        if ($this->db->field_exists('cert_key', 'lotw_certs')) {
+            $this->dbforge->drop_column('lotw_certs', 'cert_key');
+        }
     }
 }

--- a/application/migrations/044_add_key_to_lotw_certs.php
+++ b/application/migrations/044_add_key_to_lotw_certs.php
@@ -16,6 +16,6 @@ class Migration_add_key_to_lotw_certs extends CI_Migration {
 
     public function down()
     {
-        $this->dbforge->drop_column('lotw_certs', 'key');
+        $this->dbforge->drop_column('lotw_certs', 'cert_key');
     }
 }


### PR DESCRIPTION
Migration script 044 is b0rken. Downgrade does not work because the column name added with same migration is wrong:

![Screenshot from 2024-01-20 13-58-20](https://github.com/magicbug/Cloudlog/assets/7112907/a59cdc27-0473-4db1-9634-5ca390c3dcc8)
