### PR TITLE
fixed error message while logging that trim() was called with argumen…

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -289,7 +289,7 @@ class Logbook_model extends CI_Model
       $data['COL_MY_CITY'] = strtoupper(trim($station['station_city']));
       $data['COL_MY_IOTA'] = strtoupper(trim($station['station_iota']));
       $data['COL_MY_SOTA_REF'] = strtoupper(trim($station['station_sota']));
-      $data['COL_MY_WWFF_REF'] = strtoupper(trim($station['station_wwff']));
+      $data['COL_MY_WWFF_REF'] = $station['station_wwff'] ? strtoupper(trim($station['station_wwff'])) : '';
       $data['COL_MY_POTA_REF'] = $station['station_pota'] == null ? '' : strtoupper(trim($station['station_pota']));
 
       $data['COL_STATION_CALLSIGN'] = strtoupper(trim($station['station_callsign']));


### PR DESCRIPTION
I had an error in the developer mode when logging a QSO that trim() was called with value NULL because I have no station_wwff set. Handled this with an if then else one-liner.