### PR TITLE
visitor: Hide map when used without JavaScript (e.g. on qrz.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ When submitting PRs please make sure code is commented and includes one feature 
 
 ## Credits
 
-Thanks to Andy (VE7CXZ), Gavin (M1BXF), Graham (W5ISP), Robert (M0VFC), Corby (K0SKW), Andy (GI0VGV), Tobias (DL4TMA), Tony (G0WFV), Kim (DG9VH), Michael (G7VJR), Andreas (LA8AJA), Matthias (DL9MJ), Thomas (DO2TWE), Pat (KT3PJ), Flo (DF2ET), Joerg (DJ7NT) and Fabian (HB9HIL) for contributing code or help to Cloudlog.
+Thanks to Andy (VE7CXZ), Gavin (M1BXF), Graham (W5ISP), Robert (M0VFC), Corby (K0SKW), Andy (GI0VGV), Sarah (DM4NA), Tony (G0WFV), Kim (DG9VH), Michael (G7VJR), Andreas (LA8AJA), Matthias (DL9MJ), Thomas (DO2TWE), Pat (KT3PJ), Flo (DF2ET), Joerg (DJ7NT) and Fabian (HB9HIL) for contributing code or help to Cloudlog.
 
 ## Patreons & Donors
 

--- a/application/views/visitor/index.php
+++ b/application/views/visitor/index.php
@@ -48,6 +48,8 @@ function echoQrbCalcLink($mygrid, $grid, $vucc) {
 </div>
 
 <!-- Map -->
+<!-- qrz.com blocks JavaScript when embedding Cloudlog. Map display doesn't work without JS. -->
+<noscript><style> #map { display: none } </style></noscript>
 <div id="map" class="map-leaflet" style="width: 100%; height: 350px"></div>
 
 <div id="container" style="padding-top: 0px; margin-top: 5px;" class="container dashboard">


### PR DESCRIPTION
Hi,

this change makes CloudLog look a bit nicer when embedding it into a QRZ.com profile (which blocks JavaScript on iframes).
The map can't be rendered (due to the missing JS), thus let's just hide it away. 

Before:
<img src='https://screenshot.tbspace.de/elucjfvknig.png' width='1000'>

After:
<img src='https://screenshot.tbspace.de/lmazufgheqx.png' width='1000'>


