### PR TITLE
Reduce calling scp, cache result

### DIFF
--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -106,7 +106,7 @@ class Lookup extends CI_Controller {
 
 		foreach ($arCalls as $strCall)
 		{
-			echo " " . $strCall . " ";
+			echo $strCall . " ";
 		}
 
 	}

--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -55,7 +55,7 @@ class Lookup extends CI_Controller {
 
 	public function scp() {
 		if($_POST['callsign']) {
-			$uppercase_callsign = strtoupper($_POST['callsign']);
+			$uppercase_callsign = str_replace('Ø', '0', strtoupper($_POST['callsign']));
 		}
 
 		// SCP results from logbook

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1,4 +1,9 @@
 var lastCallsignUpdated=""
+var scp_data = {
+  request: "",
+  status: -1 , // -1 - never req, 0 - req in progress, 1 - request done
+  data: [],
+};
 
 $( document ).ready(function() {
 	setTimeout(function() {
@@ -1019,18 +1024,31 @@ $("#callsign").on("keypress", function(e) {
 // On Key up check and suggest callsigns
 $("#callsign").keyup(function() {
 	if ($(this).val().length >= 3) {
-	  $('.callsign-suggest').show();
-	  $callsign = $(this).val().replace('Ø', '0');
-	  $.ajax({
-		url: 'lookup/scp',
-		method: 'POST',
-		data: {
-		  callsign: $callsign.toUpperCase()
-		},
-		success: function(result) {
-		  $('.callsign-suggestions').text(result);
-		}
-	  });
+	  $callsign = $(this).val().replace('Ø', '0').toUpperCase();
+
+      if (scp_data.status < 0 || scp_data.request != $callsign.substr(0, scp_data.request.length)) {
+        scp_data.status = 0;
+        scp_data.request = $callsign;
+        scp_data.data = [];
+        $.ajax({
+          url: 'lookup/scp',
+          method: 'POST',
+          data: {
+            callsign: $callsign
+          },
+          success: function(result) {
+            scp_data.status = 1;
+            scp_data.data = result.split(" ");
+
+            var call = $("#callsign").val().replace('Ø', '0').toUpperCase();
+            $('.callsign-suggestions').text(scp_data.data.filter((el) => el.startsWith(call)).join(' '));
+            $('.callsign-suggest').show();
+          }
+        });
+      } else {
+            $('.callsign-suggestions').text(scp_data.data.filter((el) => el.startsWith($callsign)).join(' '));
+            $('.callsign-suggest').show();
+      }
 	}
   });
 

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1024,29 +1024,32 @@ $("#callsign").on("keypress", function(e) {
 // On Key up check and suggest callsigns
 $("#callsign").keyup(function() {
 	if ($(this).val().length >= 3) {
-	  $callsign = $(this).val().replace('Ø', '0').toUpperCase();
+	  let call = $(this).val().toUpperCase();
 
-      if (scp_data.status < 0 || scp_data.request != $callsign.substr(0, scp_data.request.length)) {
-        scp_data.status = 0;
-        scp_data.request = $callsign;
+      if ( scp_data.request == "" || ! call.startsWith(scp_data.request) )  {
+        scp_data.request = call;
         scp_data.data = [];
         $.ajax({
           url: 'lookup/scp',
           method: 'POST',
           data: {
-            callsign: $callsign
+            callsign: call
           },
           success: function(result) {
-            scp_data.status = 1;
-            scp_data.data = result.split(" ");
+            var call_now = $("#callsign").val().toUpperCase();
 
-            var call = $("#callsign").val().replace('Ø', '0').toUpperCase();
-            $('.callsign-suggestions').text(scp_data.data.filter((el) => el.startsWith(call)).join(' '));
-            $('.callsign-suggest').show();
+            if (call_now.startsWith(call)) {
+              scp_data.data = result.split(" ");
+
+              call_now = call_now.replace('0','Ø');
+              $('.callsign-suggestions').text(filterCallsignList(call_now, scp_data.data));
+              $('.callsign-suggest').show();
+            }
           }
         });
       } else {
-            $('.callsign-suggestions').text(scp_data.data.filter((el) => el.startsWith($callsign)).join(' '));
+            call = call.replace('0','Ø');
+            $('.callsign-suggestions').text(filterCallsignList(call, scp_data.data));
             $('.callsign-suggest').show();
       }
 	}
@@ -1111,4 +1114,9 @@ function testTimeOffConsistency() {
 		return false;
 	}
 	return true;
+}
+
+function filterCallsignList(call, list) {
+    let re = "(^|\/)" + call;
+    return list?.filter((el) => (el.search(re) !== -1)).join(' ') || '';
 }


### PR DESCRIPTION
For callsign suggestions in logging, Cloudlog requested a list from the server with every additional character typed, from a minimum of 3 on.

This PR reduces calls to the server, by saving and filtering a (matching) list from the server for additional characters typed.

Example: You typed 'DJ3' and got a list of all callsigns. Now you add 'C' ('DJ3C') and while previously, the server was asked to give a new suggestion list with this PR the already received list is filtered for 'DJ3C'.

If the original request does not match the typed callsign anymore (Example: You replace the '3' in the previous example by a '4'), a new request is made.

Included in this PR is contest-, as well as normal-logging.