### PR TITLE
Make dxped-url configurable

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -32,7 +32,6 @@ $config['datadir'] = null; // default to install directory
 $config['table_name'] = "TABLE_HRD_CONTACTS_V01";
 $config['locator'] = "";
 $config['display_freq'] = true;
-$config['dxped_list'] = "https://cdn.cloudlog.org/read_ng3k_dxped_list.php";
 
 /*
 |--------------------------------------------------------------------------

--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -32,6 +32,7 @@ $config['datadir'] = null; // default to install directory
 $config['table_name'] = "TABLE_HRD_CONTACTS_V01";
 $config['locator'] = "";
 $config['display_freq'] = true;
+$config['dxped_list'] = "https://cdn.cloudlog.org/read_ng3k_dxped_list.php";
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Workabledxcc.php
+++ b/application/controllers/Workabledxcc.php
@@ -30,7 +30,7 @@ class Workabledxcc extends CI_Controller
 	public function dxcclist()
 	{
 
-		$json = file_get_contents($this->config->item('dxped_list') ?? 'https://cdn.cloudlog.org/read_ng3k_dxped_list.php');
+		$json = file_get_contents($this->optionslib->get_option('dxped_url'));
 
 		// Decode the JSON data into a PHP array
 		$dataResult = json_decode($json, true);

--- a/application/controllers/Workabledxcc.php
+++ b/application/controllers/Workabledxcc.php
@@ -30,7 +30,7 @@ class Workabledxcc extends CI_Controller
 	public function dxcclist()
 	{
 
-		$json = file_get_contents('https://cdn.cloudlog.org/read_ng3k_dxped_list.php');
+		$json = file_get_contents($this->config->item('dxped_list') ?? 'https://cdn.cloudlog.org/read_ng3k_dxped_list.php');
 
 		// Decode the JSON data into a PHP array
 		$dataResult = json_decode($json, true);

--- a/application/migrations/175_add_dxped_url_option.php
+++ b/application/migrations/175_add_dxped_url_option.php
@@ -1,0 +1,25 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/*
+ *  This migration adds a dxped_url-key to the options table, to configure
+ *  the endpoint, from where the dxpedition-data is being loaded.
+ */
+
+class Migration_add_dxped_url_to_option extends CI_Migration {
+
+    public function up()
+    {
+        $data = array(
+            array('option_name' => "dxped_url", 'option_value' => "https://cdn.cloudlog.org/read_ng3k_dxped_list.php", 'autoload' => "yes"),
+         );
+
+         $this->db->insert_batch('options', $data);
+    }
+
+    public function down()
+    {
+        // No option to down
+    }
+}

--- a/application/models/Workabledxcc_model.php
+++ b/application/models/Workabledxcc_model.php
@@ -5,7 +5,7 @@ class Workabledxcc_model extends CI_Model
 
     public function GetThisWeek()
     {
-		$json = file_get_contents($this->config->item('dxped_list') ?? 'https://cdn.cloudlog.org/read_ng3k_dxped_list.php');
+		$json = file_get_contents($this->optionslib->get_option('dxped_url'));
 
         // Step 2: Convert the JSON data to an array.
         $data = json_decode($json, true);

--- a/application/models/Workabledxcc_model.php
+++ b/application/models/Workabledxcc_model.php
@@ -5,7 +5,7 @@ class Workabledxcc_model extends CI_Model
 
     public function GetThisWeek()
     {
-        $json = file_get_contents('https://cdn.cloudlog.org/read_ng3k_dxped_list.php');
+		$json = file_get_contents($this->config->item('dxped_list') ?? 'https://cdn.cloudlog.org/read_ng3k_dxped_list.php');
 
         // Step 2: Convert the JSON data to an array.
         $data = json_decode($json, true);


### PR DESCRIPTION
This PR adds a configuration item for the DXpeditions-source. Quite useful, if you'd like to have a cronjob loading the json onto your server and then using a (filesystem-)path for improved performance.

A path is relative to the cloudlog 'root' directory, but of course you can also use an absolute path, or an URI.