### PR TITLE
Post-Contest-Logging: Fixes and focus to time-field

### DIFF
--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -13,6 +13,7 @@ class Contesting_model extends CI_Model {
 
         $contestid = $qsoarray[2];
         $date = DateTime::createFromFormat('d-m-Y H:i:s', $qsoarray[0]);
+        if ($date == false) $date = DateTime::createFromFormat('d-m-Y H:i', $qsoarray[0]);
         $date = $date->format('Y-m-d H:i:s');
 
         $sql = "SELECT date_format(col_time_on, '%d-%m-%Y %H:%i:%s') as col_time_on, col_call, col_band, col_mode,
@@ -246,6 +247,7 @@ class Contesting_model extends CI_Model {
 			$qsoarray = explode(',', $contest_session->qso);
 	
 			$date = DateTime::createFromFormat('d-m-Y H:i:s', $qsoarray[0]);
+			if ($date == false) $date = DateTime::createFromFormat('d-m-Y H:i', $qsoarray[0]);
 			$date = $date->format('Y-m-d H:i:s');
 
 			$this->db->select('timediff(UTC_TIMESTAMP(),col_time_off) b4, COL_TIME_OFF');

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -77,17 +77,10 @@ if (!manual) {
 }
 
 // We don't want spaces to be written in callsign
-$(function () {
-	$('#callsign').on('keypress', function (e) {
-		if (e.which == 32) {
-			return false;
-		}
-	});
-});
-
 // We don't want spaces to be written in exchange
+// We don't want spaces to be written in time :)
 $(function () {
-	$('#exch_rcvd').on('keypress', function (e) {
+	$('#callsign, #exch_rcvd, #start_time').on('keypress', function (e) {
 		if (e.which == 32) {
 			return false;
 		}
@@ -129,6 +122,12 @@ document.onkeyup = function (e) {
 		// Space to jump to either callsign or the various exchanges
 	} else if (e.which == 32) {
 		var exchangetype = $("#exchangetype").val();
+
+        if (manual && $(document.activeElement).attr("id") == "start_time") {
+          $("#callsign").focus();
+          return false;
+        }
+        
 		if (exchangetype == 'Exchange') {
 			if ($(document.activeElement).attr("id") == "callsign") {
 				$("#exch_rcvd").focus();
@@ -468,7 +467,11 @@ function logQso() {
 				$('#exch_rcvd').val("");
 				$('#exch_gridsquare_r').val("");
 				$('#exch_serial_r').val("");
-				$("#callsign").focus();
+                if (manual) {
+                  $("#start_time").focus().select();
+                } else {
+                  $("#callsign").focus();
+                }
 				setSession(formdata);
 				
 				// try setting session data


### PR DESCRIPTION
This PR sets the focus to the start-time-field after submitting a qso in post-constest-logging.

Additionally a fix for the different start-time-format is included, which fixes the internal server error on checking dupes and listing the qso's so far.

That's it, i guess, for the next couple of days. As always: Feel free to reach out.