### PR TITLE
Limit Grid square to 6 chars in request to df2et.de API

### DIFF
--- a/application/controllers/Sattimers.php
+++ b/application/controllers/Sattimers.php
@@ -15,10 +15,10 @@ class Sattimers extends CI_Controller {
         $footerData['scripts'] = [
            'assets/js/sections/sattimers.js?'
         ];
-        $url = 'https://www.df2et.de/tevel/api2.php?grid='.strtoupper($this->stations->find_gridsquare());
+        $data['gridsquare'] = substr(strtoupper($this->stations->find_gridsquare()), 0, 6);
+        $url = 'https://www.df2et.de/tevel/api2.php?grid=' . $data['gridsquare'];
         $json = file_get_contents($url);
         $data['activations'] = json_decode($json, true)['data'];
-        $data['gridsquare'] = strtoupper($this->stations->find_gridsquare());
 
         $data['page_title'] = "Satellite Timers";
 


### PR DESCRIPTION
In the account settings, the Locator can contain up to 16 characters.
In the Sattimers controller, the API call to df2et.de uses this locator.
But the df2et.de API works only with 6-characters locators maximum.
So this patch just crops the locator to 6 characters max before calling the df2et.de API :)

73