### PR TITLE
Visitor page pagination

### DIFF
--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -75,6 +75,38 @@ class Visitor extends CI_Controller {
 
                 $this->load->model('logbook_model');
 
+				// Only load, config, and init pagination if public search is enabled
+				if ($this ->public_search_enabled($public_slug)) {
+					$this->load->library('pagination');
+				
+					//Pagination config
+					$config['base_url'] = base_url().'index.php/visitor/'. $public_slug . '/index';
+					$config['total_rows'] = $this->logbook_model->total_qsos($logbooks_locations_array);
+					$config['per_page'] = '25';
+					$config['num_links'] = $this->logbook_model->total_qsos($logbooks_locations_array) / 25;
+					$config['full_tag_open'] = '<ul class="pagination">';
+					$config['full_tag_close'] = '</ul>';
+					$config['attributes'] = ['class' => 'page-link'];
+					$config['first_link'] = false;
+					$config['last_link'] = false;
+					$config['first_tag_open'] = '<li class="page-item">';
+					$config['first_tag_close'] = '</li>';
+					$config['prev_link'] = '&laquo';
+					$config['prev_tag_open'] = '<li class="page-item">';
+					$config['prev_tag_close'] = '</li>';
+					$config['next_link'] = '&raquo';
+					$config['next_tag_open'] = '<li class="page-item">';
+					$config['next_tag_close'] = '</li>';
+					$config['last_tag_open'] = '<li class="page-item">';
+					$config['last_tag_close'] = '</li>';
+					$config['cur_tag_open'] = '<li class="page-item active"><a href="#" class="page-link">';
+					$config['cur_tag_close'] = '<span class="visually-hidden">(current)</span></a></li>';
+					$config['num_tag_open'] = '<li class="page-item">';
+					$config['num_tag_close'] = '</li>';
+
+					$this->pagination->initialize($config);
+				}
+
                 // Public visitor so no QRA to setup
                 $data['qra'] = "none";
 
@@ -107,8 +139,11 @@ class Visitor extends CI_Controller {
 
                 $data['total_lotw_sent'] = $QSLStatsBreakdownArray['LoTW_Sent'];
                 $data['total_lotw_rcvd'] = $QSLStatsBreakdownArray['LoTW_Received'];
-
-                $data['last_five_qsos'] = $this->logbook_model->get_last_qsos('18', $logbooks_locations_array);
+				
+				// If public search is enabled, show paginated results, otherwise show last 18 qsos
+				$data['results'] = $this->public_search_enabled($public_slug) 
+					? $this->logbook_model->get_qsos($config['per_page'], $this->uri->segment(4), $logbooks_locations_array)
+					: $this->logbook_model->get_last_qsos('18', $logbooks_locations_array);
 
                 $data['page_title'] = "Dashboard";
                 $data['slug'] = $public_slug;

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -75,37 +75,36 @@ class Visitor extends CI_Controller {
 
                 $this->load->model('logbook_model');
 
-				// Only load, config, and init pagination if public search is enabled
-				if ($this ->public_search_enabled($public_slug)) {
-					$this->load->library('pagination');
-				
-					//Pagination config
-					$config['base_url'] = base_url().'index.php/visitor/'. $public_slug . '/index';
-					$config['total_rows'] = $this->logbook_model->total_qsos($logbooks_locations_array);
-					$config['per_page'] = '25';
-					$config['num_links'] = $this->logbook_model->total_qsos($logbooks_locations_array) / 25;
-					$config['full_tag_open'] = '<ul class="pagination">';
-					$config['full_tag_close'] = '</ul>';
-					$config['attributes'] = ['class' => 'page-link'];
-					$config['first_link'] = false;
-					$config['last_link'] = false;
-					$config['first_tag_open'] = '<li class="page-item">';
-					$config['first_tag_close'] = '</li>';
-					$config['prev_link'] = '&laquo';
-					$config['prev_tag_open'] = '<li class="page-item">';
-					$config['prev_tag_close'] = '</li>';
-					$config['next_link'] = '&raquo';
-					$config['next_tag_open'] = '<li class="page-item">';
-					$config['next_tag_close'] = '</li>';
-					$config['last_tag_open'] = '<li class="page-item">';
-					$config['last_tag_close'] = '</li>';
-					$config['cur_tag_open'] = '<li class="page-item active"><a href="#" class="page-link">';
-					$config['cur_tag_close'] = '<span class="visually-hidden">(current)</span></a></li>';
-					$config['num_tag_open'] = '<li class="page-item">';
-					$config['num_tag_close'] = '</li>';
+				// load config and init pagination
+				$this->load->library('pagination');
+			
+				//Pagination config
+				$config['base_url'] = base_url().'index.php/visitor/'. $public_slug . '/index';
+				$config['total_rows'] = $this->logbook_model->total_qsos($logbooks_locations_array);
+				$config['per_page'] = '25';
+				$config['num_links'] = $this->logbook_model->total_qsos($logbooks_locations_array) / 25;
+				$config['full_tag_open'] = '<ul class="pagination">';
+				$config['full_tag_close'] = '</ul>';
+				$config['attributes'] = ['class' => 'page-link'];
+				$config['first_link'] = false;
+				$config['last_link'] = false;
+				$config['first_tag_open'] = '<li class="page-item">';
+				$config['first_tag_close'] = '</li>';
+				$config['prev_link'] = '&laquo';
+				$config['prev_tag_open'] = '<li class="page-item">';
+				$config['prev_tag_close'] = '</li>';
+				$config['next_link'] = '&raquo';
+				$config['next_tag_open'] = '<li class="page-item">';
+				$config['next_tag_close'] = '</li>';
+				$config['last_tag_open'] = '<li class="page-item">';
+				$config['last_tag_close'] = '</li>';
+				$config['cur_tag_open'] = '<li class="page-item active"><a href="#" class="page-link">';
+				$config['cur_tag_close'] = '<span class="visually-hidden">(current)</span></a></li>';
+				$config['num_tag_open'] = '<li class="page-item">';
+				$config['num_tag_close'] = '</li>';
 
-					$this->pagination->initialize($config);
-				}
+				$this->pagination->initialize($config);
+
 
                 // Public visitor so no QRA to setup
                 $data['qra'] = "none";
@@ -141,9 +140,7 @@ class Visitor extends CI_Controller {
                 $data['total_lotw_rcvd'] = $QSLStatsBreakdownArray['LoTW_Received'];
 				
 				// If public search is enabled, show paginated results, otherwise show last 18 qsos
-				$data['results'] = $this->public_search_enabled($public_slug) 
-					? $this->logbook_model->get_qsos($config['per_page'], $this->uri->segment(4), $logbooks_locations_array)
-					: $this->logbook_model->get_last_qsos('18', $logbooks_locations_array);
+				$data['results'] = $this->logbook_model->get_qsos($config['per_page'], $this->uri->segment(4), $logbooks_locations_array);
 
                 $data['page_title'] = "Dashboard";
                 $data['slug'] = $public_slug;

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -139,7 +139,7 @@ class Visitor extends CI_Controller {
                 $data['total_lotw_sent'] = $QSLStatsBreakdownArray['LoTW_Sent'];
                 $data['total_lotw_rcvd'] = $QSLStatsBreakdownArray['LoTW_Received'];
 				
-				// If public search is enabled, show paginated results, otherwise show last 18 qsos
+				// Show paginated results
 				$data['results'] = $this->logbook_model->get_qsos($config['per_page'], $this->uri->segment(4), $logbooks_locations_array);
 
                 $data['page_title'] = "Dashboard";

--- a/application/views/visitor/index.php
+++ b/application/views/visitor/index.php
@@ -79,7 +79,6 @@ function echoQrbCalcLink($mygrid, $grid, $vucc) {
 			</thead>
 
 			<?php
-			
 			$i = 0;
 			if(!empty($results)) {
 			foreach ($results->result() as $row) { ?>

--- a/application/views/visitor/index.php
+++ b/application/views/visitor/index.php
@@ -79,13 +79,13 @@ function echoQrbCalcLink($mygrid, $grid, $vucc) {
 			</thead>
 
 			<?php
+			
 			$i = 0;
-			if(!empty($last_five_qsos) > 0) {
-			foreach ($last_five_qsos->result() as $row) { ?>
+			if(!empty($results) > 0) {
+			foreach ($results->result() as $row) { ?>
 				<?php  echo '<tr class="tr'.($i & 1).'">'; ?>
 
 					<?php
-
 					// Get Date format
 					if($this->session->userdata('user_date_format')) {
 						// If Logged in and session exists
@@ -114,6 +114,11 @@ function echoQrbCalcLink($mygrid, $grid, $vucc) {
 				</tr>
 			<?php $i++; } } ?>
 		</table>
+		<?php if($this->CI->public_search_enabled($slug)) { ?>
+			<div class="pagination-links">
+				<?php echo $this->pagination->create_links(); ?>
+			</div>
+		<?php } ?>
 	</div>
   </div>
 

--- a/application/views/visitor/index.php
+++ b/application/views/visitor/index.php
@@ -81,7 +81,7 @@ function echoQrbCalcLink($mygrid, $grid, $vucc) {
 			<?php
 			
 			$i = 0;
-			if(!empty($results) > 0) {
+			if(!empty($results)) {
 			foreach ($results->result() as $row) { ?>
 				<?php  echo '<tr class="tr'.($i & 1).'">'; ?>
 

--- a/application/views/visitor/index.php
+++ b/application/views/visitor/index.php
@@ -113,11 +113,9 @@ function echoQrbCalcLink($mygrid, $grid, $vucc) {
 				</tr>
 			<?php $i++; } } ?>
 		</table>
-		<?php if($this->CI->public_search_enabled($slug)) { ?>
-			<div class="pagination-links">
-				<?php echo $this->pagination->create_links(); ?>
-			</div>
-		<?php } ?>
+		<div class="pagination-links">
+			<?php echo $this->pagination->create_links(); ?>
+		</div>
 	</div>
   </div>
 


### PR DESCRIPTION
Closes #1720 

- Added pagination to visitors page ~*only* if the public search option is enabled~
- ~Happy to update this PR if you'd rather a different config option or any other feedback, but to me it felt like if search is enabled then pagination might make sense too.  My biggest concern would be that people who have this feature enabled currently might not want the paginated results.~

Enhancements to public search functionality:

* [`application/controllers/Visitor.php`](diffhunk://#diff-e5390d77eb91cd0945b808102973347ba151fe27ed0580d54cfb99cab6a3bfb1R78-R109): In the `index` function, added a condition to load and initialize the pagination library only if public search is enabled. The pagination configuration includes settings for the base URL, total rows, per page limit, number of links, and various HTML tags and attributes for styling the pagination links.
* [`application/controllers/Visitor.php`](diffhunk://#diff-e5390d77eb91cd0945b808102973347ba151fe27ed0580d54cfb99cab6a3bfb1L111-R146): Modified the data fetching logic in the `index` function to return paginated results when public search is enabled, otherwise it continues to return the last 18 records as before.
* [`application/views/visitor/index.php`](diffhunk://#diff-c5778b0b37e488846c56144df03ce423b41eaa98b45984047357536e3900dcc1R82-L88): updated the condition and loop to use the new `results` variable instead of `last_five_qsos`. Also added a condition to display pagination links at the end of the table if public search is enabled.

Gif of feature working:

![2024-04-02 09 57 35](https://github.com/magicbug/Cloudlog/assets/6586559/b4096548-ee0e-441e-a063-d97d5108105f)

