### PR TITLE
SSTV directory fixes

### DIFF
--- a/application/helpers/storage_helper.php
+++ b/application/helpers/storage_helper.php
@@ -2,22 +2,26 @@
 
 if (!function_exists('folderSize')) {
     function folderSize($dir){
-        $count_size = 0;
-        $count = 0;
-        $dir_array = scandir($dir);
-        foreach($dir_array as $key=>$filename){
-            if($filename!=".." && $filename!="."){
-                if(is_dir($dir."/".$filename)){
-                    $new_foldersize = folderSize($dir."/".$filename);
-                    $count_size = $count_size+ $new_foldersize;
-                }else if(is_file($dir."/".$filename)){
-                    $count_size = $count_size + filesize($dir."/".$filename);
-                    $count++;
+        if (is_dir($dir)) {
+            $count_size = 0;
+            $count = 0;
+            $dir_array = scandir($dir);
+            foreach($dir_array as $key=>$filename){
+                if($filename!=".." && $filename!="."){
+                    if(is_dir($dir."/".$filename)){
+                        $new_foldersize = folderSize($dir."/".$filename);
+                        $count_size = $count_size+ $new_foldersize;
+                    }else if(is_file($dir."/".$filename)){
+                        $count_size = $count_size + filesize($dir."/".$filename);
+                        $count++;
+                    }
                 }
             }
+            return $count_size;
+        } else {
+            return 0;
         }
-        return $count_size;
-    }
+    } 
 }
 
 if (!function_exists('sizeFormat')) {

--- a/assets/sstvimages/index.html
+++ b/assets/sstvimages/index.html
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>403 Forbidden</title>
+	</head>
+	<body>
+		<p>Directory access is forbidden.</p>
+	</body>
+</html>


### PR DESCRIPTION
resolves #3062

This pull request primarily focuses on enhancing the file and directory handling in the application. The changes include an update to the `folderSize` function in `storage_helper.php` to handle cases where the input is not a directory or if the directory is missing, and the addition of an `index.html` file in `assets/sstvimages` to prevent directory access and also adds the `sstvimages` directory to the repo.

Here are the key changes:

File and Directory Handling:

* [`application/helpers/storage_helper.php`](diffhunk://#diff-413abc91cb9cb7f2cc0f661e201eea3e2c18c458a63a89b58143afcbb28d4dbcR5): The `folderSize` function now checks if the input `$dir` is a directory before proceeding with its operations. If `$dir` is not a directory, the function returns 0. This change helps prevent errors that could occur when the function is called with an invalid directory. [[1]](diffhunk://#diff-413abc91cb9cb7f2cc0f661e201eea3e2c18c458a63a89b58143afcbb28d4dbcR5) [[2]](diffhunk://#diff-413abc91cb9cb7f2cc0f661e201eea3e2c18c458a63a89b58143afcbb28d4dbcR21-R23)
* [`assets/sstvimages/index.html`](diffhunk://#diff-95c23863574c257759e4b68c5d9f03c71af134dcfbfb1e6ec98361064350b748R1-R8): A new `index.html` file has been added to the `assets/sstvimages` directory. This file displays a "403 Forbidden" message, effectively preventing unauthorized directory access.  Adding this file to the directory also allows us to add the `sstvimages` directory to the repo and should prevent users from not having it in the future.