### PR TITLE
Fix visitor pagination links

### DIFF
--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -82,7 +82,7 @@ class Visitor extends CI_Controller {
 				$config['base_url'] = base_url().'index.php/visitor/'. $public_slug . '/index';
 				$config['total_rows'] = $this->logbook_model->total_qsos($logbooks_locations_array);
 				$config['per_page'] = '25';
-				$config['num_links'] = $this->logbook_model->total_qsos($logbooks_locations_array) / 25;
+				$config['num_links'] = 6;
 				$config['full_tag_open'] = '<ul class="pagination">';
 				$config['full_tag_close'] = '</ul>';
 				$config['attributes'] = ['class' => 'page-link'];


### PR DESCRIPTION
Resolves #3060 

- This one limits the number of pagination links visible on the page at a time to 6, like the logbook page


### Before fix:
![2024-04-08 19 47 53](https://github.com/magicbug/Cloudlog/assets/6586559/732b05c4-7ac1-448b-b82e-50315db63786)


### After fix:
![2024-04-08 19 45 19](https://github.com/magicbug/Cloudlog/assets/6586559/3eee8edb-37b8-45a0-aade-7dc5a5d03aa7)
