### PR TITLE
Print activator references on QSO labels

### DIFF
--- a/application/views/labels/startatform.php
+++ b/application/views/labels/startatform.php
@@ -12,6 +12,12 @@
         </div>
     </div>
     <div class="mb-3 row">
+        <label class="my-1 me-2 col-md-4" for="via">Include awards?</label>
+        <div class="form-check-inline">
+            <input class="form-check-input" type="checkbox" name="awards" id="awards">
+        </div>
+    </div>
+    <div class="mb-3 row">
         <label class="my-1 me-2 col-md-4" for="startat">Start printing at?</label>
         <div class="d-flex align-items-center">
             <input class="form-control input-group-sm" type="number" id="startat" name="startat" value="1">


### PR DESCRIPTION
For those partaking in POTA/SOTA/IOTA/WWFF/RANDOM_SIG it is nice to print an automatic reference list in the QSL for the hunters.

This PR adds a new checkbox in the QSL printing form to add the awards references, if selected a new line will be introduced after the grid square with all the references for the current station profile.

Example label:
![tempImageHKn4Ya](https://github.com/magicbug/Cloudlog/assets/78752/1f5ad23f-16c4-443c-84a7-d5f7d4d864a0)

73 de IU5BON