### PR TITLE
Lotw fixing

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -300,20 +300,22 @@ class Lotw extends CI_Controller {
 				//If the function curl_file_create exists
 				if(function_exists('curl_file_create')){
 					//Use the recommended way, creating a CURLFile object.
-					$filePath = curl_file_create($filePath);
+					$uploadfile = curl_file_create($filePath);
+					$uploadfile->setPostFilename(basename($filePath));
 				} else{
 					//Otherwise, do it the old way.
 					//Get the canonicalized pathname of our file and prepend
 					//the @ character.
-					$filePath = '@' . realpath($filePath);
+					$uploadfile = '@' . realpath($filePath).';filename='.basename($filePath);
 					//Turn off SAFE UPLOAD so that it accepts files
 					//starting with an @
 					curl_setopt($ch, CURLOPT_SAFE_UPLOAD, false);
 				}
 
+
 				//Setup our POST fields
 				$postFields = array(
-					$uploadFieldName => $filePath
+					$uploadFieldName => $uploadfile
 				);
 
 				curl_setopt($ch, CURLOPT_POSTFIELDS, $postFields);

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -967,7 +967,7 @@ class Lotw extends CI_Controller {
 		    openssl_free_key($pkeyid);
 		  }
 		  $signature_b64 = base64_encode($signature);
-		  return $signature_b64;
+		  return $signature_b64."\n";
 		}
 
 

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -297,21 +297,9 @@ class Lotw extends CI_Controller {
 				//Tell cURL to return the output as a string.
 				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
-				//If the function curl_file_create exists
-				if(function_exists('curl_file_create')){
-					//Use the recommended way, creating a CURLFile object.
-					$uploadfile = curl_file_create($filePath);
-					$uploadfile->setPostFilename(basename($filePath));
-				} else{
-					//Otherwise, do it the old way.
-					//Get the canonicalized pathname of our file and prepend
-					//the @ character.
-					$uploadfile = '@' . realpath($filePath).';filename='.basename($filePath);
-					//Turn off SAFE UPLOAD so that it accepts files
-					//starting with an @
-					curl_setopt($ch, CURLOPT_SAFE_UPLOAD, false);
-				}
-
+				//Use the recommended way, creating a CURLFile object.
+				$uploadfile = curl_file_create($filePath);
+				$uploadfile->setPostFilename(basename($filePath));
 
 				//Setup our POST fields
 				$postFields = array(


### PR DESCRIPTION
This fixes a few things in LoTW uploads:

- The OpenSSL base64 data normally needs a newline at the end to be able to verify signatures correctly. This has been worked around on LoTW side but probably be good to be compliant in the first place
- The upload filename has the full path stripped. Not really an issue but just in case ... It does not harm to hide the directory structure of the uploading system
- The unsafe cURL file upload has been removed from PHP. So this part of the code should be removed as well as PHP fails with an error because the insecure method is not allowed any more.