### PR TITLE
Feature - New API route - Recent QSO's

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -484,6 +484,17 @@ class API extends CI_Controller {
 
 	}
 
+	function recent_qsos($key = null) {
+		header('Content-type: application/json');
+		$this->load->model('logbook_model');
+
+		$data['qsos'] = $this->logbook_model->recent_qsos(null, $key);
+
+		http_response_code(201);
+		echo json_encode($data['qsos']);
+
+	}
+
 	function lookup() {
 		// start benchmarking
 		$this->output->enable_profiler(TRUE);

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -481,7 +481,6 @@ class API extends CI_Controller {
 
 		http_response_code(201);
 		echo json_encode(['Today' => $data['todays_qsos'], 'total_qsos' => $data['total_qsos'], 'month_qsos' => $data['month_qsos'], 'year_qsos' => $data['year_qsos']]);
-
 	}
 
 	function recent_qsos($key = null) {

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2239,7 +2239,6 @@ class Logbook_model extends CI_Model
   }
 
   
-  <?php
   /* Return most recent QSOs */
   function recent_qsos($StationLocationsArray = null, $api_key = null)
   {
@@ -2309,7 +2308,6 @@ class Logbook_model extends CI_Model
         return null;
       }
   }
-  ?>
 
   /* Return QSOs over a period of days */
   function map_week_qsos($start, $end)

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2238,6 +2238,60 @@ class Logbook_model extends CI_Model
     }
   }
 
+  
+  /* Return 10 most recent QSOs */
+  function recent_qsos($StationLocationsArray = null, $api_key = null)
+  {
+    $CI = &get_instance();
+    $detailed = $this->input->get('detailed') === 'true' ? true : false;
+    $limit = $this->input->get('limit');
+    $limit = is_numeric($limit) ? $limit : 10; // Default to 10 if limit is not a number
+
+    // Throw an error if limit is greater than 100
+    if ($limit > 100) {
+        show_error('The limit cannot be greater than 100.', 400);
+        return;
+    }
+
+
+    if ($StationLocationsArray == null) {
+      $CI->load->model('logbooks_model');
+      if ($api_key != null) {
+        $CI->load->model('api_model');
+        if (strpos($this->api_model->access($api_key), 'r') !== false) {
+          $this->api_model->update_last_used($api_key);
+          $user_id = $this->api_model->key_userid($api_key);
+          $active_station_logbook = $CI->logbooks_model->find_active_station_logbook_from_userid($user_id);
+          $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($active_station_logbook);
+        } else {
+          $logbooks_locations_array = [];
+        }
+      } else {
+        $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+      }
+    } else {
+      $logbooks_locations_array = $StationLocationsArray;
+    }
+
+    if ($logbooks_locations_array) {
+      if ($detailed) {
+        $this->db->select('*');
+      } else {
+        $this->db->select('COL_CALL, COL_BAND, COL_FREQ, COL_MODE, COL_SUBMODE, COL_NAME, COL_MY_GRIDSQUARE, COL_COUNTRY, COL_DXCC, COL_CONTEST_ID, COL_FREQ_RX, COL_MY_CITY, COL_MY_CNTY, COL_MY_COUNTRY, COL_COMMENT, COL_DISTANCE, COL_NAME, COL_OPERATOR, COL_RST_RCVD, COL_RST_SENT, COL_STATION_CALLSIGN, COL_TIME_OFF, COL_TIME_ON, COL_TX_PWR');
+      }
+      $this->db->where_in('station_id', $logbooks_locations_array);
+      $this->db->order_by('COL_TIME_ON', 'DESC');
+      $this->db->limit($limit);
+      $query = $this->db->get($this->config->item('table_name'));
+
+      if ($query->num_rows() > 0) {
+        return $query->result();
+      }
+    } else {
+      return null;
+    }
+  }
+
   /* Return QSOs over a period of days */
   function map_week_qsos($start, $end)
   {


### PR DESCRIPTION
Resolves #3127 

Added a new route to the API that returns the most recent QSO's.

There are 2 options you can pass in:

- `detailed` - defaults to `false` and returns all the columns if set to true in the request URL
- `limit` - defaults to 10 and limits the amount of QSO's returned to provided amount.  
- limit throws an error if a user sets it higher than 100.  - This can change, i figured it might be good to put a hard limit to prevent bad actors trying to slog the server down or something
- returns `null` if no qso's are found


Example routes:
[http://localhost/index.php/api/recent_qsos?limit=5&detailed=true](http://localhost/index.php/api/recent_qsos?limit=5&detailed=true)
[http://localhost/index.php/api/recent_qsos?limit=1](http://localhost/index.php/api/recent_qsos?limit=1)

### Standard json return (not detailed)
```json
[
    {
        "COL_CALL": "N0RC",
        "COL_BAND": "20m",
        "COL_FREQ": "14200000",
        "COL_MODE": "SSB",
        "COL_SUBMODE": "USB",
        "COL_NAME": "Reid Crowe",
        "COL_MY_GRIDSQUARE": "EM28NW",
        "COL_COUNTRY": "United States Of America",
        "COL_DXCC": "291",
        "COL_CONTEST_ID": null,
        "COL_FREQ_RX": "0",
        "COL_MY_CITY": "OLATHE",
        "COL_MY_CNTY": "JOHNSON",
        "COL_MY_COUNTRY": "UNITED STATES OF AMERICA",
        "COL_COMMENT": "",
        "COL_DISTANCE": "0",
        "COL_OPERATOR": "KS3CKC",
        "COL_RST_RCVD": "59",
        "COL_RST_SENT": "59",
        "COL_STATION_CALLSIGN": "KS3CKC",
        "COL_TIME_OFF": "2024-05-29 19:30:20",
        "COL_TIME_ON": "2024-05-29 19:30:20",
        "COL_TX_PWR": "100"
    }
]
```