### PR TITLE
rollback commit fc6b196 [Added the possibility of sending data to the…

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -193,13 +193,8 @@ class API extends CI_Controller {
 		// Decode JSON and store
 		$obj = json_decode(file_get_contents("php://input"), true);
 		if ($obj === NULL) {
-			// Decoding not valid try simple www-x-form-urlencoded
-		    $objTmp = file_get_contents("php://input");
-		    parse_str($objTmp, $obj);
-		    if ($obj === NULL) {
-		        echo json_encode(['status' => 'failed', 'reason' => "wrong JSON"]);
-		        die();
-		    }
+			echo json_encode(['status' => 'failed', 'reason' => "wrong JSON"]);
+			die();
 		}
 
 		if(!isset($obj['key']) || $this->api_model->authorize($obj['key']) == 0) {


### PR DESCRIPTION
A few days ago, the commit fc6b196 
[Added the possibility of sending data to the "qso" method API also in…](https://github.com/magicbug/Cloudlog/pull/3126/commits/fc6b1966e3b08f00732fbb5b24e6abdf7da02eec) 
[fc6b196](https://github.com/magicbug/Cloudlog/pull/3126/commits/fc6b1966e3b08f00732fbb5b24e6abdf7da02eec)

 relating to the modification of the API to also allow www-x-form-urlencoded format payloads was moved to "main" by mistake.
This PR resets the code.