### PR TITLE
Corrected labels for WAB in language files

### DIFF
--- a/application/language/bulgarian/awards_lang.php
+++ b/application/language/bulgarian/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "For more information, please visit: <a h
 
 /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/chinese_simplified/awards_lang.php
+++ b/application/language/chinese_simplified/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "请访问 <a href='https://www.jarl.org/
 
 /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/czech/awards_lang.php
+++ b/application/language/czech/awards_lang.php
@@ -195,10 +195,10 @@ $lang['awards_waja_description_ln3'] = "May be claimed for having contacted (hea
 $lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://www.jarl.org/English/4_Library/A-4-2_Awards/Award_Main.htm' target='_blank'>https://www.jarl.org/English/4_Library/A-4-2_Awards/Award_Main.htm</a>.";
 /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/dutch/awards_lang.php
+++ b/application/language/dutch/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "For more information, please visit: <a h
 
     /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/english/awards_lang.php
+++ b/application/language/english/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "For more information, please visit: <a h
 
 /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/finnish/awards_lang.php
+++ b/application/language/finnish/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "For more information, please visit: <a h
 
  /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/french/awards_lang.php
+++ b/application/language/french/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "For more information, please visit: <a h
 
     /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/german/awards_lang.php
+++ b/application/language/german/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "For more information, please visit: <a h
 
     /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/greek/awards_lang.php
+++ b/application/language/greek/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "For more information, please visit: <a h
 
 /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/italian/awards_lang.php
+++ b/application/language/italian/awards_lang.php
@@ -180,10 +180,10 @@ $lang['awards_waja_description_ln3'] = "Può essere rivendicato per aver contatt
 $lang['awards_waja_description_ln4'] = "Per ulteriori informazioni, visitare: <a href='https://www.jarl.org/English/4_Library/A-4-2_Awards/Award_Main.htm' target='_blank' >https://www.jarl.org/English/4_Library/A-4-2_Awards/Award_Main.htm</a>.";
 /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "Il Worked All Britain Award (WAB) è un prestigioso programma di riconoscimento all\'interno della comunità dei radioamatori che celebra i risultati ottenuti nella comunicazione in tutto il Regno Unito. Il programma del premio WAB incoraggia gli operatori radio a stabilire un contatto con le stazioni situati in diverse regioni della Gran Bretagna, favorendo il cameratismo e promuovendo le capacità di comunicazione radiofonica. Per ottenere il premio WAB, i partecipanti devono stabilire contatti radio con successo con stazioni situate in aree WAB specifiche, definite dai quadrati della griglia dell\'Ordnance Survey. Questi quadrati della griglia coprono l\'intero della Gran Bretagna, tra cui Inghilterra, Scozia, Galles e alcune isole al largo.";
 $lang['awards_wab_description_ln3'] = "I partecipanti al programma WAB Award si scambiano informazioni come la loro posizione, la potenza del segnale e il riferimento quadrato WAB durante i contatti radio. I punti vengono assegnati in base alla posizione della stazione contattata, con diversi valori in punti assegnati ai contatti effettuati all\'interno di diverse aree WAB Accumulando punti dai contatti riusciti, gli operatori radiofonici possono progredire attraverso vari livelli di premio, ognuno dei quali rappresenta una pietra miliare significativa nel loro viaggio radioamatoriale. Il Premio WAB non solo riconosce la dedizione e l\'abilità degli operatori radiofonici, ma anche promuove la diversità geografica e incoraggia l\'esplorazione del ricco mosaico di luoghi in tutta la Gran Bretagna attraverso il mezzo della radio amatoriale.";
-$lang['awards_waja_description_ln4'] = "Per ulteriori informazioni, visitare: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net /default.php</a>.";
+$lang['awards_wab_description_ln4'] = "Per ulteriori informazioni, visitare: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net /default.php</a>.";

--- a/application/language/polish/awards_lang.php
+++ b/application/language/polish/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "For more information, please visit: <a h
 
     /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/russian/awards_lang.php
+++ b/application/language/russian/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "For more information, please visit: <a h
 
     /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/spanish/awards_lang.php
+++ b/application/language/spanish/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "Para más información, por favor visite
 
     /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/swedish/awards_lang.php
+++ b/application/language/swedish/awards_lang.php
@@ -196,10 +196,10 @@ $lang['awards_waja_description_ln4'] = "For more information, please visit: <a h
 
     /*
 ___________________________________________________________________________________________
-WAB -- Use all 3 Lines of Text
+WAB -- Use all 4 Lines of Text
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Worked All Britain Award";
+$lang['awards_wab_description_ln1'] = "WAB - Worked All Britain Award";
 $lang['awards_wab_description_ln2'] = "The Amateur Radio Worked All Britain (WAB) Award is a prestigious recognition program within the amateur radio community that celebrates communication achievements across the United Kingdom. The WAB Award scheme encourages radio operators to establish contact with stations located in different regions of Britain, fostering camaraderie and promoting radio communication skills. To earn the WAB Award, participants must make successful radio contacts with stations located in specific WAB areas, which are defined by Ordnance Survey grid squares. These grid squares cover the entirety of Great Britain, including England, Scotland, Wales, and some offshore islands.";
 $lang['awards_wab_description_ln3'] = "Participants in the WAB Award program exchange information such as their location, signal strength, and WAB square reference during radio contacts. Points are awarded based on the location of the contacted station, with different point values assigned to contacts made within different WAB areas. By accumulating points from successful contacts, radio operators can progress through various award levels, each representing a significant milestone in their amateur radio journey. The WAB Award not only recognizes the dedication and skill of radio operators but also promotes geographic diversity and encourages exploration of the rich tapestry of locations across Britain through the medium of amateur radio.";
-$lang['awards_waja_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";
+$lang['awards_wab_description_ln4'] = "For more information, please visit: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net/default.php</a>.";

--- a/application/language/turkish/awards_lang.php
+++ b/application/language/turkish/awards_lang.php
@@ -190,10 +190,10 @@ $lang['awards_waja_description_ln4'] = "Daha fazla bilgi için lütfen şu adres
 
      /*
 ___________________________________________________________________________________________
-WAB - Metnin 3 Satırının Tümünü Kullan
+WAB - Metnin 4 Satırının Tümünü Kullan
 ___________________________________________________________________________________________
 */
-$lang['awards_waja_description_ln1'] = "WAB - Tüm Britanya'da Çalıştı Ödülü";
+$lang['awards_wab_description_ln1'] = "WAB - Tüm Britanya'da Çalıştı Ödülü";
 $lang['awards_wab_description_ln2'] = "Amatör Radyo Tüm Britanya'da Çalıştı (WAB) Ödülü, amatör radyo topluluğu içinde Birleşik Krallık genelindeki iletişim başarılarını kutlayan prestijli bir tanınma programıdır. WAB Ödülü programı radyo operatörlerini istasyonlarla iletişim kurmaya teşvik eder Britanya'nın farklı bölgelerinde bulunan, dostluğu teşvik eden ve radyo iletişim becerilerini destekleyen WAB Ödülünü kazanmak için, katılımcıların Ordnance Survey Kılavuz kareleri tarafından tanımlanan belirli WAB alanlarında bulunan istasyonlarla başarılı radyo bağlantıları kurmaları gerekir. İngiltere, İskoçya, Galler ve bazı açık deniz adaları da dahil olmak üzere Büyük Britanya'nın.";
 $lang['awards_wab_description_ln3'] = "WAB Ödülü programındaki katılımcılar, radyo bağlantıları sırasında konumları, sinyal güçleri ve WAB kare referansı gibi bilgileri paylaşırlar. Puanlar, atanmış farklı puan değerleri ile, iletişim kurulan istasyonun konumuna göre verilir. Başarılı bağlantılardan puan toplayarak, telsiz operatörleri, her biri amatör telsiz yolculuklarında önemli bir dönüm noktasını temsil eden çeşitli ödül seviyelerinde ilerleyebilirler. WAB Ödülü, yalnızca telsiz operatörlerinin özveri ve becerilerini ödüllendirmektedir. coğrafi çeşitliliği teşvik eder ve amatör radyo aracılığıyla Britanya'nın her yerindeki zengin dokuların keşfedilmesini teşvik eder.";
-$lang['awards_waja_description_ln4'] = "Daha fazla bilgi için lütfen şu adresi ziyaret edin: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net /default.php</a>.";
+$lang['awards_wab_description_ln4'] = "Daha fazla bilgi için lütfen şu adresi ziyaret edin: <a href='https://wab.intermip.net/default.php' target='_blank'>https://wab.intermip.net /default.php</a>.";


### PR DESCRIPTION
Corrected labels for awards_wab_description_ln1 and awards_wab_description_ln4 for WAB in language files.

Following errors were logged which triggered me to correct:

ERROR - 2024-06-16 15:44:15 --> Could not find the language line "awards_wab_description_ln1"
ERROR - 2024-06-16 15:44:15 --> Could not find the language line "awards_wab_description_ln4"

