### PR TITLE
Return the station list sorted by call and name

### DIFF
--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -30,6 +30,8 @@ class Stations extends CI_Model {
 		$this->db->select('station_profile.*, dxcc_entities.name as station_country, dxcc_entities.end as dxcc_end');
 		$this->db->where('user_id', $userid);
 		$this->db->join('dxcc_entities','station_profile.station_dxcc = dxcc_entities.adif','left outer');
+		$this->db->order_by('station_profile.station_callsign');
+		$this->db->order_by('station_profile.station_profile_name');
 		return $this->db->get('station_profile');
 	}
 


### PR DESCRIPTION
When going through that station profile list, this appears to be sorted randomly.
Use cases are (for ex) on Import and Export ADIF, where it's difficult to find the correct profile if you have many stations.
By  returning the list of stations sorted by call and name some organization is provided, and it becomes easier to find the correct station profile for the operation.
