### PR TITLE
Custom maps: set dates to full logbook range + submodes filter fix + some wording fixes

### DIFF
--- a/application/controllers/Map.php
+++ b/application/controllers/Map.php
@@ -10,10 +10,10 @@ class Map extends CI_Controller {
     function custom()
 	{
 		$this->load->model('bands');
-        $this->load->model('modes');
+        $this->load->model('gridmap_model');
 
-        $data['worked_bands'] = $this->bands->get_worked_bands(); // Used in the view for band select
-		$data['modes'] = $this->modes->active(); 					// Used in the view for mode select
+        $data['worked_bands'] = $this->bands->get_worked_bands();  // Used in the view for band select
+		$data['modes'] = $this->gridmap_model->get_worked_modes(); // Used in the view for mode select
 
         if ($this->input->post('band') != NULL) {   			// Band is not set when page first loads.
             if ($this->input->post('band') == 'All') {          // Did the user specify a band? If not, use all bands
@@ -98,5 +98,12 @@ class Map extends CI_Controller {
 			echo json_encode(array_merge($plot_array, $station_array));
 		}
 
+	}
+
+	// Function to fetch the date of the oldest QSO in the log
+	public function get_oldest_qso_date() {
+		$this->load->model('logbook_model');
+		$oldestQSOdate = $this->logbook_model->get_oldest_qso_date();
+		echo $oldestQSOdate;
 	}
 }

--- a/application/language/bulgarian/general_words_lang.php
+++ b/application/language/bulgarian/general_words_lang.php
@@ -230,3 +230,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['datatables_language'] = "en-GB";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/chinese_simplified/general_words_lang.php
+++ b/application/language/chinese_simplified/general_words_lang.php
@@ -230,3 +230,5 @@ $lang['dashboard_logbooks_warning'] = '你没有电台日志。 请前往<a href
 $lang['hams_at_no_activations_found'] = '未找到即将进行的激活。 请稍后再回来查看。';
 
 $lang['datatables_language'] = "en-GB";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/czech/general_words_lang.php
+++ b/application/language/czech/general_words_lang.php
@@ -225,3 +225,5 @@ $lang['general_word_today'] = 'Dnes';
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['datatables_language'] = "en-GB";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/dutch/general_words_lang.php
+++ b/application/language/dutch/general_words_lang.php
@@ -230,3 +230,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['datatables_language'] = "en-GB";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/english/general_words_lang.php
+++ b/application/language/english/general_words_lang.php
@@ -230,3 +230,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['datatables_language'] = "en-GB";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/finnish/general_words_lang.php
+++ b/application/language/finnish/general_words_lang.php
@@ -230,3 +230,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['datatables_language'] = "en-GB";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/french/general_words_lang.php
+++ b/application/language/french/general_words_lang.php
@@ -230,3 +230,5 @@ $lang['dashboard_logbooks_warning'] = "Vous n'avez pas de journal de travail pou
 $lang['hams_at_no_activations_found'] = "Aucune activation à venir trouvée. Veuillez revenir plus tard.";
 
 $lang['datatables_language'] = "fr-FR";
+
+$lang['set_log_to_full_dates'] = "Dates du log complet";

--- a/application/language/german/general_words_lang.php
+++ b/application/language/german/general_words_lang.php
@@ -230,3 +230,5 @@ $lang['dashboard_logbooks_warning'] = 'Es wurde kein Stationslogbuch angelegt. K
 $lang['hams_at_no_activations_found'] = 'Keine bevorstehenden Aktivierungen gefunden. Bitte später noch einmal vorbeischauen.';
 
 $lang['datatables_language'] = "de-DE";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/greek/general_words_lang.php
+++ b/application/language/greek/general_words_lang.php
@@ -230,3 +230,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['datatables_language'] = "en-GB";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/italian/general_words_lang.php
+++ b/application/language/italian/general_words_lang.php
@@ -229,3 +229,5 @@ $lang['dashboard_logbooks_warning'] = 'Non hai il registro di stazione. Vai <a h
 $lang['hams_at_no_activations_found'] = 'Nessuna attivazione imminente trovata. Per favore controllare più tardi.';
 
 $lang['datatables_language'] = "it-IT";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/polish/general_words_lang.php
+++ b/application/language/polish/general_words_lang.php
@@ -225,3 +225,5 @@ $lang['general_word_today'] = 'Today';
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['datatables_language'] = "en-GB";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/russian/general_words_lang.php
+++ b/application/language/russian/general_words_lang.php
@@ -231,3 +231,5 @@ $lang['dashboard_logbooks_warning'] = 'У вас нет аппаратного �
 $lang['hams_at_no_activations_found'] = 'не найдены предстоящие активации. Проверьте позже.';
 
 $lang['datatables_language'] = "ru-RU";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/spanish/general_words_lang.php
+++ b/application/language/spanish/general_words_lang.php
@@ -231,3 +231,5 @@ $lang['dashboard_logbooks_warning'] = 'No tiene libro de guardias. ¡Haga clic <
 $lang['hams_at_no_activations_found'] = 'No hay activaciones próximas. Por favor vuelve a revisar más tarde.';
 
 $lang['datatables_language'] = "es-ES";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/swedish/general_words_lang.php
+++ b/application/language/swedish/general_words_lang.php
@@ -232,3 +232,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['datatables_language'] = "en-GB";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/language/turkish/general_words_lang.php
+++ b/application/language/turkish/general_words_lang.php
@@ -228,3 +228,5 @@ $lang['dashboard_logbooks_warning'] = 'İstasyon Kayıt kitabınız yok. Buraya 
 $lang['hams_at_no_activations_found'] = 'Yakın gelecekte aktivasyon bulunamadı. Sonra tekrar deneyin.';
 
 $lang['datatables_language'] = "tr-TR";
+
+$lang['set_log_to_full_dates'] = "Set log to full dates";

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4856,6 +4856,15 @@ class Logbook_model extends CI_Model
     }
     return $json;
   }
+
+  public function get_oldest_qso_date()
+  {
+    $query = $this->db->query('SELECT DATE(min(col_time_on)) as oldest_qso_date FROM TABLE_HRD_CONTACTS_V01');
+    $row = $query->row();
+    if (isset($row)) {
+      return $row->oldest_qso_date;
+    }
+  }
 }
 
 function validateADIFDate($date, $format = 'Ymd')

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -797,9 +797,20 @@ if ($this->session->userdata('user_id') != null) {
                 };
                 initplot(qso_loc, customdata);
             })
-
-
         });
+
+        function get_oldest_qso_date() {
+            $.ajax({
+                url: base_url + 'index.php/map/get_oldest_qso_date',
+                type: 'post',
+                success: function(data) {
+                    document.getElementById('from').value = data;
+                    document.getElementById('to').value = new Date().toISOString().split('T')[0];
+                },
+                error: function() {
+                },
+            });
+        }
     </script>
 <?php } ?>
 

--- a/application/views/map/custom_date.php
+++ b/application/views/map/custom_date.php
@@ -1,6 +1,6 @@
 <div class="container custom-map-QSOs">
     <br>
-    <h2><?php echo $logbook_name ?> logbook QSOs (Custom Date)</h2>
+    <h2><?php echo $logbook_name; echo strpos($logbook_name, 'logbook') ? '' : ' logbook'; ?> QSOs (Custom Dates)</h2>
 
     <?php if ($this->session->flashdata('notice')) { ?>
         <div class="alert alert-info" role="alert">
@@ -19,6 +19,10 @@
                 <label for="to"><?php echo lang('gen_to_date') . ": " ?></label>
                 <input name="to" id="to" type="date" class="form-control w-auto" value="<?php echo $date_to; ?>" max="<?php echo $date_to; ?>">
             </div>
+
+            <div class="mb-3 col-md-3 d-flex align-items-end">
+                <input class="btn btn-secondary" type="button" value="<?php echo lang('set_log_to_full_dates'); ?>" onclick="get_oldest_qso_date();">
+            </div>
         </div>
 
         <div class="row">
@@ -34,21 +38,14 @@
                 </select>
             </div>
 
-
             <div class="mb-3 col-md-3">
                 <label for="mode">Mode</label>
                 <select id="mode" name="mode" class="form-select">
-                    <option value="All" <?php if ($this->input->post('mode') == "All" || $this->input->method() !== 'post') echo ' selected'; ?>>All</option>
+                    <option value="All" <?php if ($this->input->post('mode') == "All" || $this->input->method() !== 'post') echo ' selected'; ?>><?php echo lang('general_word_all') ?></option>
                     <?php
-                    foreach ($modes->result() as $mode) {
-                        if ($mode->submode == null) {
-                            echo '<option value="' . $mode->mode . '"';
-                            if ($this->input->post('mode') == $mode->mode) echo ' selected';
-                            echo '>' . $mode->mode . '</option>' . "\n";
-                        } else {
-                            echo '<option value="' . $mode->submode . '"';
-                            if ($this->input->post('mode') == $mode->submode) echo ' selected';
-                            echo '>' . $mode->submode . '</option>' . "\n";
+                    foreach ($modes as $mode) {
+                        if ($mode->submode ?? '' == '') {
+                            echo '<option value="' . $mode . '">' . strtoupper($mode) . '</option>'."\n";
                         }
                     }
                     ?>
@@ -58,7 +55,8 @@
             <div class="mb-3 col-md-3">
                 <label for="selectPropagation">Propagation Mode</label>
                 <select class="form-select" id="selectPropagation" name="prop_mode">
-                    <option value="All" <?php if ($this->input->post('prop_mode') == "All" || $this->input->method() !== 'post') echo ' selected'; ?>>All</option>
+                    <option value="All" <?php if ($this->input->post('prop_mode') == "All" || $this->input->method() !== 'post') echo ' selected'; ?>><?php echo lang('general_word_all') ?></option>
+                    <option value="" <?php if ($this->input->post('prop_mode') == "" && $this->input->method() == 'post') echo ' selected'; ?>><?php echo lang('general_word_undefined') ?></option>
                     <option value="AS" <?php if ($this->input->post('prop_mode') == "AS") echo ' selected'; ?>>Aircraft Scatter</option>
                     <option value="AUR" <?php if ($this->input->post('prop_mode') == "AUR") echo ' selected'; ?>>Aurora</option>
                     <option value="AUE" <?php if ($this->input->post('prop_mode') == "AUE") echo ' selected'; ?>>Aurora-E</option>
@@ -82,7 +80,7 @@
         </div>
 
         <div class="row">
-            <div class="mb-1 col-md-1">
+            <div class="mb-2 col-md-2">
                 <input class="btn btn-primary btn_submit_map_custom" type="button" value="Load Map">
             </div>
             <div class="mb-4 col-md-4">
@@ -96,4 +94,4 @@
 <!-- Map -->
 <div id="custommap" class="map-leaflet mt-2" style="width: 100%; height: 1000px;"></div>
 
-<div class="alert alert-success" role="alert">Showing QSOs for Custom Date for Active Logbook <?php echo $logbook_name ?></div>
+<div class="alert alert-success" role="alert">Showing QSOs for Custom Dates for Active Logbook <?php echo $logbook_name ?></div>


### PR DESCRIPTION
Custom maps analytics :
- New button to quickly set the dates to the full range of the logbook
- Fixed the list of modes to include all submodes
- Fixed some texts