### PR TITLE
Analytics: number of QSOs for each day of the week

### DIFF
--- a/application/controllers/Dayswithqso.php
+++ b/application/controllers/Dayswithqso.php
@@ -21,6 +21,7 @@ class Dayswithqso extends CI_Controller {
         $data['streaks'] = $this->dayswithqso_model->getLongestStreak();
         $data['currentstreak'] = $this->dayswithqso_model->getCurrentStreak();
         $data['almostcurrentstreak'] = $this->dayswithqso_model->getAlmostCurrentStreak();
+        $data['daysofweek'] = $this->dayswithqso_model->getDaysOfWeek();
 
         $this->load->view('interface_assets/header', $data);
         $this->load->view('dayswithqso/index');
@@ -34,6 +35,17 @@ class Dayswithqso extends CI_Controller {
 
         // get data
         $data = $this->dayswithqso_model->getDaysWithQso();
+        header('Content-Type: application/json');
+        echo json_encode($data);
+    }
+
+    public function get_weekdays(){
+
+        //load model
+        $this->load->model('dayswithqso_model');
+
+        // get data
+        $data = $this->dayswithqso_model->getDaysOfWeek();
         header('Content-Type: application/json');
         echo json_encode($data);
     }

--- a/application/language/bulgarian/statistics_lang.php
+++ b/application/language/bulgarian/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Timeline";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Number of days with QSOs each year";
-$lang['statistics_days_with_qso_short'] = "Days with QSOs";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Days with QSOs";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Longest streak with QSOs in the log";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "A maximum of the 10 longest streaks are shown!";
 $lang['statistics_dwq_streak_continuous_days'] = "Streak (continuous days with QSOs)";

--- a/application/language/chinese_simplified/statistics_lang.php
+++ b/application/language/chinese_simplified/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "时间线";
 *
 */
 
-$lang['statistics_days_with_qso'] = "本年QSO总数";
-$lang['statistics_days_with_qso_short'] = "QSO的日期";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "QSO的日期";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "日志中最长QSO连续记录";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "最多显示10条最长QSO连续记录";
 $lang['statistics_dwq_streak_continuous_days'] = "最长QSO连续记录";

--- a/application/language/czech/statistics_lang.php
+++ b/application/language/czech/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Timeline";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Number of days with QSOs each year";
-$lang['statistics_days_with_qso_short'] = "Days with QSOs";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Days with QSOs";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Longest streak with QSOs in the log";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "A maximum of the 10 longest streaks are shown!";
 $lang['statistics_dwq_streak_continuous_days'] = "Streak (continuous days with QSOs)";

--- a/application/language/dutch/statistics_lang.php
+++ b/application/language/dutch/statistics_lang.php
@@ -50,8 +50,13 @@ $lang['statistics_timeline'] = "Timeline";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Number of days with QSOs each year";
-$lang['statistics_days_with_qso_short'] = "Days with QSOs";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Days with QSOs";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Longest streak with QSOs in the log";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "A maximum of the 10 longest streaks are shown!";
 $lang['statistics_dwq_streak_continuous_days'] = "Streak (continuous days with QSOs)";

--- a/application/language/english/statistics_lang.php
+++ b/application/language/english/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Timeline";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Number of days with QSOs each year";
-$lang['statistics_days_with_qso_short'] = "Days with QSOs";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Days with QSOs";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Longest streak with QSOs in the log";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "A maximum of the 10 longest streaks are shown!";
 $lang['statistics_dwq_streak_continuous_days'] = "Streak (continuous days with QSOs)";
@@ -62,4 +67,3 @@ $lang['statistics_dwq_current_streak_in_log'] = "Current streak with QSOs in the
 $lang['statistics_dwq_current_streak_continuous_days'] = "Current streak (continuous days with QSOs)";
 $lang['statistics_dwq_make_qso_to_extend_streak'] = "If you make a QSO today, you can continue to extend your streak... or else your current streak will be broken!";
 $lang['statistics_dwq_no_current_streak'] = "No current streak found!";
-

--- a/application/language/finnish/statistics_lang.php
+++ b/application/language/finnish/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Timeline";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Number of days with QSOs each year";
-$lang['statistics_days_with_qso_short'] = "Days with QSOs";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Days with QSOs";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Longest streak with QSOs in the log";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "A maximum of the 10 longest streaks are shown!";
 $lang['statistics_dwq_streak_continuous_days'] = "Streak (continuous days with QSOs)";

--- a/application/language/french/general_words_lang.php
+++ b/application/language/french/general_words_lang.php
@@ -50,8 +50,8 @@ $lang['general_word_city'] = "Ville";
 $lang['general_word_total'] = "Total";
 $lang['general_word_year'] = "Année";
 $lang['general_word_month'] = "Mois";
-$lang['general_word_day'] = "Day";
-$lang['general_word_days'] = "Days";
+$lang['general_word_day'] = "Jour";
+$lang['general_word_days'] = "Jours";
 
 $lang['general_word_colors'] = "Couleurs";
 $lang['general_word_light'] = "Lumière/Laser";

--- a/application/language/french/statistics_lang.php
+++ b/application/language/french/statistics_lang.php
@@ -53,13 +53,17 @@ $lang['statistics_timeline'] = "Chronologie";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Number of days with QSOs each year";
-$lang['statistics_days_with_qso_short'] = "Days with QSOs";
-$lang['statistics_dwq_longest_streak_in_log'] = "Longest streak with QSOs in the log";
-$lang['statistics_dwq_longest_streak_in_log_hint'] = "A maximum of the 10 longest streaks are shown!";
-$lang['statistics_dwq_streak_continuous_days'] = "Streak (continuous days with QSOs)";
-$lang['statistics_dwq_current_streak_in_log'] = "Current streak with QSOs in the log";
-$lang['statistics_dwq_current_streak_continuous_days'] = "Current streak (continuous days with QSOs)";
-$lang['statistics_dwq_make_qso_to_extend_streak'] = "If you make a QSO today, you can continue to extend your streak... or else your current streak will be broken!";
-$lang['statistics_dwq_no_current_streak'] = "No current streak found!";
-
+$lang['statistics_tab_yearly'] = "Statistiques annuelles";
+$lang['statistics_tab_streaks'] = "Séries de jours";
+$lang['statistics_tab_weekdays'] = "Jours de la semaine";
+$lang['statistics_days_yearly'] = "Nombre de jours avec des QSOs par année";
+$lang['statistics_days_with_qso'] = "Jours avec des QSOs";
+$lang['statistics_weekdays_with_qso'] = "QSOs par jour de la semaine";
+$lang['statistics_number_of_qsos_this_weekday'] = "Nombre de QSOs pour ce jour de la semaine";
+$lang['statistics_dwq_longest_streak_in_log'] = "Plus longue série de jours avec des QSOs";
+$lang['statistics_dwq_longest_streak_in_log_hint'] = "Seules les 10 plus longues séries sont affichées";
+$lang['statistics_dwq_streak_continuous_days'] = "Série (jours consécutifs avec des QSOs)";
+$lang['statistics_dwq_current_streak_in_log'] = "Série en cours";
+$lang['statistics_dwq_current_streak_continuous_days'] = "Série en cours (jours consécutifs avec des QSOs)";
+$lang['statistics_dwq_make_qso_to_extend_streak'] = "Si vous faites un QSO aujourd'hui, vous pouvez continuer la série en cours... sinon elle sera perdue !";
+$lang['statistics_dwq_no_current_streak'] = "Aucune série en cours !";

--- a/application/language/german/statistics_lang.php
+++ b/application/language/german/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Zeitleiste";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Anzahl der Tage mit QSOs pro Jahr";
-$lang['statistics_days_with_qso_short'] = "Tage mit QSOs";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Tage mit QSOs";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Längste Serie mit QSOs im Logbuch";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "Es werden maximal die 10 längsten Serien angezeigt!";
 $lang['statistics_dwq_streak_continuous_days'] = "Serie (fortlaufende Tage mit QSOs)";

--- a/application/language/greek/statistics_lang.php
+++ b/application/language/greek/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Timeline";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Number of days with QSOs each year";
-$lang['statistics_days_with_qso_short'] = "Days with QSOs";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Days with QSOs";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Longest streak with QSOs in the log";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "A maximum of the 10 longest streaks are shown!";
 $lang['statistics_dwq_streak_continuous_days'] = "Streak (continuous days with QSOs)";

--- a/application/language/italian/statistics_lang.php
+++ b/application/language/italian/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Sequenza temporale";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Numero di giorni con QSO ogni anno";
-$lang['statistics_days_with_qso_short'] = "Giorni con QSO";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Giorni con QSO";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Serie più lunga di QSO nel log";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "Vengono mostrate al massimo le 10 serie più lunghe!";
 $lang['statistics_dwq_streak_continuous_days'] = "Streak (giorni continui con QSO)";

--- a/application/language/polish/statistics_lang.php
+++ b/application/language/polish/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Timeline";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Number of days with QSOs each year";
-$lang['statistics_days_with_qso_short'] = "Days with QSOs";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Days with QSOs";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Longest streak with QSOs in the log";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "A maximum of the 10 longest streaks are shown!";
 $lang['statistics_dwq_streak_continuous_days'] = "Streak (continuous days with QSOs)";

--- a/application/language/russian/statistics_lang.php
+++ b/application/language/russian/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Лента времени";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Количество дней с QSO в каждом году";
-$lang['statistics_days_with_qso_short'] = "Дней с QSO";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Дней с QSO";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Самый длинный интервал дней с QSO в журнале";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "Отображаются 10 самых длинных интервалов!";
 $lang['statistics_dwq_streak_continuous_days'] = "Интервал (непрерывных дней с QSO)";

--- a/application/language/spanish/statistics_lang.php
+++ b/application/language/spanish/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Línea de tiempo";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Número de días con QSOs en cada año";
-$lang['statistics_days_with_qso_short'] = "Días con QSOs";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Días con QSOs";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Mayor racha de QSOs en el libro";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "¡Se muestra un máximo de 10 rachas más largas!";
 $lang['statistics_dwq_streak_continuous_days'] = "Racha (días continuos con QSOs)";

--- a/application/language/swedish/statistics_lang.php
+++ b/application/language/swedish/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Timeline";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Number of days with QSOs each year";
-$lang['statistics_days_with_qso_short'] = "Days with QSOs";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "Days with QSOs";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Longest streak with QSOs in the log";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "A maximum of the 10 longest streaks are shown!";
 $lang['statistics_dwq_streak_continuous_days'] = "Streak (continuous days with QSOs)";

--- a/application/language/turkish/statistics_lang.php
+++ b/application/language/turkish/statistics_lang.php
@@ -53,8 +53,13 @@ $lang['statistics_timeline'] = "Zaman Çizelgesi";
 *
 */
 
-$lang['statistics_days_with_qso'] = "Her yıl QSO'ların olduğu gün sayısı";
-$lang['statistics_days_with_qso_short'] = "QSO'lu Günler";
+$lang['statistics_tab_yearly'] = "Yearly";
+$lang['statistics_tab_streaks'] = "Streaks";
+$lang['statistics_tab_weekdays'] = "Days of the week";
+$lang['statistics_days_yearly'] = "Number of days with QSOs each year";
+$lang['statistics_days_with_qso'] = "QSO'lu Günler";
+$lang['statistics_weekdays_with_qso'] = "QSOs breakdown by day of the week";
+$lang['statistics_number_of_qsos_this_weekday'] = "Number of QSOs for this day of the week";
 $lang['statistics_dwq_longest_streak_in_log'] = "Günlükteki QSO'larla en uzun seri";
 $lang['statistics_dwq_longest_streak_in_log_hint'] = "Maksimum en uzun 10 seri gösteriliyor!";
 $lang['statistics_dwq_streak_continuous_days'] = "Seri (QSO'larla sürekli günler)";

--- a/application/models/Dayswithqso_model.php
+++ b/application/models/Dayswithqso_model.php
@@ -180,4 +180,27 @@ class Dayswithqso_model extends CI_Model
         return $query->result();
     }
 
+    /*
+     * Returns the total number of QSOs made for each day of the week (Monday to Sunday)
+     */
+    function getDaysOfWeek()
+    {
+		$CI =& get_instance();
+		$CI->load->model('logbooks_model');
+		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+
+        if (!$logbooks_locations_array) {
+            return null;
+        }
+
+		$location_list = "'".implode("','",$logbooks_locations_array)."'";
+
+        $sql = "SELECT DAYNAME(col_time_off) AS weekday, COUNT(*) AS qsos FROM " . $this->config->item('table_name')
+              . " WHERE WEEKDAY(col_time_off) BETWEEN 0 AND 6 AND station_id in (" . $location_list . ")"
+              . " GROUP BY weekday ORDER BY FIELD(weekday, 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday')";
+
+        $query = $this->db->query($sql);
+
+        return $query->result();
+    }
 }

--- a/application/views/dayswithqso/index.php
+++ b/application/views/dayswithqso/index.php
@@ -1,125 +1,156 @@
 <script>
-    var lang_days_with_qso_short = "<?php echo lang('statistics_days_with_qso_short'); ?>";
+    var lang_days_with_qso = "<?php echo lang('statistics_days_with_qso'); ?>";
+    var lang_qsos_this_weekday = "<?php echo lang('statistics_number_of_qsos_this_weekday'); ?>";
 </script>
 
 <div class="container">
-
     <br>
-
     <h2><?php echo $page_title; ?></h2>
 
-    <?php
-    if (is_array($result)) {
-    echo '<div id="diffDays" class="table-responsive"><table class="qsotable table table-sm table-bordered table-hover table-striped table-condensed">';
+    <br>
+	<div class="tabs">
+		<ul class="nav nav-tabs" id="myTab" role="tablist">
+			<li class="nav-item">
+				<a class="nav-link active" id="home-tab" data-bs-toggle="tab" href="#home" role="tab" aria-controls="home" aria-selected="true"><?php echo lang('statistics_tab_yearly'); ?></a>
+			</li>
+			<li class="nav-item">
+				<a class="nav-link" id="daysofweek-tab" data-bs-toggle="tab" href="#daysofweek" role="tab" aria-controls="daysofweek" aria-selected="false"><?php echo lang('statistics_tab_weekdays'); ?></a>
+			</li>
+			<li class="nav-item">
+				<a class="nav-link" id="streaks-tab" data-bs-toggle="tab" href="#streaks" role="tab" aria-controls="streaks" aria-selected="false"><?php echo lang('statistics_tab_streaks'); ?></a>
+			</li>
+		</ul>
+	</div>
 
-            echo '<tr>';
-                echo '<th style=\'text-align: center\'>' . lang('general_word_year') . '</th>';
+    <div class="tab-content" id="myTabContent">
+        <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
+            <br/>
+            <h3><?php echo lang('statistics_days_yearly'); ?></h3>
+            <br/>
+            <?php
+            if (is_array($result)) {
+            echo '<div id="diffDays" class="table-responsive"><table class="qsotable table table-sm table-bordered table-hover table-striped table-condensed">';
 
-                foreach ($result as $master) {
-                echo '<td style=\'text-align: center\'>' . $master->Year . '</td>';
-                }
+                    echo '<tr>';
+                        echo '<th style=\'text-align: center\'>' . lang('general_word_year') . '</th>';
 
-                echo '</tr>';
+                        foreach ($result as $master) {
+                        echo '<td style=\'text-align: center\'>' . $master->Year . '</td>';
+                        }
 
-            echo '<tr>';
-                echo '<th style=\'text-align: center\'>' . lang('general_word_days') . '</th>';
+                        echo '</tr>';
 
-                foreach ($result as $master) {
-                echo '<td style=\'text-align: center\'>' . $master->Days . '</td>';
-                }
+                    echo '<tr>';
+                        echo '<th style=\'text-align: center\'>' . lang('general_word_days') . '</th>';
 
-                echo '</tr>';
+                        foreach ($result as $master) {
+                        echo '<td style=\'text-align: center\'>' . $master->Days . '</td>';
+                        }
 
-            echo '</table></div>';
-    }
-    ?>
-    <canvas id="myChartDiff" width="400" height="150"></canvas>
-    <h2><?php echo lang('statistics_dwq_longest_streak_in_log'); ?></h2>
-    <p><?php echo lang('statistics_dwq_longest_streak_in_log_hint'); ?></p>
+                        echo '</tr>';
 
-    <?php 
-    // Get Date format
-    if($this->session->userdata('user_date_format')) {
-        // If Logged in and session exists
-        $custom_date_format = $this->session->userdata('user_date_format');
-    } else {
-        // Get Default date format from /config/cloudlog.php
-        $custom_date_format = $this->config->item('qso_date_format');
-    }
-    ?>
+                    echo '</table></div>';
+            }
+            ?>
+            <canvas id="myChartDiff" width="400" height="150"></canvas>
+        </div>
 
-    <?php
-    if (is_array($streaks)) {
-        echo '<div id="streaks" class="table-responsive"><table class="qsotable table table-sm table-bordered table-hover table-striped table-condensed">';
+        <div class="tab-pane fade" id="daysofweek" role="tabpanel" aria-labelledby="daysofweek-tab">
+            <br/>
+            <h3><?php echo lang('statistics_weekdays_with_qso'); ?></h3>
+            <canvas id="weekdaysChart" width="400" height="150"></canvas>
+        </div>
 
-            echo '<tr>';
-                echo '<th style=\'text-align: center\'>' . lang('statistics_dwq_streak_continuous_days') . '</th>';
+        <div class="tab-pane fade" id="streaks" role="tabpanel" aria-labelledby="streaks-tab">
+            <br/>
+            <h3><?php echo lang('statistics_dwq_longest_streak_in_log'); ?></h3>
+            <p><?php echo lang('statistics_dwq_longest_streak_in_log_hint'); ?></p>
+
+            <?php 
+            // Get Date format
+            if($this->session->userdata('user_date_format')) {
+                // If Logged in and session exists
+                $custom_date_format = $this->session->userdata('user_date_format');
+            } else {
+                // Get Default date format from /config/cloudlog.php
+                $custom_date_format = $this->config->item('qso_date_format');
+            }
+            ?>
+
+            <?php
+            if (is_array($streaks)) {
+                echo '<div id="streaks" class="table-responsive"><table class="qsotable table table-sm table-bordered table-hover table-striped table-condensed">';
+
+                    echo '<tr>';
+                        echo '<th style=\'text-align: center\'>' . lang('statistics_dwq_streak_continuous_days') . '</th>';
+                        echo '<th style=\'text-align: center\'>' . lang('general_word_startdate') . '</th>';
+                        echo '<th style=\'text-align: center\'>' . lang('general_word_enddate') . '</th>';
+                        echo '</tr>';
+
+                    foreach ($streaks as $streak) {
+                        echo '<tr>';
+                        echo '<td style=\'text-align: center\'>' . $streak['highstreak'] . '</td>';
+                        $beginstreak_newdate = strtotime($streak['beginstreak']);
+                        echo '<td style=\'text-align: center\'>' . date($custom_date_format, $beginstreak_newdate) . '</td>';
+                        $endstreak_newdate = strtotime($streak['endstreak']);
+                        echo '<td style=\'text-align: center\'>' . date($custom_date_format, $endstreak_newdate) . '</td>';
+                        echo '</tr>';
+                    }
+
+                    echo '</table></div>';
+            }
+            else {
+                echo '<div class="alert alert-danger" role="alert">No streak found!</div>';
+            }
+            ?>
+
+            <h3><?php echo lang('statistics_dwq_current_streak_in_log'); ?></h3>
+            <?php
+            if (is_array($currentstreak)) {
+                echo '<div id="streaks" class="table-responsive"><table class="qsotable table table-sm table-bordered table-hover table-striped table-condensed">';
+
+                echo '<tr>';
+                echo '<th style=\'text-align: center\'>' . lang('statistics_dwq_current_streak_continuous_days') . '</th>';
                 echo '<th style=\'text-align: center\'>' . lang('general_word_startdate') . '</th>';
                 echo '<th style=\'text-align: center\'>' . lang('general_word_enddate') . '</th>';
                 echo '</tr>';
 
-            foreach ($streaks as $streak) {
+                    echo '<tr>';
+                    echo '<td style=\'text-align: center\'>' . $currentstreak['highstreak'] . '</td>';
+                    $beginstreak_newdate = strtotime($currentstreak['beginstreak']);
+                    echo '<td style=\'text-align: center\'>' . date($custom_date_format, $beginstreak_newdate) . '</td>';
+                    $endstreak_newdate = strtotime($currentstreak['endstreak']);
+                    echo '<td style=\'text-align: center\'>' . date($custom_date_format, $endstreak_newdate) . '</td>';
+                    echo '</tr>';
+
+                echo '</table></div>';
+            }
+            elseif (is_array($almostcurrentstreak)) {
+                ?>
+                <div class="alert alert-warning" role="alert"><?php echo lang('statistics_dwq_make_qso_to_extend_streak'); ?></div>
+                <?php
+                echo '<div id="streaks" class="table-responsive"><table class="qsotable table table-sm table-bordered table-hover table-striped table-condensed">';
+
                 echo '<tr>';
-                echo '<td style=\'text-align: center\'>' . $streak['highstreak'] . '</td>';
-                $beginstreak_newdate = strtotime($streak['beginstreak']);
+                echo '<th style=\'text-align: center\'>' . lang('statistics_dwq_current_streak_continuous_days') . '</th>';
+                echo '<th style=\'text-align: center\'>' . lang('general_word_startdate') . '</th>';
+                echo '<th style=\'text-align: center\'>' . lang('general_word_enddate') . '</th>';
+                echo '</tr>';
+
+                echo '<tr>';
+                echo '<td style=\'text-align: center\'>' . $almostcurrentstreak['highstreak'] . '</td>';
+                $beginstreak_newdate = strtotime($almostcurrentstreak['beginstreak']);
                 echo '<td style=\'text-align: center\'>' . date($custom_date_format, $beginstreak_newdate) . '</td>';
-                $endstreak_newdate = strtotime($streak['endstreak']);
+                $endstreak_newdate = strtotime($almostcurrentstreak['endstreak']);
                 echo '<td style=\'text-align: center\'>' . date($custom_date_format, $endstreak_newdate) . '</td>';
                 echo '</tr>';
+
+                echo '</table></div>';
             }
-
-            echo '</table></div>';
-    }
-    else {
-        echo '<div class="alert alert-danger" role="alert">No streak found!</div>';
-    }
-    ?>
-
-    <h2><?php echo lang('statistics_dwq_current_streak_in_log'); ?></h2>
-    <?php
-    if (is_array($currentstreak)) {
-        echo '<div id="streaks" class="table-responsive"><table class="qsotable table table-sm table-bordered table-hover table-striped table-condensed">';
-
-        echo '<tr>';
-        echo '<th style=\'text-align: center\'>' . lang('statistics_dwq_current_streak_continuous_days') . '</th>';
-        echo '<th style=\'text-align: center\'>' . lang('general_word_startdate') . '</th>';
-        echo '<th style=\'text-align: center\'>' . lang('general_word_enddate') . '</th>';
-        echo '</tr>';
-
-            echo '<tr>';
-            echo '<td style=\'text-align: center\'>' . $currentstreak['highstreak'] . '</td>';
-            $beginstreak_newdate = strtotime($currentstreak['beginstreak']);
-            echo '<td style=\'text-align: center\'>' . date($custom_date_format, $beginstreak_newdate) . '</td>';
-            $endstreak_newdate = strtotime($currentstreak['endstreak']);
-            echo '<td style=\'text-align: center\'>' . date($custom_date_format, $endstreak_newdate) . '</td>';
-            echo '</tr>';
-
-        echo '</table></div>';
-    }
-    elseif (is_array($almostcurrentstreak)) {
-        ?>
-        <div class="alert alert-warning" role="alert"><?php echo lang('statistics_dwq_make_qso_to_extend_streak'); ?></div>
-        <?php
-        echo '<div id="streaks" class="table-responsive"><table class="qsotable table table-sm table-bordered table-hover table-striped table-condensed">';
-
-        echo '<tr>';
-        echo '<th style=\'text-align: center\'>' . lang('statistics_dwq_current_streak_continuous_days') . '</th>';
-        echo '<th style=\'text-align: center\'>' . lang('general_word_startdate') . '</th>';
-        echo '<th style=\'text-align: center\'>' . lang('general_word_enddate') . '</th>';
-        echo '</tr>';
-
-        echo '<tr>';
-        echo '<td style=\'text-align: center\'>' . $almostcurrentstreak['highstreak'] . '</td>';
-        $beginstreak_newdate = strtotime($almostcurrentstreak['beginstreak']);
-        echo '<td style=\'text-align: center\'>' . date($custom_date_format, $beginstreak_newdate) . '</td>';
-        $endstreak_newdate = strtotime($almostcurrentstreak['endstreak']);
-        echo '<td style=\'text-align: center\'>' . date($custom_date_format, $endstreak_newdate) . '</td>';
-        echo '</tr>';
-
-        echo '</table></div>';
-    }
-    else {
-        echo '<div class="alert alert-danger" role="alert">' . lang('statistics_dwq_no_current_streak') . '</div>';
-    }
-    ?>
+            else {
+                echo '<div class="alert alert-danger" role="alert">' . lang('statistics_dwq_no_current_streak') . '</div>';
+            }
+            ?>
+        </div>
+    </div>
 </div>

--- a/assets/js/sections/dayswithqso.js
+++ b/assets/js/sections/dayswithqso.js
@@ -1,51 +1,110 @@
-$.ajax({
-	url: base_url + 'index.php/dayswithqso/get_days',
-	success: function (data) {
-		if ($.trim(data)) {
-			var labels = [];
-			var dataDxcc = [];
-			$.each(data, function () {
-				labels.push(this.Year);
-				dataDxcc.push(this.Days);
-			});
-			var ctx = document.getElementById("myChartDiff").getContext('2d');
-			var color = ifDarkModeThemeReturn('white', 'grey');
-			var myChart = new Chart(ctx, {
-				type: 'bar',
-				data: {
-					labels: labels,
-					datasets: [{
-						label: lang_days_with_qso_short,
-						data: dataDxcc,
-						backgroundColor: 'rgba(54, 162, 235, 0.2)',
-						borderColor: 'rgba(54, 162, 235, 1)',
-						borderWidth: 2,
-						color: color
-					}]
-				},
-				options: {
-					scales: {
-						y: {
-							ticks: {
-								beginAtZero: true,
-								color: color
+daysPerYear();
+weekDays();
+
+function daysPerYear() {
+	$.ajax({
+		url: base_url + 'index.php/dayswithqso/get_days',
+		success: function (data) {
+			if ($.trim(data)) {
+				var labels = [];
+				var dataDxcc = [];
+				$.each(data, function () {
+					labels.push(this.Year);
+					dataDxcc.push(this.Days);
+				});
+				var ctx = document.getElementById("myChartDiff").getContext('2d');
+				var color = ifDarkModeThemeReturn('white', 'grey');
+				var myChart = new Chart(ctx, {
+					type: 'bar',
+					data: {
+						labels: labels,
+						datasets: [{
+							label: lang_days_with_qso,
+							data: dataDxcc,
+							backgroundColor: 'rgba(54, 162, 235, 0.2)',
+							borderColor: 'rgba(54, 162, 235, 1)',
+							borderWidth: 2,
+							color: color
+						}]
+					},
+					options: {
+						scales: {
+							y: {
+								ticks: {
+									beginAtZero: true,
+									color: color
+								}
+							},
+							x: {
+								ticks: {
+									color: color
+								}
 							}
 						},
-						x: {
-							ticks: {
-								color: color
-							}
-						}
-					},
-					plugins: {
-						legend: {
-							labels: {
-								color: color
+						plugins: {
+							legend: {
+								labels: {
+									color: color
+								}
 							}
 						}
 					}
-				}
-			});
+				});
+			}
 		}
-	}
-});
+	});
+}
+
+function weekDays() {
+	$.ajax({
+		url: base_url + 'index.php/dayswithqso/get_weekdays',
+		success: function (data) {
+			if ($.trim(data)) {
+				var labels = [];
+				var dataDays = [];
+				$.each(data, function () {
+					labels.push(this.weekday);
+					dataDays.push(this.qsos);
+				});
+				var ctx = document.getElementById("weekdaysChart").getContext('2d');
+				var color = ifDarkModeThemeReturn('white', 'grey');
+				var myChart = new Chart(ctx, {
+					type: 'bar',
+					data: {
+						labels: labels,
+						datasets: [{
+							label: lang_qsos_this_weekday,
+							data: dataDays,
+							backgroundColor: 'rgba(54, 162, 235, 0.2)',
+							borderColor: 'rgba(54, 162, 235, 1)',
+							borderWidth: 2,
+							color: color
+						}]
+					},
+					options: {
+						scales: {
+							y: {
+								ticks: {
+									beginAtZero: true,
+									color: color
+								}
+							},
+							x: {
+								ticks: {
+									color: color
+								}
+							}
+						},
+						plugins: {
+							legend: {
+								labels: {
+									color: color
+								}
+							}
+						}
+					}
+				});
+			}
+		}
+	});
+}


### PR DESCRIPTION
Analytics > Days with QSOs: added a graph with the number of QSOs for each day of the week, and reorganized the page with tabs.

<img width="1414" alt="QSOs by day of the week" src="https://github.com/user-attachments/assets/5ca08f38-f2f7-4ce3-ac57-f97297ffa81a">
