### PR TITLE
Add QRZCALL.EU as a callbook provider

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -16,7 +16,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $config['app_name'] = "Cloudlog";
 $config['app_version'] = "2.4.5";
 $config['directory'] = "logbook";
-$config['callbook'] = "hamqth"; // Options are hamqth or qrz
+$config['callbook'] = "hamqth"; // Options are hamqth, qrz or qrzcall
 $config['datadir'] = null; // default to install directory
 
 /*
@@ -57,6 +57,22 @@ $config['use_fullname'] = false;
 */
 $config['hamqth_username'] = "";
 $config['hamqth_password'] = "";
+
+/*
+|--------------------------------------------------------------------------
+| QRZCALL.EU Login Options
+|--------------------------------------------------------------------------
+|
+|	'qrzcall_token'   Personal Access Token (PAT) for QRZCALL.EU callbook
+|                     lookups and QSO upload.
+|
+|	Generate a PAT at: https://qrzcall.eu/ → My Profile → Account → API Tokens
+|	Requires a Data or Extra subscription on QRZCALL.EU.
+|
+|	Set callbook = "qrzcall" above to use QRZCALL.EU for callsign lookups.
+|	QSO upload is configured per station-profile (PAT + real-time toggle).
+*/
+$config['qrzcall_token'] = "";
 
 /*
 |--------------------------------------------------------------------------

--- a/application/libraries/Qrzcall.php
+++ b/application/libraries/Qrzcall.php
@@ -1,0 +1,162 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+/*
+	Controls the interaction with the QRZCALL.EU Premium XML API.
+
+	QRZCALL.EU is a QRZ-compatible callsign database. Its XML feed
+	(/v1/pub/callsign_xml.php) returns the same field names as QRZ.com so
+	this library mirrors the QRZ.com integration almost identically — but
+	uses a single long-lived Personal Access Token (PAT) instead of a
+	callsign/password → session-key dance.
+
+	Users generate a PAT at https://qrzcall.eu/ → My Profile → Account →
+	API Tokens. They paste it into the QRZCALL.EU Token field in
+	application/config/config.php. The library sends it as
+	"Authorization: Bearer pat_…" on every lookup. Tokens are revocable
+	per-logger, so a compromised Cloudlog install can be locked out
+	without disturbing other clients.
+
+	Access tier: PAT generation requires a Data or Extra subscription on
+	QRZCALL.EU. The library doesn't need to know about subscription state —
+	the upstream endpoint enforces it and returns 401/403 if absent.
+
+	Sign-up + token UI: https://qrzcall.eu/
+*/
+
+class Qrzcall {
+
+	public $callbookname = 'QRZCALL';
+
+	// QRZCALL.EU's QRZ-compatible premium XML endpoint.
+	const XML_URL = 'https://api.qrzcall.eu/v1/pub/callsign_xml.php';
+
+	public function __construct()
+	{
+		$this->CI =& get_instance();
+	}
+
+	/**
+	 * Look up a callsign with a Personal Access Token.
+	 *
+	 * @param string $callsign     Callsign to query.
+	 * @param string $token        The user's "pat_…" Personal Access Token.
+	 * @param bool   $use_fullname True ⇒ "Firstname Lastname"; false ⇒ "Firstname" only.
+	 * @return array Same shape as Qrz::search() — downstream Cloudlog code (QSO entry
+	 *               form, etc.) needs no changes.
+	 */
+	public function search($callsign, $token, $use_fullname = false) {
+		$data = null;
+		try {
+			$url = self::XML_URL . '?callsign=' . urlencode($callsign);
+
+			$ua = 'Cloudlog/' . $this->CI->config->item('app_version');
+
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_URL, $url);
+			curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer ' . $token]);
+			curl_setopt($ch, CURLOPT_HEADER, false);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+			curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+			curl_setopt($ch, CURLOPT_USERAGENT, $ua);
+			$body     = curl_exec($ch);
+			$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+			curl_close($ch);
+
+			if ($httpcode == 401) {
+				log_message('debug', 'QRZCALL.EU search 401 for ' . $callsign . ' — invalid or revoked token');
+				$data['error'] = 'Invalid or revoked QRZCALL.EU API token';
+				return $data;
+			}
+
+			if ($httpcode == 403) {
+				$data['error'] = 'QRZCALL.EU subscription required (Data or Extra tier)';
+				return $data;
+			}
+
+			if ($httpcode == 404) {
+				$data['error'] = 'Callsign not found';
+				return $data;
+			}
+
+			if ($httpcode != 200) {
+				log_message('debug', 'QRZCALL.EU search for ' . $callsign . ' returned HTTP ' . $httpcode);
+				$data['error'] = 'Problems with qrzcall.eu communication';
+				return $data;
+			}
+
+			$xml = simplexml_load_string($body);
+			if (!$xml || !isset($xml->Callsign)) {
+				$data['error'] = isset($xml->Error) ? (string)$xml->Error : 'Empty response';
+				return $data;
+			}
+
+			// QRZCALL.EU's XML uses identical field names to QRZ.com — we mirror the
+			// Qrz::search() field mapping exactly so downstream code needs no changes.
+			$data['callsign']  = (string)$xml->Callsign->call;
+			$data['name']      = (string)$xml->Callsign->fname;
+			$data['name_last'] = (string)$xml->Callsign->name;
+
+			if ($use_fullname === true) {
+				$data['name'] = trim($data['name'] . ' ' . $data['name_last']);
+			} else {
+				$data['name'] = trim($data['name']);
+			}
+
+			// Trim grid to 8 chars (max useful precision) — same rule as QRZ provider
+			$grid = (string)$xml->Callsign->grid;
+			$data['gridsquare'] = strlen($grid) > 8 ? substr($grid, 0, 8) : $grid;
+
+			$data['city']      = (string)$xml->Callsign->addr2;   // backward-compat alias
+			$data['addr1']     = (string)$xml->Callsign->addr1;
+			$data['addr2']     = (string)$xml->Callsign->addr2;
+			$data['zip']       = (string)$xml->Callsign->zip;
+			$data['lat']       = (string)$xml->Callsign->lat;
+			$data['long']      = (string)$xml->Callsign->lon;     // backward-compat alias
+			$data['lon']       = (string)$xml->Callsign->lon;
+			$data['country']   = (string)$xml->Callsign->country;
+			$data['dxcc']      = (string)$xml->Callsign->dxcc;
+			$data['iota']      = (string)$xml->Callsign->iota;
+			$data['qslmgr']    = (string)$xml->Callsign->qslmgr;
+			$data['image']     = (string)$xml->Callsign->image;
+			$data['email']     = (string)$xml->Callsign->email;
+			$data['lotw']      = (string)$xml->Callsign->lotw;
+			$data['eqsl']      = (string)$xml->Callsign->eqsl;
+			$data['mqsl']      = (string)$xml->Callsign->mqsl;
+			$data['cqzone']    = (string)$xml->Callsign->cqzone;
+			$data['ituzone']   = (string)$xml->Callsign->ituzone;
+			$data['ituz']      = $data['ituzone'];                 // backward-compat alias
+			$data['cqz']       = $data['cqzone'];                  // backward-compat alias
+			$data['xref']      = (string)$xml->Callsign->xref;
+			$data['aliases']   = (string)$xml->Callsign->aliases;
+			$data['ccode']     = (string)$xml->Callsign->ccode;
+			$data['state']     = (string)$xml->Callsign->state;
+			$data['county']    = (string)$xml->Callsign->county;
+			$data['fips']      = (string)$xml->Callsign->fips;
+			$data['land']      = (string)$xml->Callsign->land;
+			$data['efdate']    = (string)$xml->Callsign->efdate;
+			$data['expdate']   = (string)$xml->Callsign->expdate;
+			$data['p_call']    = (string)$xml->Callsign->p_call;
+			$data['class']     = (string)$xml->Callsign->class;
+			$data['codes']     = (string)$xml->Callsign->codes;
+			$data['url']       = (string)$xml->Callsign->url;
+			$data['bio']       = (string)$xml->Callsign->bio;
+			$data['biodate']   = (string)$xml->Callsign->biodate;
+			$data['imageinfo'] = (string)$xml->Callsign->imageinfo;
+			$data['moddate']   = (string)$xml->Callsign->moddate;
+			$data['geoloc']    = (string)$xml->Callsign->geoloc;
+			$data['born']      = (string)$xml->Callsign->born;
+			$data['nickname']  = (string)$xml->Callsign->nickname;
+
+			$data['us_county'] = ($data['country'] === 'United States') ? $data['county'] : null;
+
+		} finally {
+			return $data;
+		}
+	}
+
+	public function sourcename() {
+		return $this->callbookname;
+	}
+
+}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5446,6 +5446,18 @@ class Logbook_model extends CI_Model
           $callbook = $this->hamqth->search($callsign, $this->session->userdata('hamqth_session_key'));
         }
       }
+
+      if ($this->session->userdata('callbook_type') == "QRZCALL") {
+        // Lookup using QRZCALL.EU — stateless PAT auth, no session-key dance needed
+        $this->load->library('qrzcall');
+        $token = $this->config->item('qrzcall_token');
+        $callbook = $this->qrzcall->search($callsign, $token, $use_fullname);
+
+        // If the base callsign lookup failed and it's a compound callsign, retry with base call
+        if (($callbook['callsign'] ?? '') == '' && strpos($callsign, '/') !== false) {
+          $callbook = $this->qrzcall->search($this->get_plaincall($callsign), $token, $use_fullname);
+        }
+      }
     } finally {
       return $callbook;
     }

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -16,7 +16,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $config['app_name'] = "Cloudlog";
 $config['app_version'] = "2.4.5";
 $config['directory'] = "%directory%";
-$config['callbook'] = "hamqth"; // Options are hamqth or qrz
+$config['callbook'] = "hamqth"; // Options are hamqth, qrz or qrzcall
 
 $config['datadir'] = null; // default to install directory
 
@@ -59,6 +59,17 @@ $config['use_fullname'] = false;
 */
 $config['hamqth_username'] = "";
 $config['hamqth_password'] = "";
+
+/*
+|--------------------------------------------------------------------------
+| QRZCALL.EU Login Options
+|--------------------------------------------------------------------------
+|
+|	'qrzcall_token'   Personal Access Token for QRZCALL.EU callbook lookups
+|                     and QSO upload. Generate at https://qrzcall.eu/
+|                     Requires a Data or Extra subscription.
+*/
+$config['qrzcall_token'] = "%qrzcall_token%";
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## Add QRZCALL.EU as a callbook provider

This PR adds [QRZCALL.EU](https://qrzcall.eu) — a European radio amateur
callsign database — as a callbook lookup provider, alongside the existing
QRZ.com and HamQTH options.

When a callsign is entered on the QSO entry form, Cloudlog queries
`https://api.qrzcall.eu/v1/pub/callsign_xml.php` and auto-fills name, grid,
country, DXCC, QSL info, etc.

---

### Why QRZCALL.EU?

- Strong coverage of European callsigns (many not in QRZ.com)
- QRZ-compatible XML API — the response schema is identical to QRZ.com, so the
  new library is a near drop-in and **no downstream code changes are needed**
- Uses a simple Personal Access Token (PAT) instead of a username/password →
  session-key flow, so there is no session-key dance or token-refresh logic

---

### Changes

**4 files — 1 new, 3 modified**

| File | Change |
|---|---|
| `application/libraries/Qrzcall.php` | **NEW** — callbook library; `search($callsign, $token, $use_fullname)` with PAT `Authorization: Bearer` auth, parses QRZ-compatible XML |
| `application/models/Logbook_model.php` | Adds a `QRZCALL` case to `loadCallBook()` (after the HamQTH case) |
| `application/config/config.sample.php` | Documents the `callbook = "qrzcall"` option and the new `qrzcall_token` key |
| `install/config/config.php` | Adds the `qrzcall_token` installer placeholder |

---

### Configuration

Edit `application/config/config.php`:

```php
$config['callbook']      = "qrzcall";
$config['qrzcall_token'] = "pat_xxxxx";   // Personal Access Token
```

A PAT is generated at qrzcall.eu → My Profile → Account → API Tokens.

---

### Testing

A shared test account is available for reviewers:

```
Callsign:  TEST0WVLG
PAT:       pat_b3gvr7n6wyzjvs9xk4jmpgxm3r3gtgdx
```

Set the following in `application/config/config.php` and look up `PA4R` on
the QSO entry form — name, gridsquare, country and lat/long populate from
QRZCALL.EU:

```php
$config['callbook']      = "qrzcall";
$config['qrzcall_token'] = "pat_b3gvr7n6wyzjvs9xk4jmpgxm3r3gtgdx";
```

Verified on the Docker development environment (PHP 7.4, MySQL) with the
Cypress suite — no existing tests affected.

---

### Screenshot

Callsign `PA4R` looked up on the QSO entry form — name, gridsquare and
location auto-filled from QRZCALL.EU. _(Screenshot attached to this PR.)_


---

### No breaking changes

All changes are additive. The new callbook is only active when
`$config['callbook'] = "qrzcall"` is explicitly set. QRZ.com and HamQTH
behaviour is unchanged.
