### PR TITLE
Add QRZCALL.EU as a QSO upload target

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 270;
+$config['migration_version'] = 271;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Qrzcall_upload.php
+++ b/application/controllers/Qrzcall_upload.php
@@ -1,0 +1,146 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+/*
+	Controller to push QSOs from Cloudlog to a QRZCALL.EU logbook.
+
+	Uses the QRZ-compatible logbook API endpoint on QRZCALL.EU so no extra
+	server-side changes are required. The user's Personal Access Token (PAT,
+	format pat_xxxxx) is stored per station-profile in the qrzcallapikey
+	column and sent as the KEY parameter.
+
+	Route:  GET /index.php/qrzcall_upload/upload
+	Trigger: cron job, or manually from the Cloudlog admin menu.
+*/
+
+class Qrzcall_upload extends CI_Controller {
+
+	public function index() {
+		$this->config->load('config');
+	}
+
+	/*
+	 * Upload all pending QSOs to QRZCALL.EU.
+	 * Loops through all station profiles that have a PAT configured.
+	 * QSOs where COL_QRZCALL_QSO_UPLOAD_STATUS is NULL or 'N' are uploaded.
+	 */
+	public function upload() {
+		$this->setOptions();
+		$this->load->model('logbook_model');
+
+		$station_ids = $this->logbook_model->get_station_id_with_qrzcall_api();
+
+		if ($station_ids) {
+			foreach ($station_ids as $station) {
+				$pat = $station->qrzcallapikey;
+				$result = $this->mass_upload_qsos($station->station_id, $pat, true);
+				if ($result['count'] > 0) {
+					echo "Uploaded " . $result['count'] . " QSO(s) to QRZCALL.EU for station_id: " . $station->station_id . "\n";
+					log_message('info', 'QRZCALL.EU: Uploaded ' . $result['count'] . ' QSO(s) for station_id: ' . $station->station_id);
+				} else {
+					echo "No QSOs pending for station_id: " . $station->station_id . "\n";
+				}
+				if (!empty($result['errormessages'])) {
+					foreach ($result['errormessages'] as $msg) {
+						echo "Error: " . $msg . "\n";
+					}
+				}
+			}
+		} else {
+			echo "No station profiles with a QRZCALL.EU API token found.\n";
+			log_message('info', 'QRZCALL.EU: No station profiles with a PAT found.');
+		}
+	}
+
+	private function setOptions() {
+		$this->config->load('config');
+		ini_set('memory_limit', '-1');
+		ini_set('display_errors', 1);
+		ini_set('display_startup_errors', 1);
+		error_reporting(E_ALL);
+	}
+
+	/*
+	 * Batch-upload all pending QSOs for the given station to QRZCALL.EU.
+	 * Fetches QSOs in batches of 1000 to prevent memory exhaustion.
+	 * Returns array with 'count' (number uploaded) and 'errormessages'.
+	 */
+	function mass_upload_qsos($station_id, $pat, $trusted = false) {
+		$i = 0;
+		$errormessages     = [];
+		$successful_uploads = [];
+		$batch_size         = 1000;
+		$update_batch_size  = 100;
+		$offset             = 0;
+		$has_more_qsos      = true;
+
+		$this->load->library('AdifHelper');
+
+		while ($has_more_qsos) {
+			$data['qsos'] = $this->logbook_model->get_qrzcall_qsos($station_id, $trusted, $batch_size, $offset);
+
+			if (!$data['qsos'] || $data['qsos']->num_rows() == 0) {
+				$has_more_qsos = false;
+				break;
+			}
+
+			foreach ($data['qsos']->result() as $qso) {
+				$adif = $this->adifhelper->getAdifLine($qso);
+
+				// A QSO marked 'M' was edited after it was first uploaded —
+				// send it with OPTION=REPLACE so QRZCALL.EU updates the
+				// existing record instead of rejecting it as a duplicate.
+				if ($qso->COL_QRZCALL_QSO_UPLOAD_STATUS == 'M') {
+					$result = $this->logbook_model->push_qso_to_qrzcall($pat, $adif, true);
+				} else {
+					$result = $this->logbook_model->push_qso_to_qrzcall($pat, $adif);
+				}
+
+				if ($result['status'] == 'OK') {
+					$successful_uploads[] = $qso->COL_PRIMARY_KEY;
+					$i++;
+
+					// Flush batch updates to DB for memory efficiency
+					if (count($successful_uploads) >= $update_batch_size) {
+						$this->logbook_model->mark_qrzcall_qsos_sent_batch($successful_uploads);
+						$successful_uploads = [];
+					}
+				} elseif (stristr($result['message'] ?? '', 'RESULT=AUTH')) {
+					// Invalid or revoked PAT — stop immediately to avoid hammering the API
+					log_message('error', 'QRZCALL.EU upload stopped for station_id ' . $station_id . ': auth failure — ' . $result['message']);
+					$errormessages[] = 'Auth failure (invalid/revoked PAT): ' . $result['message'];
+					break 2;
+				} else {
+					log_message('error', 'QRZCALL.EU upload failed for QSO: Call: ' . $qso->COL_CALL
+						. ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE
+						. ' Time: ' . $qso->COL_TIME_ON . ' — ' . ($result['message'] ?? ''));
+					$errormessages[] = ($result['message'] ?? 'unknown error')
+						. ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND
+						. ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+				}
+			}
+
+			if ($data['qsos']->num_rows() < $batch_size) {
+				$has_more_qsos = false;
+			} else {
+				$offset += $batch_size;
+				log_message('info', 'QRZCALL.EU batch: processed ' . $offset . ' QSOs so far for station_id: ' . $station_id);
+			}
+		}
+
+		// Flush remaining successful uploads
+		if (!empty($successful_uploads)) {
+			$this->logbook_model->mark_qrzcall_qsos_sent_batch($successful_uploads);
+			log_message('info', 'QRZCALL.EU: marked final batch of ' . count($successful_uploads) . ' QSOs as uploaded for station_id: ' . $station_id);
+		}
+
+		if ($i > 0) {
+			log_message('info', 'QRZCALL.EU upload completed: ' . $i . ' QSO(s) uploaded for station_id: ' . $station_id);
+		}
+
+		return [
+			'count'         => $i,
+			'errormessages' => $errormessages,
+		];
+	}
+
+}

--- a/application/migrations/271_add_qrzcall_to_cloudlog.php
+++ b/application/migrations/271_add_qrzcall_to_cloudlog.php
@@ -1,0 +1,68 @@
+<?php
+
+defined('BASEPATH') or exit('No direct script access allowed');
+
+/*
+ * Migration: Add QRZCALL.EU support to Cloudlog
+ *
+ * Adds two columns to station_profile for storing the user's Personal Access
+ * Token and real-time upload preference, and two columns to the QSO table
+ * for tracking upload status.
+ */
+
+class Migration_add_qrzcall_to_cloudlog extends CI_Migration
+{
+    public function up()
+    {
+        // --- station_profile: QRZCALL.EU Personal Access Token ---
+        if (!$this->db->field_exists('qrzcallapikey', 'station_profile')) {
+            $fields = [
+                'qrzcallapikey varchar(100) DEFAULT NULL',
+            ];
+            $this->dbforge->add_column('station_profile', $fields);
+        }
+
+        // --- station_profile: real-time upload toggle ---
+        if (!$this->db->field_exists('qrzcallrealtime', 'station_profile')) {
+            $fields = [
+                'qrzcallrealtime tinyint(1) DEFAULT 0',
+            ];
+            $this->dbforge->add_column('station_profile', $fields);
+        }
+
+        // --- QSO table: upload status (NULL/N = pending, Y = uploaded, M = modified/re-upload) ---
+        if (!$this->db->field_exists('COL_QRZCALL_QSO_UPLOAD_STATUS', $this->config->item('table_name'))) {
+            $fields = [
+                'COL_QRZCALL_QSO_UPLOAD_STATUS varchar(1) DEFAULT NULL',
+            ];
+            $this->dbforge->add_column($this->config->item('table_name'), $fields);
+        }
+
+        // --- QSO table: timestamp of last successful upload ---
+        if (!$this->db->field_exists('COL_QRZCALL_QSO_UPLOAD_DATE', $this->config->item('table_name'))) {
+            $fields = [
+                'COL_QRZCALL_QSO_UPLOAD_DATE datetime DEFAULT NULL',
+            ];
+            $this->dbforge->add_column($this->config->item('table_name'), $fields);
+        }
+    }
+
+    public function down()
+    {
+        if ($this->db->field_exists('qrzcallapikey', 'station_profile')) {
+            $this->dbforge->drop_column('station_profile', 'qrzcallapikey');
+        }
+
+        if ($this->db->field_exists('qrzcallrealtime', 'station_profile')) {
+            $this->dbforge->drop_column('station_profile', 'qrzcallrealtime');
+        }
+
+        if ($this->db->field_exists('COL_QRZCALL_QSO_UPLOAD_STATUS', $this->config->item('table_name'))) {
+            $this->dbforge->drop_column($this->config->item('table_name'), 'COL_QRZCALL_QSO_UPLOAD_STATUS');
+        }
+
+        if ($this->db->field_exists('COL_QRZCALL_QSO_UPLOAD_DATE', $this->config->item('table_name'))) {
+            $this->dbforge->drop_column($this->config->item('table_name'), 'COL_QRZCALL_QSO_UPLOAD_DATE');
+        }
+    }
+}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -830,6 +830,21 @@ class Logbook_model extends CI_Model
         }
       }
 
+      $result = ''; // Empty result from previous attempt for safety
+      $result = $this->exists_qrzcall_api_key($data['station_id']);
+      // Push QSO to QRZCALL.EU if PAT is set and realtime upload is enabled
+      if (isset($result->qrzcallapikey) && !empty($result->qrzcallapikey) && $result->qrzcallrealtime == 1) {
+        $CI = &get_instance();
+        $CI->load->library('AdifHelper');
+        $qso = $this->get_qso($last_id, true)->result();
+
+        $adif = $CI->adifhelper->getAdifLine($qso[0]);
+        $upload = $this->push_qso_to_qrzcall($result->qrzcallapikey, $adif);
+        if ($upload['status'] == 'OK') {
+          $this->mark_qrzcall_qso_sent($last_id);
+        }
+      }
+
       $result = $this->exists_webadif_api_key($data['station_id']);
       // Push qso to webadif if apikey is set, and realtime upload is enabled, and we're not importing an adif-file
       if (isset($result->webadifapikey) && $result->webadifrealtime == 1) {
@@ -1077,6 +1092,101 @@ class Logbook_model extends CI_Model
       return $result;
     }
     curl_close($ch);
+  }
+
+  /*
+   * Function uploads a QSO to QRZCALL.EU logbook using the QRZ-compatible endpoint.
+   * $pat is the user's Personal Access Token (format: pat_xxxxx).
+   * $adif contains a line with the QSO in the ADIF format.
+   */
+  function push_qso_to_qrzcall($pat, $adif, $replaceoption = false)
+  {
+    $url = 'https://api.qrzcall.eu/v1/pub/logbook_api.php';
+
+    $ci = & get_instance();
+    $ua = 'Cloudlog/' . $ci->config->item('app_version');
+
+    $post_data['KEY']    = $pat;
+    $post_data['ACTION'] = 'INSERT';
+    $post_data['ADIF']   = $adif;
+
+    // OPTION=REPLACE asks QRZCALL.EU to update an existing matching QSO in
+    // place instead of rejecting it as a duplicate — used to re-sync edited
+    // QSOs (status 'M'). Mirrors Cloudlog's QRZ.com push_qso_to_qrz().
+    if ($replaceoption) {
+      $post_data['OPTION'] = 'REPLACE';
+    }
+
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+    curl_setopt($ch, CURLOPT_HEADER, 0);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_USERAGENT, $ua);
+
+    $content = curl_exec($ch);
+    curl_close($ch);
+
+    if ($content) {
+      if (stristr($content, 'RESULT=OK') || stristr($content, 'RESULT=REPLACE')) {
+        $result['status'] = 'OK';
+        return $result;
+      } elseif (stristr($content, 'duplicate')) {
+        // QRZCALL.EU rejected the QSO because an identical one is already in
+        // the logbook. Treat it as success so the QSO is marked uploaded and
+        // not retried on every run (mirrors Cloudlog's QRZ.com handling).
+        $result['status']    = 'OK';
+        $result['duplicate'] = true;
+        return $result;
+      } elseif (stristr($content, 'RESULT=AUTH')) {
+        $result['status'] = 'error';
+        $result['message'] = $content;
+        return $result;
+      } else {
+        $result['status'] = 'error';
+        $result['message'] = $content;
+        return $result;
+      }
+    }
+    if (curl_errno($ch)) {
+      $result['status'] = 'error';
+      $result['message'] = 'Curl error: ' . curl_errno($ch);
+      return $result;
+    }
+  }
+
+  /*
+   * Function marks a QSO as uploaded to QRZCALL.EU
+   */
+  function mark_qrzcall_qso_sent($primarykey)
+  {
+    $data = array(
+      'COL_QRZCALL_QSO_UPLOAD_DATE'   => date("Y-m-d H:i:s", strtotime("now")),
+      'COL_QRZCALL_QSO_UPLOAD_STATUS' => 'Y',
+    );
+    $this->db->where('COL_PRIMARY_KEY', $primarykey);
+    $this->db->update($this->config->item('table_name'), $data);
+  }
+
+  /*
+   * Function marks a batch of QSOs as uploaded to QRZCALL.EU
+   */
+  function mark_qrzcall_qsos_sent_batch($primarykeys)
+  {
+    if (empty($primarykeys)) return;
+    $placeholders = implode(',', array_fill(0, count($primarykeys), '?'));
+    $params = array_merge(
+      [date("Y-m-d H:i:s", strtotime("now"))],
+      $primarykeys
+    );
+    $this->db->query(
+      "UPDATE " . $this->config->item('table_name') . "
+       SET COL_QRZCALL_QSO_UPLOAD_DATE = ?,
+           COL_QRZCALL_QSO_UPLOAD_STATUS = 'Y'
+       WHERE COL_PRIMARY_KEY IN (" . $placeholders . ")",
+      $params
+    );
   }
 
   /*
@@ -1527,6 +1637,11 @@ class Logbook_model extends CI_Model
 
     if ($this->exists_qrz_api_key($data['station_id'])) {
       $data['COL_QRZCOM_QSO_UPLOAD_STATUS'] = 'M';
+    }
+
+    $qrzcall_station = $this->exists_qrzcall_api_key($data['station_id']);
+    if (isset($qrzcall_station->qrzcallapikey) && !empty($qrzcall_station->qrzcallapikey)) {
+      $data['COL_QRZCALL_QSO_UPLOAD_STATUS'] = 'M';
     }
 
     if ($this->exists_clublog_credentials($data['station_id'])) {
@@ -2228,6 +2343,82 @@ class Logbook_model extends CI_Model
     } else {
       return null;
     }
+  }
+
+  /*
+     * Function returns all the station_id's with a QRZCALL.EU PAT configured
+     */
+  function get_station_id_with_qrzcall_api()
+  {
+    $sql = 'select station_id, qrzcallapikey from station_profile
+              where coalesce(qrzcallapikey, "") <> ""';
+
+    $query = $this->db->query($sql);
+    $result = $query->result();
+
+    if ($result) {
+      return $result;
+    } else {
+      return null;
+    }
+  }
+
+  /*
+     * Function checks if a QRZCALL.EU PAT exists for the given station id
+     */
+  function exists_qrzcall_api_key($station_id)
+  {
+    $sql = 'select qrzcallapikey, qrzcallrealtime from station_profile
+              where station_id = ?';
+
+    $query = $this->db->query($sql, $station_id);
+    $result = $query->row();
+
+    if ($result) {
+      return $result;
+    } else {
+      return false;
+    }
+  }
+
+  /*
+     * Function returns QSOs not yet uploaded to QRZCALL.EU for the given station
+     */
+  function get_qrzcall_qsos($station_id, $trusted = false, $limit = 1000, $offset = 0)
+  {
+    $CI = &get_instance();
+    $CI->load->model('stations');
+    if ((!$trusted) && (!$CI->stations->check_station_is_accessible($station_id))) {
+      return;
+    }
+    // Select the station_profile columns AdifHelper::getAdifLine() reads for
+    // the "MY" station fields (STATION_CALLSIGN, MY_GRIDSQUARE, MY_DXCC, ...),
+    // so the exported ADIF is complete and no undefined-property notices are
+    // raised while building it.
+    $sql = "select thcv.*, dxcc_entities.name as station_country,
+              station_profile.station_callsign, station_profile.station_city,
+              station_profile.station_cnty, station_profile.station_cq,
+              station_profile.station_dxcc, station_profile.station_gridsquare,
+              station_profile.station_iota, station_profile.station_itu,
+              station_profile.station_pota, station_profile.station_sig,
+              station_profile.station_sig_info, station_profile.station_sota,
+              station_profile.station_wab, station_profile.station_wwff,
+              station_profile.state,
+              TRIM(COALESCE(NULLIF(CONCAT_WS(' ', users.user_firstname, users.user_lastname), ''), users.user_name, '')) as export_my_name
+              from " . $this->config->item('table_name') . ' thcv
+              left join station_profile on thcv.station_id = station_profile.station_id
+              left join ' . $this->config->item('auth_table') . ' users on station_profile.user_id = users.user_id
+              left outer join dxcc_entities on thcv.col_my_dxcc = dxcc_entities.adif
+              where thcv.station_id = ' . intval($station_id) . '
+              and (COL_QRZCALL_QSO_UPLOAD_STATUS is NULL
+                or COL_QRZCALL_QSO_UPLOAD_STATUS = ""
+                or COL_QRZCALL_QSO_UPLOAD_STATUS = "N"
+                or COL_QRZCALL_QSO_UPLOAD_STATUS = "M")
+              ORDER BY thcv.COL_PRIMARY_KEY ASC
+              LIMIT ' . intval($limit) . ' OFFSET ' . intval($offset);
+
+    $query = $this->db->query($sql);
+    return $query;
   }
 
   /*
@@ -3742,11 +3933,14 @@ class Logbook_model extends CI_Model
     }
 
     // Check if QRZ or ClubLog is already uploaded. If so, set qso to reupload to qrz.com (M) or clublog
-    $qsql = "select COL_CLUBLOG_QSO_UPLOAD_STATUS as CL_STATE, COL_QRZCOM_QSO_UPLOAD_STATUS as QRZ_STATE from " . $this->config->item('table_name') . " where COL_BAND=? and COL_CALL=? and COL_STATION_CALLSIGN=? and date_format(COL_TIME_ON, '%Y-%m-%d %H:%i') = ?";
+    $qsql = "select COL_CLUBLOG_QSO_UPLOAD_STATUS as CL_STATE, COL_QRZCOM_QSO_UPLOAD_STATUS as QRZ_STATE, COL_QRZCALL_QSO_UPLOAD_STATUS as QRZCALL_STATE from " . $this->config->item('table_name') . " where COL_BAND=? and COL_CALL=? and COL_STATION_CALLSIGN=? and date_format(COL_TIME_ON, '%Y-%m-%d %H:%i') = ?";
     $query = $this->db->query($qsql, array($band, $callsign, $station_callsign, $datetime));
     $row = $query->row();
     if (($row->QRZ_STATE ?? '') == 'Y') {
       $data['COL_QRZCOM_QSO_UPLOAD_STATUS'] = 'M';
+    }
+    if (($row->QRZCALL_STATE ?? '') == 'Y') {
+      $data['COL_QRZCALL_QSO_UPLOAD_STATUS'] = 'M';
     }
     if (($row->CL_STATE ?? '') == 'Y') {
       $data['COL_CLUBLOG_QSO_UPLOAD_STATUS'] = 'M';
@@ -3858,6 +4052,7 @@ class Logbook_model extends CI_Model
                    COL_CALL, COL_BAND, COL_STATION_CALLSIGN,
                    COL_CLUBLOG_QSO_UPLOAD_STATUS as CL_STATE,
                    COL_QRZCOM_QSO_UPLOAD_STATUS as QRZ_STATE,
+                   COL_QRZCALL_QSO_UPLOAD_STATUS as QRZCALL_STATE,
                    COL_LOTW_QSL_RCVD,
                    station_profile.station_gridsquare,
                    station_profile.station_id
@@ -3928,9 +4123,12 @@ class Logbook_model extends CI_Model
         $update_data['COL_ITUZ'] = $record['ituz'];
       }
       
-      // Mark for re-upload to QRZ/ClubLog if already uploaded
+      // Mark for re-upload to QRZ/QRZCALL.EU/ClubLog if already uploaded
       if ($qso->QRZ_STATE == 'Y') {
         $update_data['COL_QRZCOM_QSO_UPLOAD_STATUS'] = 'M';
+      }
+      if ($qso->QRZCALL_STATE == 'Y') {
+        $update_data['COL_QRZCALL_QSO_UPLOAD_STATUS'] = 'M';
       }
       if ($qso->CL_STATE == 'Y') {
         $update_data['COL_CLUBLOG_QSO_UPLOAD_STATUS'] = 'M';

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -138,6 +138,8 @@ class Stations extends CI_Model {
 			'webadifapikey' => xss_clean($this->input->post('webadifapikey', true)),
 			'webadifapiurl' => 'https://qo100dx.club/api',
 			'webadifrealtime' => xss_clean($this->input->post('webadifrealtime', true)),
+			'qrzcallapikey' => xss_clean($this->input->post('qrzcallapikey', true)),
+			'qrzcallrealtime' => xss_clean($this->input->post('qrzcallrealtime', true)),
 		);
 
 		// Insert Records & return insert id //
@@ -189,6 +191,8 @@ class Stations extends CI_Model {
 			'webadifapikey' => xss_clean($this->input->post('webadifapikey', true)),
 			'webadifapiurl' => 'https://qo100dx.club/api',
 			'webadifrealtime' => xss_clean($this->input->post('webadifrealtime', true)),
+			'qrzcallapikey' => xss_clean($this->input->post('qrzcallapikey', true)),
+			'qrzcallrealtime' => xss_clean($this->input->post('qrzcallrealtime', true)),
 		);
 
 		$this->db->where('user_id', $this->session->userdata('user_id'));

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -325,6 +325,21 @@
 
 				<div class="row">
 					<div class="mb-3 col-sm-6">
+						<label for="qrzcallApiKey">QRZCALL.EU Personal Access Token</label> <!-- This does not need Multilanguage Support -->
+						<input type="text" class="form-control" name="qrzcallapikey" id="qrzcallApiKey" aria-describedby="qrzcallApiKeyHelp" placeholder="pat_xxxxx">
+						<small id="qrzcallApiKeyHelp" class="form-text text-muted">Generate at <a href="https://qrzcall.eu/" target="_blank">qrzcall.eu</a> → My Profile → Account → API Tokens (Data / Extra tier)</small>
+					</div>
+					<div class="mb-3 col-sm-6">
+						<label for="qrzcallrealtime">QRZCALL.EU real-time upload</label> <!-- This does not need Multilanguage Support -->
+						<select class="form-select" id="qrzcallrealtime" name="qrzcallrealtime">
+							<option value="1"><?php echo lang("general_word_yes"); ?></option>
+							<option value="0" selected><?php echo lang("general_word_no"); ?></option>
+						</select>
+					</div>
+				</div>
+
+				<div class="row">
+					<div class="mb-3 col-sm-6">
 						<label for="webadifApiKey"> QO-100 Dx Club API Key </label> <!-- This does not need Multilanguage Support -->
 						<input type="text" class="form-control" name="webadifapikey" id="webadifApiKey" aria-describedby="webadifApiKeyHelp">
 						<small id="webadifApiKeyHelp" class="form-text text-muted"><?php echo lang("station_location_qo100_hint"); ?></a></small>

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -1048,6 +1048,28 @@
 	<div class="row">
 		<div class="col-md">
 			<div class="card">
+				<h5 class="card-header">QRZCALL.EU <span class="badge text-bg-warning">Data / Extra</span></h5> <!-- This does not need Multilanguage Support -->
+				<div class="card-body">
+					<div class="mb-3">
+						<label for="qrzcallApiKey">QRZCALL.EU Personal Access Token</label> <!-- This does not need Multilanguage Support -->
+						<input type="text" class="form-control" name="qrzcallapikey" id="qrzcallApiKey" aria-describedby="qrzcallApiKeyHelp" placeholder="pat_xxxxx" value="<?php if(set_value('qrzcallapikey') != "") { echo set_value('qrzcallapikey'); } else { echo $my_station_profile->qrzcallapikey; } ?>">
+						<small id="qrzcallApiKeyHelp" class="form-text text-muted">Generate at <a href="https://qrzcall.eu/" target="_blank">qrzcall.eu</a> → My Profile → Account → API Tokens (requires Data or Extra subscription)</small>
+					</div>
+					<div class="mb-3">
+						<label for="qrzcallrealtime">Real-time QSO upload</label> <!-- This does not need Multilanguage Support -->
+						<select class="form-select" id="qrzcallrealtime" name="qrzcallrealtime">
+							<option value="1" <?php if ($my_station_profile->qrzcallrealtime == 1) { echo " selected=\"selected\""; } ?>><?php echo lang("general_word_yes"); ?></option>
+							<option value="0" <?php if ($my_station_profile->qrzcallrealtime == 0) { echo " selected=\"selected\""; } ?>><?php echo lang("general_word_no"); ?></option>
+						</select>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+	<div class="row">
+		<div class="col-md">
+			<div class="card">
 				<h5 class="card-header">QO-100 Dx Club</h5> <!-- This does not need Multilanguage Support -->
 				<div class="card-body">
 					<div class="mb-3">

--- a/cypress/e2e/6-qrzcall.cy.js
+++ b/cypress/e2e/6-qrzcall.cy.js
@@ -1,0 +1,44 @@
+describe("QRZCALL.EU integration", () => {
+	beforeEach(() => {
+		cy.login();
+	});
+
+	it("should show the QRZCALL.EU PAT field on the station create page", () => {
+		cy.visit("/index.php/station/create");
+
+		// The Personal Access Token text input should be present
+		cy.get('input[name="qrzcallapikey"]')
+			.should("exist")
+			.and("be.visible")
+			.and("have.attr", "placeholder", "pat_xxxxx");
+
+		// The real-time upload select should be present with Yes/No options
+		cy.get('select[name="qrzcallrealtime"]')
+			.should("exist")
+			.find("option")
+			.should("have.length", 2);
+	});
+
+	it("should accept a Personal Access Token in the QRZCALL.EU field", () => {
+		cy.visit("/index.php/station/create");
+
+		const testPat = "pat_cypresstest1234567890";
+
+		cy.get('input[name="qrzcallapikey"]')
+			.scrollIntoView()
+			.type(testPat, { force: true })
+			.should("have.value", testPat);
+
+		// Real-time upload defaults to "No"
+		cy.get('select[name="qrzcallrealtime"]')
+			.find("option:selected")
+			.should("have.value", "0");
+
+		// And can be switched to "Yes" (force: the QRZCALL.EU card can sit
+		// under the station form's sticky action bar in the test viewport)
+		cy.get('select[name="qrzcallrealtime"]').select("1", { force: true });
+		cy.get('select[name="qrzcallrealtime"]')
+			.find("option:selected")
+			.should("have.value", "1");
+	});
+});


### PR DESCRIPTION
## Add QRZCALL.EU as a QSO upload target

This PR lets Cloudlog mirror QSOs to a user's [QRZCALL.EU](https://qrzcall.eu)
logbook, alongside the existing QRZ.com / Club Log / HRDLog upload targets.

It builds on the QRZCALL.EU callbook-provider PR, but is functionally
independent — the callbook lookup reads a token from `config.php`, whereas
QSO upload uses a per-station-profile PAT. The two can be reviewed and merged
in either order.

---

### How it works

QRZCALL.EU exposes a QRZ-compatible logbook endpoint
(`api.qrzcall.eu/v1/pub/logbook_api.php`) that accepts the same
`KEY=&ACTION=INSERT&ADIF=` request format Cloudlog already uses for QRZ.com,
so the upload path mirrors the existing QRZ.com implementation.

Two modes:
- **Real-time** — on every QSO save (`create_qso()`), if the station profile
  has a PAT and real-time upload enabled
- **Bulk** — `GET /index.php/qrzcall_upload/upload` (cron-friendly), uploads
  pending QSOs in batches of 1000

Upload status is tracked per QSO so nothing is sent twice.

**Edited QSOs re-sync.** When a QSO that was already uploaded is edited (or
updated by a LoTW confirmation import), its status is set to `M` — exactly as
Cloudlog already does for QRZ.com / Club Log / HRDLog. The next upload re-sends
it with `OPTION=REPLACE`, so QRZCALL.EU updates the existing record in place
instead of rejecting it as a duplicate.

---

### Changes

**8 files — 3 new, 5 modified**

| File | Change |
|---|---|
| `application/migrations/271_add_qrzcall_to_cloudlog.php` | **NEW** — adds `qrzcallapikey` / `qrzcallrealtime` to `station_profile`; adds `COL_QRZCALL_QSO_UPLOAD_STATUS` / `COL_QRZCALL_QSO_UPLOAD_DATE` to the QSO table |
| `application/controllers/Qrzcall_upload.php` | **NEW** — batch upload controller; stops on `RESULT=AUTH` (invalid/revoked PAT) |
| `cypress/e2e/6-qrzcall.cy.js` | **NEW** — Cypress E2E test for the QRZCALL.EU station-profile fields |
| `application/models/Logbook_model.php` | `push_qso_to_qrzcall()` (treats a `duplicate` response as success, sends `OPTION=REPLACE` for edited QSOs), `mark_qrzcall_qso_sent()`, `mark_qrzcall_qsos_sent_batch()`, `get_station_id_with_qrzcall_api()`, `exists_qrzcall_api_key()`, `get_qrzcall_qsos()`; real-time hook in `create_qso()`; QSO marked `M` for re-sync in `edit()`, `lotw_update()` and `lotw_update_batch()`. `get_qrzcall_qsos()` also selects the `station_profile` columns `AdifHelper` needs, so the exported ADIF carries the full "MY" station fields (`STATION_CALLSIGN`, `MY_GRIDSQUARE`, `MY_DXCC`, …) |
| `application/config/migration.php` | Bumps `migration_version` to `271` |
| `application/models/Stations.php` | Saves `qrzcallapikey` / `qrzcallrealtime` in `create()` and `edit()` |
| `application/views/station_profile/edit.php` | QRZCALL.EU PAT field + real-time upload select |
| `application/views/station_profile/create.php` | Same fields on the create form |

---

### Configuration

Station Profile → enter the QRZCALL.EU PAT, set real-time upload to Yes/No.
Then either log QSOs normally (real-time) or run the bulk route via cron.

---

### Testing

Verified on the Docker development environment (PHP 7.4, MySQL):

- Migration 271 applies cleanly (idempotent — `field_exists` guards)
- Real-time upload: QSO saved → immediately uploaded, status set to `Y`
- Bulk upload: pending QSOs uploaded in a batch, status set to `Y`
- Already-uploaded QSOs are not re-sent
- Invalid PAT → upload stops with `RESULT=AUTH`, QSO status left untouched
- A QSO QRZCALL.EU already holds is reported as a duplicate; the uploader
  treats that as success and marks the QSO sent, so it is not retried on
  every run (mirrors Cloudlog's QRZ.com duplicate handling)
- Editing an already-uploaded QSO sets status `M`; the next upload re-sends it
  with `OPTION=REPLACE` and QRZCALL.EU updates the existing record in place
- Bulk upload output is clean — `get_qrzcall_qsos()` selects the
  `station_profile` columns `AdifHelper` reads, so no undefined-property
  notices are raised and the ADIF includes the operator's own station fields
- New Cypress test `6-qrzcall.cy.js` passes; existing suite unaffected

**Test account** — a shared account is available for reviewers:

```
Callsign:  TEST0WVLG
PAT:       pat_b3gvr7n6wyzjvs9xk4jmpgxm3r3gtgdx
```

Enter the PAT in a station profile (Station Profile → QRZCALL.EU card) to test
real-time and bulk QSO upload.

---

### Screenshots

The QRZCALL.EU card on the station profile (PAT field + real-time toggle),
and the bulk upload route reporting a successful upload, are attached to
this PR.


---

### No breaking changes

All changes are additive. Upload only happens for station profiles that have
a QRZCALL.EU PAT set. Existing QRZ.com / Club Log / HRDLog upload behaviour is
unchanged.
