### PR TITLE
Add QRZCALL.EU as a callbook provider

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -1005,9 +1005,24 @@ class Logbook extends CI_Controller
 				if (isset($callsign['callsign']['error'])) {
 					$callsign['error'] = $callsign['callsign']['error'];
 				}
+			} elseif ($this->session->userdata('callbook_type') == "QRZCALL") {
+				// Lookup using QRZCALL.EU — stateless PAT auth, no session-key dance
+				$this->load->library('qrzcall');
+				$this->load->library('encryption');
+
+				$token = $this->encryption->decrypt($this->session->userdata('callbook_password'));
+				$callsign['callsign'] = $this->qrzcall->search($id, $token, $this->config->item('use_fullname'));
+
+				if (isset($callsign['callsign']['dxcc'])) {
+					$this->load->model('logbook_model');
+					$entity = $this->logbook_model->get_entity($callsign['callsign']['dxcc']);
+					if (is_array($entity) && isset($entity['name'])) {
+						$callsign['callsign']['dxcc_name'] = $entity['name'];
+					}
+				}
 			} else {
 				// No callbook type set, return error message
-				$callsign['error'] = 'Online callbook not configured. Go to <a href="' . site_url('user/edit/' . $this->session->userdata('user_id')) . '" class="alert-link">Account Settings</a> and select either QRZ or HamQTH in the "Callbook" section.';
+				$callsign['error'] = 'Online callbook not configured. Go to <a href="' . site_url('user/edit/' . $this->session->userdata('user_id')) . '" class="alert-link">Account Settings</a> and select QRZ, HamQTH or QRZCALL.EU in the "Callbook" section.';
 			}
 
 			if (isset($callsign['callsign']['gridsquare'])) {
@@ -1116,6 +1131,28 @@ class Logbook extends CI_Controller
 							$this->session->set_userdata('hamqth_session_key', $hamqth_session_key);
 							$data['callsign'] = $this->hamqth->search($fixedid, $this->session->userdata('hamqth_session_key'));
 						}
+						if (isset($data['callsign']['gridsquare'])) {
+							$this->load->model('logbook_model');
+							$data['grid_worked'] = $this->logbook_model->check_if_grid_worked_in_logbook(strtoupper(substr($data['callsign']['gridsquare'], 0, 4)), 0, $this->session->userdata('user_default_band'));
+						}
+						if (isset($data['callsign']['dxcc'])) {
+							$this->load->model('logbook_model');
+							$entity = $this->logbook_model->get_entity($data['callsign']['dxcc']);
+							if (is_array($entity) && isset($entity['name'])) {
+								$data['callsign']['dxcc_name'] = $entity['name'];
+							}
+						}
+						if (isset($data['callsign']['error'])) {
+							$data['error'] = $data['callsign']['error'];
+						}
+					} elseif ($this->session->userdata('callbook_type') == "QRZCALL") {
+						// Lookup using QRZCALL.EU — stateless PAT auth, no session-key dance
+						$this->load->library('qrzcall');
+						$this->load->library('encryption');
+
+						$token = $this->encryption->decrypt($this->session->userdata('callbook_password'));
+						$data['callsign'] = $this->qrzcall->search($fixedid, $token, $this->config->item('use_fullname'));
+
 						if (isset($data['callsign']['gridsquare'])) {
 							$this->load->model('logbook_model');
 							$data['grid_worked'] = $this->logbook_model->check_if_grid_worked_in_logbook(strtoupper(substr($data['callsign']['gridsquare'], 0, 4)), 0, $this->session->userdata('user_default_band'));

--- a/application/libraries/Qrzcall.php
+++ b/application/libraries/Qrzcall.php
@@ -1,0 +1,164 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+/*
+	Controls the interaction with the QRZCALL.EU Premium XML API.
+
+	QRZCALL.EU is a QRZ-compatible callsign database. Its XML feed
+	(/v1/pub/callsign_xml.php) returns the same field names as QRZ.com so
+	this library mirrors the QRZ.com integration almost identically — but
+	uses a single long-lived Personal Access Token (PAT) instead of a
+	callsign/password → session-key dance.
+
+	Users generate a PAT at https://qrzcall.eu/ → My Profile → Account →
+	API Tokens. In Cloudlog they select "QRZCALL.EU" as their Callbook
+	Provider in Account Settings and paste the PAT into the Callbook
+	Password field (stored encrypted, per user, like the QRZ password);
+	the Callbook Username field is left blank. The library sends the PAT
+	as "Authorization: Bearer pat_…" on every lookup. Tokens are revocable
+	per-logger, so a compromised Cloudlog install can be locked out
+	without disturbing other clients.
+
+	Access tier: PAT generation requires a Data or Extra subscription on
+	QRZCALL.EU. The library doesn't need to know about subscription state —
+	the upstream endpoint enforces it and returns 401/403 if absent.
+
+	Sign-up + token UI: https://qrzcall.eu/
+*/
+
+class Qrzcall {
+
+	public $callbookname = 'QRZCALL';
+
+	// QRZCALL.EU's QRZ-compatible premium XML endpoint.
+	const XML_URL = 'https://api.qrzcall.eu/v1/pub/callsign_xml.php';
+
+	public function __construct()
+	{
+		$this->CI =& get_instance();
+	}
+
+	/**
+	 * Look up a callsign with a Personal Access Token.
+	 *
+	 * @param string $callsign     Callsign to query.
+	 * @param string $token        The user's "pat_…" Personal Access Token.
+	 * @param bool   $use_fullname True ⇒ "Firstname Lastname"; false ⇒ "Firstname" only.
+	 * @return array Same shape as Qrz::search() — downstream Cloudlog code (QSO entry
+	 *               form, etc.) needs no changes.
+	 */
+	public function search($callsign, $token, $use_fullname = false) {
+		$data = null;
+		try {
+			$url = self::XML_URL . '?callsign=' . urlencode($callsign);
+
+			$ua = 'Cloudlog/' . $this->CI->config->item('app_version');
+
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_URL, $url);
+			curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer ' . $token]);
+			curl_setopt($ch, CURLOPT_HEADER, false);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+			curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+			curl_setopt($ch, CURLOPT_USERAGENT, $ua);
+			$body     = curl_exec($ch);
+			$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+			curl_close($ch);
+
+			if ($httpcode == 401) {
+				log_message('debug', 'QRZCALL.EU search 401 for ' . $callsign . ' — invalid or revoked token');
+				$data['error'] = 'Invalid or revoked QRZCALL.EU API token';
+				return $data;
+			}
+
+			if ($httpcode == 403) {
+				$data['error'] = 'QRZCALL.EU subscription required (Data or Extra tier)';
+				return $data;
+			}
+
+			if ($httpcode == 404) {
+				$data['error'] = 'Callsign not found';
+				return $data;
+			}
+
+			if ($httpcode != 200) {
+				log_message('debug', 'QRZCALL.EU search for ' . $callsign . ' returned HTTP ' . $httpcode);
+				$data['error'] = 'Problems with qrzcall.eu communication';
+				return $data;
+			}
+
+			$xml = simplexml_load_string($body);
+			if (!$xml || !isset($xml->Callsign)) {
+				$data['error'] = isset($xml->Error) ? (string)$xml->Error : 'Empty response';
+				return $data;
+			}
+
+			// QRZCALL.EU's XML uses identical field names to QRZ.com — we mirror the
+			// Qrz::search() field mapping exactly so downstream code needs no changes.
+			$data['callsign']  = (string)$xml->Callsign->call;
+			$data['name']      = (string)$xml->Callsign->fname;
+			$data['name_last'] = (string)$xml->Callsign->name;
+
+			if ($use_fullname === true) {
+				$data['name'] = trim($data['name'] . ' ' . $data['name_last']);
+			} else {
+				$data['name'] = trim($data['name']);
+			}
+
+			// Trim grid to 8 chars (max useful precision) — same rule as QRZ provider
+			$grid = (string)$xml->Callsign->grid;
+			$data['gridsquare'] = strlen($grid) > 8 ? substr($grid, 0, 8) : $grid;
+
+			$data['city']      = (string)$xml->Callsign->addr2;   // backward-compat alias
+			$data['addr1']     = (string)$xml->Callsign->addr1;
+			$data['addr2']     = (string)$xml->Callsign->addr2;
+			$data['zip']       = (string)$xml->Callsign->zip;
+			$data['lat']       = (string)$xml->Callsign->lat;
+			$data['long']      = (string)$xml->Callsign->lon;     // backward-compat alias
+			$data['lon']       = (string)$xml->Callsign->lon;
+			$data['country']   = (string)$xml->Callsign->country;
+			$data['dxcc']      = (string)$xml->Callsign->dxcc;
+			$data['iota']      = (string)$xml->Callsign->iota;
+			$data['qslmgr']    = (string)$xml->Callsign->qslmgr;
+			$data['image']     = (string)$xml->Callsign->image;
+			$data['email']     = (string)$xml->Callsign->email;
+			$data['lotw']      = (string)$xml->Callsign->lotw;
+			$data['eqsl']      = (string)$xml->Callsign->eqsl;
+			$data['mqsl']      = (string)$xml->Callsign->mqsl;
+			$data['cqzone']    = (string)$xml->Callsign->cqzone;
+			$data['ituzone']   = (string)$xml->Callsign->ituzone;
+			$data['ituz']      = $data['ituzone'];                 // backward-compat alias
+			$data['cqz']       = $data['cqzone'];                  // backward-compat alias
+			$data['xref']      = (string)$xml->Callsign->xref;
+			$data['aliases']   = (string)$xml->Callsign->aliases;
+			$data['ccode']     = (string)$xml->Callsign->ccode;
+			$data['state']     = (string)$xml->Callsign->state;
+			$data['county']    = (string)$xml->Callsign->county;
+			$data['fips']      = (string)$xml->Callsign->fips;
+			$data['land']      = (string)$xml->Callsign->land;
+			$data['efdate']    = (string)$xml->Callsign->efdate;
+			$data['expdate']   = (string)$xml->Callsign->expdate;
+			$data['p_call']    = (string)$xml->Callsign->p_call;
+			$data['class']     = (string)$xml->Callsign->class;
+			$data['codes']     = (string)$xml->Callsign->codes;
+			$data['url']       = (string)$xml->Callsign->url;
+			$data['bio']       = (string)$xml->Callsign->bio;
+			$data['biodate']   = (string)$xml->Callsign->biodate;
+			$data['imageinfo'] = (string)$xml->Callsign->imageinfo;
+			$data['moddate']   = (string)$xml->Callsign->moddate;
+			$data['geoloc']    = (string)$xml->Callsign->geoloc;
+			$data['born']      = (string)$xml->Callsign->born;
+			$data['nickname']  = (string)$xml->Callsign->nickname;
+
+			$data['us_county'] = ($data['country'] === 'United States') ? $data['county'] : null;
+
+		} finally {
+			return $data;
+		}
+	}
+
+	public function sourcename() {
+		return $this->callbookname;
+	}
+
+}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5291,6 +5291,15 @@ class Logbook_model extends CI_Model
             $callbook = $this->hamqth->search($callsign, $this->session->userdata('hamqth_session_key'));
           }
         }
+
+        if ($this->session->userdata('callbook_type') == "QRZCALL") {
+          // Lookup using QRZCALL.EU — stateless PAT auth, no session-key dance
+          $this->load->library('qrzcall');
+          $this->load->library('encryption');
+
+          $token = $this->encryption->decrypt($this->session->userdata('callbook_password'));
+          $callbook = $this->qrzcall->search($callsign, $token);
+        }
         if (isset($callbook)) {
           if (isset($callbook['error'])) {
             printf("Error: " . $callbook['error'] . "<br />");
@@ -5444,6 +5453,21 @@ class Logbook_model extends CI_Model
           $hamqth_session_key = $this->hamqth->session($this->session->userdata('callbook_username'), $decrypted_password);
           $this->session->set_userdata('hamqth_session_key', $hamqth_session_key);
           $callbook = $this->hamqth->search($callsign, $this->session->userdata('hamqth_session_key'));
+        }
+      }
+
+      if ($this->session->userdata('callbook_type') == "QRZCALL") {
+        // Lookup using QRZCALL.EU — stateless PAT auth, no session-key dance needed.
+        // The user pastes their Personal Access Token into the "Callbook Password"
+        // field in Account Settings; it is stored encrypted like the QRZ password.
+        $this->load->library('qrzcall');
+        $this->load->library('encryption');
+        $token = $this->encryption->decrypt($this->session->userdata('callbook_password'));
+        $callbook = $this->qrzcall->search($callsign, $token, $use_fullname);
+
+        // If the base callsign lookup failed and it's a compound callsign, retry with base call
+        if (($callbook['callsign'] ?? '') == '' && strpos($callsign, '/') !== false) {
+          $callbook = $this->qrzcall->search($this->get_plaincall($callsign), $token, $use_fullname);
         }
       }
     } finally {

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -1148,10 +1148,12 @@
 													<option value="None" <?php if (isset($user_callbook_type) && $user_callbook_type == 'None') echo 'selected'; ?>>None</option>
 													<option value="QRZ" <?php if (isset($user_callbook_type) && $user_callbook_type == 'QRZ') echo 'selected'; ?>>QRZ</option>
 													<option value="HamQTH" <?php if (isset($user_callbook_type) && $user_callbook_type == 'HamQTH') echo 'selected'; ?>>HamQTH</option>
+													<option value="QRZCALL" <?php if (isset($user_callbook_type) && $user_callbook_type == 'QRZCALL') echo 'selected'; ?>>QRZCALL.EU</option>
 												</select>
 												<?php if (isset($callbook_type_error)) {
 													echo "<small class=\"error\">" . $callbook_type_error . "</small>";
 												} ?>
+												<small class="form-text text-muted">QRZCALL.EU: paste your Personal Access Token into the Callbook Password field below and leave Callbook Username blank.</small>
 											</div>
 
 											<div class="mb-3">


### PR DESCRIPTION
## Add QRZCALL.EU as a callbook provider

This PR adds [QRZCALL.EU](https://qrzcall.eu) — a European radio amateur
callsign database — as a callbook lookup provider, alongside the existing
QRZ.com and HamQTH options.

QRZCALL.EU is selected **per user in Account Settings** (Callbook section),
exactly like QRZ and HamQTH. When a callsign is entered, Cloudlog queries
`https://api.qrzcall.eu/v1/pub/callsign_xml.php` and auto-fills name, grid,
country, DXCC, QSL info, etc.

---

### Why QRZCALL.EU?

- Strong coverage of European callsigns (many not in QRZ.com)
- QRZ-compatible XML API — the response schema is identical to QRZ.com, so the
  new library is a near drop-in and **no downstream code changes are needed**
- Uses a single Personal Access Token (PAT) instead of a username/password →
  session-key flow, so there is no session-key dance or token-refresh logic

---

### How it integrates

QRZCALL.EU follows the existing per-user callbook pattern:

- The user picks **QRZCALL.EU** from the Callbook Provider dropdown in
  Account Settings and pastes their PAT into the **Callbook Password** field
  (stored encrypted in `user_options`, exactly like the QRZ password); the
  Callbook Username field is left blank.
- The lookup reads the PAT from the user's session and decrypts it — there is
  no `config.php` involvement.
- QRZCALL.EU is wired into **all four** callbook lookup paths so it behaves
  identically to QRZ/HamQTH everywhere: `loadCallBook()`, the QSO-entry
  "Results" panel (`partial()`), `search_result()`, and the
  `check_missing_grid_id()` batch grid-fill.

---

### Changes

**4 files — 1 new, 3 modified**

| File | Change |
|---|---|
| `application/libraries/Qrzcall.php` | **NEW** — callbook library; `search($callsign, $token, $use_fullname)` with PAT `Authorization: Bearer` auth, parses QRZ-compatible XML |
| `application/views/user/edit.php` | Adds `QRZCALL.EU` to the Callbook Provider dropdown + a one-line hint (PAT → Callbook Password) |
| `application/models/Logbook_model.php` | `QRZCALL` case in `loadCallBook()` and in the `check_missing_grid_id()` batch lookup — reads the PAT from the user's decrypted `callbook_password` |
| `application/controllers/Logbook.php` | `QRZCALL` branch in `partial()` and `search_result()`; "not configured" message updated to mention QRZCALL.EU |

---

### Configuration

No `config.php` changes. A user enables it entirely from the UI:
**Account Settings → Callbook → Provider: QRZCALL.EU**, then paste the PAT into
**Callbook Password** (leave Callbook Username blank). A PAT is generated at
qrzcall.eu → My Profile → Account → API Tokens.

---

### Testing

A shared test account is available for reviewers:

```
Callsign:  TEST0WVLG
PAT:       pat_b3gvr7n6wyzjvs9xk4jmpgxm3r3gtgdx
```

In Account Settings choose Callbook Provider "QRZCALL.EU", paste the PAT into
Callbook Password, save, then look up `PA4R` on the QSO entry form — name,
gridsquare, country and lat/long populate from QRZCALL.EU, and the "Results
for PA4R" panel shows the callbook card (no "not configured" message).

Verified on the Docker development environment (PHP 7.4, MySQL) across all
four lookup paths; existing Cypress suite unaffected.

---

### Screenshot

Callsign `PA4R` looked up on the QSO entry form — name, gridsquare and
location auto-filled from QRZCALL.EU. _(Screenshot attached to this PR.)_

---

### No breaking changes

All changes are additive. The new provider is only active when a user
explicitly selects "QRZCALL.EU" in their Account Settings. QRZ.com and HamQTH
behaviour is unchanged.
