### PR TITLE
perf: lazy-load Leaflet assets only on pages with maps

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -36,6 +36,16 @@
 <script src="<?php echo base_url(); ?>assets/js/jquery-3.3.1.min.js"></script>
 <script src="<?php echo base_url(); ?>assets/js/jquery.fancybox.min.js"></script>
 <script src="<?php echo base_url(); ?>assets/js/bootstrap.bundle.js"></script>
+<?php
+// Pages that do not require Leaflet map assets (must match header.php list)
+$_no_map_pages = array('options', 'user', 'mode', 'themes', 'update', 'maintenance', 'debug', 'band', 'csv', 'cabrillo', 'backup', 'notes', 'sattimers', 'mostworked', 'dayswithqso', 'statistics', 'continents', 'accumulated', 'timeplotter', 'timeline', 'monthlyreport', 'plugins');
+$_current_page = $this->uri->segment(1);
+$_needs_maps = !isset($load_maps) || $load_maps !== false;
+if (in_array($_current_page, $_no_map_pages)) { $_needs_maps = false; }
+if ($_current_page == 'adif' && $this->uri->segment(2) != 'import_progress') { $_needs_maps = false; }
+if ($_current_page == 'api' && $this->uri->segment(2) == 'help') { $_needs_maps = false; }
+?>
+<?php if ($_needs_maps) { ?>
 <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/leaflet/leaflet.js"></script>
 <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/leaflet/Control.FullScreen.js"></script>
 <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/leaflet/L.Maidenhead.qrb.js"></script>
@@ -44,10 +54,11 @@
     <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/leaflet/L.Maidenhead.activators.js"></script>
 <?php } ?>
 <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/leaflet/leaflet.geodesic.js"></script>
+<script type="text/javascript" src="<?php echo base_url(); ?>assets/js/easyprint.js"></script>
+<?php } ?>
 <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/radiohelpers.js"></script>
 <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/darkmodehelpers.js"></script>
 <script src="<?php echo base_url(); ?>assets/js/bootstrapdialog/js/bootstrap-dialog.min.js"></script>
-<script type="text/javascript" src="<?php echo base_url(); ?>assets/js/easyprint.js"></script>
 <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/sections/common.js"></script>
 <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/sections/eqslcharcounter.js"></script>
 <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/sections/version_dialog.js"></script>

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -27,8 +27,20 @@
 	<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/flag-icons.min.css" />
 
 	<!-- Maps -->
+	<?php
+	// Pages that do not require Leaflet map assets
+	$_no_map_pages = array('options', 'user', 'mode', 'themes', 'update', 'maintenance', 'debug', 'band', 'csv', 'cabrillo', 'backup', 'notes', 'sattimers', 'mostworked', 'dayswithqso', 'statistics', 'continents', 'accumulated', 'timeplotter', 'timeline', 'monthlyreport', 'plugins');
+	$_current_page = $this->uri->segment(1);
+	$_needs_maps = !isset($load_maps) || $load_maps !== false;
+	if (in_array($_current_page, $_no_map_pages)) { $_needs_maps = false; }
+	// Also skip for admin-style subpages that never show maps
+	if ($_current_page == 'adif' && $this->uri->segment(2) != 'import_progress') { $_needs_maps = false; }
+	if ($_current_page == 'api' && $this->uri->segment(2) == 'help') { $_needs_maps = false; }
+	?>
+	<?php if ($_needs_maps) { ?>
 	<link rel="stylesheet" type="text/css" href="<?php echo base_url(); ?>assets/js/leaflet/leaflet.css" />
 	<link rel="stylesheet" type="text/css" href="<?php echo base_url(); ?>assets/js/leaflet/Control.FullScreen.css" />
+	<?php } ?>
 
 	<?php if ($this->uri->segment(1) == "search" && $this->uri->segment(2) == "filter") { ?>
 		<link rel="stylesheet" type="text/css" href="<?php echo base_url(); ?>assets/css/query-builder.default.min.css" />


### PR DESCRIPTION
## Summary

Leaflet JS (~150KB), CSS (~20KB), and plugins (geodesic, FullScreen, Terminator, Maidenhead, easyprint) were loaded unconditionally on every page. This change conditionally loads them only on pages that actually render maps.

## Changes

- **header.php**: Wrap Leaflet CSS includes in a conditional
- **footer.php**: Wrap Leaflet JS + easyprint includes in a conditional

A shared `$_no_map_pages` array defines pages that never display maps. Pages not in this list continue to load Leaflet as before (backward compatible).

## Pages that no longer load ~200KB of map assets

options, user, mode, themes, update, maintenance, debug, band, csv, cabrillo, backup, notes, sattimers, mostworked, dayswithqso, statistics, continents, accumulated, timeplotter, timeline, monthlyreport, plugins, adif, api/help

## Pages unaffected (still load Leaflet)

dashboard, qso, logbookadvanced, gridmap, awards/\*, activators, map/custom, logbook/view, and all other map-displaying pages

## Testing

- Verified map pages still load all Leaflet assets (dashboard: 9 refs, awards/dxcc: 8, gridmap: 10, qso: 8)
- Verified non-map pages skip Leaflet entirely (options: 0, statistics: 0, maintenance: 0, debug: 0, notes: 0)
- Core scripts (radiohelpers, darkmodehelpers, bootstrap-dialog, common.js) still load on all pages
- PHP syntax validated with `php -l` on both modified files
- Controllers can also pass `\$load_maps = false` for additional fine-grained control