### PR TITLE
Add Global Options toggle for confirmations on public visitor maps

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 277;
+$config['migration_version'] = 278;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Options.php
+++ b/application/controllers/Options.php
@@ -531,4 +531,39 @@ class Options extends CI_Controller {
 		}
 	}
 
+	function public_map_show_confirmations() {
+
+		$data['page_title'] = $this->lang->line('options_cloudlog_options');
+		$data['sub_heading'] = $this->lang->line('options_public_map_show_confirmations');
+
+		$this->load->view('interface_assets/header', $data);
+		$this->load->view('options/public_map_show_confirmations');
+		$this->load->view('interface_assets/footer');
+	}
+
+	function public_map_show_confirmations_save() {
+
+		$data['page_title'] = $this->lang->line('options_cloudlog_options');
+		$data['sub_heading'] = $this->lang->line('options_public_map_show_confirmations');
+
+		$this->load->helper(array('form', 'url'));
+
+		$this->load->library('form_validation');
+
+		$this->form_validation->set_rules('public_map_show_confirmations', 'Public Map Confirmations', 'required');
+
+		if ($this->form_validation->run() == FALSE) {
+			$this->load->view('interface_assets/header', $data);
+			$this->load->view('options/public_map_show_confirmations');
+			$this->load->view('interface_assets/footer');
+		} else {
+			$update = $this->optionslib->update('public_map_show_confirmations', $this->input->post('public_map_show_confirmations'), 'yes');
+			if($update == TRUE) {
+				$this->session->set_flashdata('success', $this->lang->line('options_public_map_show_confirmations_settings_saved'));
+			}
+
+			redirect('/options/public_map_show_confirmations');
+		}
+	}
+
 }

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -203,7 +203,8 @@ class Visitor extends CI_Controller {
 
 		$qsos = $this->logbook_model->get_qsos('18', $offset, $logbooks_locations_array);
 		// [PLOT] ADD plot //
-		$plot_array = $this->logbook_model->get_plot_array_for_map($qsos->result());
+		$hide_conf = !$this->visitor_show_confirmations();
+		$plot_array = $this->logbook_model->get_plot_array_for_map($qsos->result(), $hide_conf);
 	
 		header('Content-Type: application/json; charset=utf-8');
 		echo json_encode($plot_array);
@@ -309,8 +310,10 @@ class Visitor extends CI_Controller {
 		$array_confirmed_grid_4char = array();
 		$array_confirmed_grid_6char = array();
 
+		$show_conf = $this->visitor_show_confirmations() ? 'true' : 'false';
+
 		// Get initial data for "All" bands
-		$query = $this->gridmap_model->get_band_confirmed($default_band, $default_mode, 'false', 'false', 'false', 'false', $default_sat, $logbooks_locations_array);
+		$query = $this->gridmap_model->get_band_confirmed($default_band, $default_mode, $show_conf, $show_conf, $show_conf, $show_conf, $default_sat, 'All', $logbooks_locations_array);
 
 		if ($query && $query->num_rows() > 0)
 		{
@@ -340,7 +343,7 @@ class Visitor extends CI_Controller {
 		}
 
 		// Get worked squares (all bands by default)
-		$query = $this->gridmap_model->get_band($default_band, $default_mode, 'false', 'false', 'false', 'false', $default_sat, $logbooks_locations_array);
+		$query = $this->gridmap_model->get_band($default_band, $default_mode, 'false', 'false', 'false', 'false', $default_sat, 'All', $logbooks_locations_array);
 
 		if ($query && $query->num_rows() > 0)
 		{
@@ -370,7 +373,7 @@ class Visitor extends CI_Controller {
 		}
 
 		// Get VUCC squares (worked)
-		$query_vucc = $this->gridmap_model->get_band_worked_vucc_squares($default_band, $default_mode, 'false', 'false', 'false', 'false', $default_sat, $logbooks_locations_array);
+		$query_vucc = $this->gridmap_model->get_band_worked_vucc_squares($default_band, $default_mode, 'false', 'false', 'false', 'false', $default_sat, 'All', $logbooks_locations_array);
 
 		if ($query_vucc && $query_vucc->num_rows() > 0)
 		{
@@ -395,7 +398,7 @@ class Visitor extends CI_Controller {
 		}
 
 		// Confirmed VUCC Squares  
-		$query_vucc = $this->gridmap_model->get_band_confirmed_vucc_squares($default_band, $default_mode, 'false', 'false', 'false', 'false', $default_sat, $logbooks_locations_array);
+		$query_vucc = $this->gridmap_model->get_band_confirmed_vucc_squares($default_band, $default_mode, $show_conf, $show_conf, $show_conf, $show_conf, $default_sat, 'All', $logbooks_locations_array);
 
 		if ($query_vucc && $query_vucc->num_rows() > 0)
 		{
@@ -544,8 +547,9 @@ class Visitor extends CI_Controller {
 		$array_grid_4char_confirmed = array();
 		$array_grid_6char_confirmed = array();
 
-		// For public visitor, we don't show QSL confirmations, so set all to false
-		$query = $this->gridmap_model->get_band_confirmed($band, $mode, 'false', 'false', 'false', 'false', $sat, $logbooks_locations_array);
+		$show_conf = $this->visitor_show_confirmations() ? 'true' : 'false';
+
+		$query = $this->gridmap_model->get_band_confirmed($band, $mode, $show_conf, $show_conf, $show_conf, $show_conf, $sat, 'All', $logbooks_locations_array);
 
 		if ($query && $query->num_rows() > 0) {
 			foreach ($query->result() as $row) 	{
@@ -568,7 +572,7 @@ class Visitor extends CI_Controller {
 			}
 		}
 
-		$query = $this->gridmap_model->get_band($band, $mode, 'false', 'false', 'false', 'false', $sat, $logbooks_locations_array);
+		$query = $this->gridmap_model->get_band($band, $mode, 'false', 'false', 'false', 'false', $sat, 'All', $logbooks_locations_array);
 
 		if ($query && $query->num_rows() > 0) {
 			foreach ($query->result() as $row) {
@@ -592,7 +596,7 @@ class Visitor extends CI_Controller {
 
 			}
 		}
-		$query_vucc = $this->gridmap_model->get_band_worked_vucc_squares($band, $mode, 'false', 'false', 'false', 'false', $sat, $logbooks_locations_array);
+		$query_vucc = $this->gridmap_model->get_band_worked_vucc_squares($band, $mode, 'false', 'false', 'false', 'false', $sat, 'All', $logbooks_locations_array);
 
 		if ($query_vucc && $query_vucc->num_rows() > 0) {
 			foreach ($query_vucc->result() as $row) {
@@ -617,7 +621,7 @@ class Visitor extends CI_Controller {
 		}
 
 		// // Confirmed Squares
-		$query_vucc = $this->gridmap_model->get_band_confirmed_vucc_squares($band, $mode, 'false', 'false', 'false', 'false', $sat, $logbooks_locations_array);
+		$query_vucc = $this->gridmap_model->get_band_confirmed_vucc_squares($band, $mode, $show_conf, $show_conf, $show_conf, $show_conf, $sat, 'All', $logbooks_locations_array);
 
 		if ($query_vucc && $query_vucc->num_rows() > 0) {
 			foreach ($query_vucc->result() as $row) 			{
@@ -651,6 +655,10 @@ class Visitor extends CI_Controller {
 
 		header('Content-Type: application/json');
 		echo json_encode($data);
+	}
+
+	private function visitor_show_confirmations() {
+		return $this->optionslib->get_option('public_map_show_confirmations') == '1';
 	}
 
 }

--- a/application/language/bulgarian/options_lang.php
+++ b/application/language/bulgarian/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Публичен дневник на с
 $lang['options_public_station_diary_enabled'] = 'Публичен дневник на станцията';
 $lang['options_public_station_diary_enabled_hint'] = 'Активирайте или деактивирайте способността на потребителите да създават публични вписания в дневника на станцията. When disabled, all diary entries remain private regardless of individual settings.';
 $lang['options_public_station_diary_settings_saved'] = 'Настройките на публичния дневник на станцията бяха успешно запазени.';
+$lang['options_public_map_show_confirmations'] = 'Потвърждения на публични карти';
+$lang['options_public_map_show_confirmations_enabled'] = 'Показване на потвърждения на публични карти';
+$lang['options_public_map_show_confirmations_hint'] = 'Активирайте или деактивирайте показването на потвърдени QSO (LoTW, eQSL, хартиена QSL или QRZ.com) на публичните карти за посетители.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Настройките за потвърждения на публични карти бяха успешно запазени.';
 $lang['options_enabled'] = 'Активирана';
 $lang['options_disabled'] = 'Деактивирана';
 

--- a/application/language/chinese_simplified/options_lang.php
+++ b/application/language/chinese_simplified/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = '公开电台日志';
 $lang['options_public_station_diary_enabled'] = '公开电台日志';
 $lang['options_public_station_diary_enabled_hint'] = '启用或禁用用户创建公开电台日志条目的功能。 禁用时，无论个人设置如何，所有日志条目都保持私密。';
 $lang['options_public_station_diary_settings_saved'] = '公开电台日志设置已成功保存。';
+$lang['options_public_map_show_confirmations'] = '公开地图确认';
+$lang['options_public_map_show_confirmations_enabled'] = '在公开地图上显示确认';
+$lang['options_public_map_show_confirmations_hint'] = '启用或禁用在公开访客地图上显示哪些 QSO 已确认（LoTW、eQSL、纸质 QSL 或 QRZ.com）。';
+$lang['options_public_map_show_confirmations_settings_saved'] = '公开地图确认设置已成功保存。';
 $lang['options_enabled'] = '启用';
 $lang['options_disabled'] = '禁用';
 

--- a/application/language/czech/options_lang.php
+++ b/application/language/czech/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Veřejný deník stanice';
 $lang['options_public_station_diary_enabled'] = 'Veřejný deník stanice';
 $lang['options_public_station_diary_enabled_hint'] = 'Povolte nebo zakažte uživatelům vytvářeník veřejných položek deníku stanice. Pokud je zakázáno, všechny položky deníku zůstávají soukromé, bez ohledu na jednotlivá nastavení.';
 $lang['options_public_station_diary_settings_saved'] = 'Nastavení veřejného deníku stanice byla úspěšně uložena.';
+$lang['options_public_map_show_confirmations'] = 'Potvrzení na veřejných mapách';
+$lang['options_public_map_show_confirmations_enabled'] = 'Zobrazit potvrzení na veřejných mapách';
+$lang['options_public_map_show_confirmations_hint'] = 'Povolte nebo zakažte zobrazení potvrzených QSO (LoTW, eQSL, papírové QSL nebo QRZ.com) na veřejných mapách pro návštěvníky.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Nastavení potvrzení na veřejných mapách byla úspěšně uložena.';
 $lang['options_enabled'] = 'Povoleno';
 $lang['options_disabled'] = 'Zakázáno';
 

--- a/application/language/dutch/options_lang.php
+++ b/application/language/dutch/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Openbaar stationsdagboek';
 $lang['options_public_station_diary_enabled'] = 'Openbaar stationsdagboek';
 $lang['options_public_station_diary_enabled_hint'] = 'Schakel de mogelijkheid voor gebruikers in of uit om openbare stationsdagboekitems te maken. Wanneer uitgeschakeld, blijven alle dagboekitems privé, ongeacht de individuele instellingen.';
 $lang['options_public_station_diary_settings_saved'] = 'Instellingen voor openbaar stationsdagboek zijn succesvol opgeslagen.';
+$lang['options_public_map_show_confirmations'] = 'Bevestigingen op openbare kaarten';
+$lang['options_public_map_show_confirmations_enabled'] = 'Bevestigingen op openbare kaarten tonen';
+$lang['options_public_map_show_confirmations_hint'] = 'Schakel het tonen van bevestigde QSO\'s (LoTW, eQSL, papieren QSL of QRZ.com) op openbare bezoekerskaarten in of uit.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Instellingen voor bevestigingen op openbare kaarten zijn succesvol opgeslagen.';
 $lang['options_enabled'] = 'Ingeschakeld';
 $lang['options_disabled'] = 'Uitgeschakeld';
 

--- a/application/language/english/options_lang.php
+++ b/application/language/english/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Public Station Diary';
 $lang['options_public_station_diary_enabled'] = 'Public Station Diary';
 $lang['options_public_station_diary_enabled_hint'] = 'Enable or disable the ability for users to create public station diary entries. When disabled, all diary entries remain private regardless of individual settings.';
 $lang['options_public_station_diary_settings_saved'] = 'Public Station Diary settings have been saved successfully.';
+$lang['options_public_map_show_confirmations'] = 'Public Map Confirmations';
+$lang['options_public_map_show_confirmations_enabled'] = 'Show Confirmations on Public Maps';
+$lang['options_public_map_show_confirmations_hint'] = 'Enable or disable showing which QSOs are confirmed (LoTW, eQSL, paper QSL, or QRZ.com) on public visitor maps.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Public Map Confirmations settings have been saved successfully.';
 $lang['options_enabled'] = 'Enabled';
 $lang['options_disabled'] = 'Disabled';
 

--- a/application/language/finnish/options_lang.php
+++ b/application/language/finnish/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Julkinen asemapäiväkirja';
 $lang['options_public_station_diary_enabled'] = 'Julkinen asemapäiväkirja';
 $lang['options_public_station_diary_enabled_hint'] = 'Ota käyttöön tai poista käytöstä käyttäjien kyky luoda julkisia asemapäiväkirjamerkintöjä. Kun poistetaan käytöstä, kaikki päiväkirjamerkinnät pysyvät yksityisinä yksittäisistä asetuksista riippumatta.';
 $lang['options_public_station_diary_settings_saved'] = 'Julkisen asemapäiväkirjan asetukset on tallennettu onnistuneesti.';
+$lang['options_public_map_show_confirmations'] = 'Vahvistukset julkisilla kartoilla';
+$lang['options_public_map_show_confirmations_enabled'] = 'Näytä vahvistukset julkisilla kartoilla';
+$lang['options_public_map_show_confirmations_hint'] = 'Ota käyttöön tai poista käytöstä vahvistettujen QSO:iden (LoTW, eQSL, paperinen QSL tai QRZ.com) näyttäminen julkisilla vierailijakartoilla.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Julkisten karttojen vahvistusasetukset on tallennettu onnistuneesti.';
 $lang['options_enabled'] = 'Käytössä';
 $lang['options_disabled'] = 'Poissa käytöstä';
 

--- a/application/language/french/options_lang.php
+++ b/application/language/french/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Journal de station public';
 $lang['options_public_station_diary_enabled'] = 'Journal de station public';
 $lang['options_public_station_diary_enabled_hint'] = 'Activez ou désactivez la capacité des utilisateurs à créer des entrées de journal de station public. Lorsque désactivé, toutes les entrées du journal restent privées quel que soit les paramètres individuels.';
 $lang['options_public_station_diary_settings_saved'] = 'Les paramètres du journal de station public ont été enregistrés avec succès.';
+$lang['options_public_map_show_confirmations'] = 'Confirmations sur les cartes publiques';
+$lang['options_public_map_show_confirmations_enabled'] = 'Afficher les confirmations sur les cartes publiques';
+$lang['options_public_map_show_confirmations_hint'] = 'Activez ou désactivez l\'affichage des QSO confirmés (LoTW, eQSL, QSL papier ou QRZ.com) sur les cartes publiques des visiteurs.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Les paramètres des confirmations sur les cartes publiques ont été enregistrés avec succès.';
 $lang['options_enabled'] = 'Activé';
 $lang['options_disabled'] = 'Désactivé';
 

--- a/application/language/german/options_lang.php
+++ b/application/language/german/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Öffentliches Stationstagebuch';
 $lang['options_public_station_diary_enabled'] = 'Öffentliches Stationstagebuch';
 $lang['options_public_station_diary_enabled_hint'] = 'Aktivieren oder deaktivieren Sie die Möglichkeit für Benutzer, öffentliche Stationstagebuche zu erstellen. Wenn deaktiviert, bleiben alle Tagebucheinträge privat, unabhängig von den einzelnen Einstellungen.';
 $lang['options_public_station_diary_settings_saved'] = 'Einstellungen für öffentliches Stationstagebuch wurden erfolgreich gespeichert.';
+$lang['options_public_map_show_confirmations'] = 'Bestätigungen auf öffentlichen Karten';
+$lang['options_public_map_show_confirmations_enabled'] = 'Bestätigungen auf öffentlichen Karten anzeigen';
+$lang['options_public_map_show_confirmations_hint'] = 'Aktivieren oder deaktivieren Sie die Anzeige, welche QSOs bestätigt sind (LoTW, eQSL, Papier-QSL oder QRZ.com) auf öffentlichen Besucherkarten.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Einstellungen für Bestätigungen auf öffentlichen Karten wurden erfolgreich gespeichert.';
 $lang['options_enabled'] = 'Aktiviert';
 $lang['options_disabled'] = 'Deaktiviert';
 

--- a/application/language/greek/options_lang.php
+++ b/application/language/greek/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Δημόσιο ημερολόγιο σ�
 $lang['options_public_station_diary_enabled'] = 'Δημόσιο ημερολόγιο σταθμού';
 $lang['options_public_station_diary_enabled_hint'] = 'Ενεργοποιήστε ή απενεργοποιήστε τη δυνατότητα των χρηστών να δημιουργούν δημόσιες εγγραφές ημερολογίου σταθμού. Όταν απενεργοποιηθεί, όλες οι εγγραφές του ημερολογίου παραμένουν ιδιωτικές ανεξάρτητα από τις ατομικές ρυθμίσεις.';
 $lang['options_public_station_diary_settings_saved'] = 'Οι ρυθμίσεις δημόσιου ημερολογίου σταθμού έχουν αποθηκευθεί με επιτυχία.';
+$lang['options_public_map_show_confirmations'] = 'Επιβεβαιώσεις σε δημόσιους χάρτες';
+$lang['options_public_map_show_confirmations_enabled'] = 'Εμφάνιση επιβεβαιώσεων σε δημόσιους χάρτες';
+$lang['options_public_map_show_confirmations_hint'] = 'Ενεργοποιήστε ή απενεργοποιήστε την εμφάνιση των επιβεβαιωμένων QSO (LoTW, eQSL, έντυπο QSL ή QRZ.com) στους δημόσιους χάρτες επισκεπτών.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Οι ρυθμίσεις επιβεβαιώσεων σε δημόσιους χάρτες έχουν αποθηκευθεί με επιτυχία.';
 $lang['options_enabled'] = 'Ενεργοποιημένο';
 $lang['options_disabled'] = 'Απενεργοποιημένο';
 

--- a/application/language/italian/options_lang.php
+++ b/application/language/italian/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Diario stazione pubblico';
 $lang['options_public_station_diary_enabled'] = 'Diario stazione pubblico';
 $lang['options_public_station_diary_enabled_hint'] = 'Abilita o disabilita la possibilità per gli utenti di creare voci pubbliche del diario della stazione. Se disabilitato, tutte le voci del diario rimangono private indipendentemente dalle impostazioni individuali.';
 $lang['options_public_station_diary_settings_saved'] = 'Le impostazioni del diario stazione pubblico sono state salvate con successo.';
+$lang['options_public_map_show_confirmations'] = 'Conferme sulle mappe pubbliche';
+$lang['options_public_map_show_confirmations_enabled'] = 'Mostra conferme sulle mappe pubbliche';
+$lang['options_public_map_show_confirmations_hint'] = 'Abilita o disabilita la visualizzazione dei QSO confermati (LoTW, eQSL, QSL cartacea o QRZ.com) sulle mappe pubbliche per i visitatori.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Le impostazioni delle conferme sulle mappe pubbliche sono state salvate con successo.';
 $lang['options_enabled'] = 'Abilitato';
 $lang['options_disabled'] = 'Disabilitato';
 

--- a/application/language/polish/options_lang.php
+++ b/application/language/polish/options_lang.php
@@ -117,6 +117,10 @@ $lang['options_public_station_diary'] = 'Publiczny dziennik stacji';
 $lang['options_public_station_diary_enabled'] = 'Publiczny dziennik stacji';
 $lang['options_public_station_diary_enabled_hint'] = 'Włącz lub wyłącz możliwość tworzenia publicznych wpisów dziennika stacji przez użytkowników. Po wyłączeniu wszystkie wpisy dziennika pozostają prywatne niezależnie od indywidualnych ustawień.';
 $lang['options_public_station_diary_settings_saved'] = 'Ustawienia publicznego dziennika stacji zostały pomyślnie zapisane.';
+$lang['options_public_map_show_confirmations'] = 'Potwierdzenia na mapach publicznych';
+$lang['options_public_map_show_confirmations_enabled'] = 'Pokazuj potwierdzenia na mapach publicznych';
+$lang['options_public_map_show_confirmations_hint'] = 'Włącz lub wyłącz wyświetlanie potwierdzonych QSO (LoTW, eQSL, papierowe QSL lub QRZ.com) na publicznych mapach dla odwiedzających.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Ustawienia potwierdzeń na mapach publicznych zostały pomyślnie zapisane.';
 $lang['options_enabled'] = 'Włączone';
 $lang['options_disabled'] = 'Wyłączone';
 

--- a/application/language/portuguese/options_lang.php
+++ b/application/language/portuguese/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Diário de estação pública';
 $lang['options_public_station_diary_enabled'] = 'Diário de estação pública';
 $lang['options_public_station_diary_enabled_hint'] = 'Ativar ou desativar a capacidade dos usuários criarem entradas públicas de diário da estação. Quando desativado, todas as entradas do diário permanecem privadas independentemente das configurações individuais.';
 $lang['options_public_station_diary_settings_saved'] = 'As configurações do diário de estação pública foram salvas com sucesso.';
+$lang['options_public_map_show_confirmations'] = 'Confirmações em mapas públicos';
+$lang['options_public_map_show_confirmations_enabled'] = 'Mostrar confirmações em mapas públicos';
+$lang['options_public_map_show_confirmations_hint'] = 'Ative ou desative a exibição de quais QSOs estão confirmados (LoTW, eQSL, QSL em papel ou QRZ.com) nos mapas públicos para visitantes.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'As configurações de confirmações em mapas públicos foram salvas com sucesso.';
 $lang['options_enabled'] = 'Ativado';
 $lang['options_disabled'] = 'Desativado';
 

--- a/application/language/russian/options_lang.php
+++ b/application/language/russian/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Общедоступный дневни
 $lang['options_public_station_diary_enabled'] = 'Общедоступный дневник станции';
 $lang['options_public_station_diary_enabled_hint'] = 'Включить или отключить возможность для пользователей создавать общедоступные записи дневника станции. После отключения все записи дневника остаются приватными независимо от индивидуальных настроек.';
 $lang['options_public_station_diary_settings_saved'] = 'Параметры общедоступного дневника станции успешно сохранены.';
+$lang['options_public_map_show_confirmations'] = 'Подтверждения на публичных картах';
+$lang['options_public_map_show_confirmations_enabled'] = 'Показывать подтверждения на публичных картах';
+$lang['options_public_map_show_confirmations_hint'] = 'Включить или отключить отображение подтверждённых QSO (LoTW, eQSL, бумажная QSL или QRZ.com) на публичных картах для посетителей.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Параметры подтверждений на публичных картах успешно сохранены.';
 $lang['options_enabled'] = 'Включено';
 $lang['options_disabled'] = 'Отключено';
 

--- a/application/language/spanish/options_lang.php
+++ b/application/language/spanish/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Diario de estación público';
 $lang['options_public_station_diary_enabled'] = 'Diario de estación público';
 $lang['options_public_station_diary_enabled_hint'] = 'Habilite o deshabilite la capacidad de los usuarios para crear entradas públicas en el diario de la estación. Cuando está deshabilitado, todas las entradas del diario permanecen privadas independientemente de la configuración individual.';
 $lang['options_public_station_diary_settings_saved'] = 'La configuración del diario de estación público se ha guardado correctamente.';
+$lang['options_public_map_show_confirmations'] = 'Confirmaciones en mapas públicos';
+$lang['options_public_map_show_confirmations_enabled'] = 'Mostrar confirmaciones en mapas públicos';
+$lang['options_public_map_show_confirmations_hint'] = 'Habilite o deshabilite la visualización de qué QSO están confirmados (LoTW, eQSL, QSL en papel o QRZ.com) en los mapas públicos para visitantes.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'La configuración de confirmaciones en mapas públicos se ha guardado correctamente.';
 $lang['options_enabled'] = 'Habilitado';
 $lang['options_disabled'] = 'Deshabilitado';
 

--- a/application/language/swedish/options_lang.php
+++ b/application/language/swedish/options_lang.php
@@ -114,6 +114,10 @@ $lang['options_public_station_diary'] = 'Offentlig stationslogg';
 $lang['options_public_station_diary_enabled'] = 'Offentlig stationslogg';
 $lang['options_public_station_diary_enabled_hint'] = 'Aktivera eller inaktivera möjligheten för användare att skapa offentliga stationsloggposter. Om det är inaktiverat förblir alla loggposter privata oavsett individuella inställningar.';
 $lang['options_public_station_diary_settings_saved'] = 'Inställningarna för offentlig stationslogg har sparats framgångsrikt.';
+$lang['options_public_map_show_confirmations'] = 'Bekräftelser på offentliga kartor';
+$lang['options_public_map_show_confirmations_enabled'] = 'Visa bekräftelser på offentliga kartor';
+$lang['options_public_map_show_confirmations_hint'] = 'Aktivera eller inaktivera visning av vilka QSO:er som är bekräftade (LoTW, eQSL, pappers-QSL eller QRZ.com) på offentliga besökarkartor.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Inställningarna för bekräftelser på offentliga kartor har sparats framgångsrikt.';
 $lang['options_enabled'] = 'Aktiverad';
 $lang['options_disabled'] = 'Inaktiverad';
 

--- a/application/language/turkish/options_lang.php
+++ b/application/language/turkish/options_lang.php
@@ -112,6 +112,10 @@ $lang['options_public_station_diary'] = 'Genel istasyon günlüğü';
 $lang['options_public_station_diary_enabled'] = 'Genel istasyon günlüğü';
 $lang['options_public_station_diary_enabled_hint'] = 'Kullanıcıların genel istasyon günlüğü giriş oluşturma yeteneğini etkinleştirin veya devre dışı bırakın. Devre dışı bırakıldığında, bireysel ayarlardan bağımsız olarak tüm günlük giriş leri özel kalır.';
 $lang['options_public_station_diary_settings_saved'] = 'Genel istasyon günlüğü ayarları başarıyla kaydedildi.';
+$lang['options_public_map_show_confirmations'] = 'Genel haritalarda onaylar';
+$lang['options_public_map_show_confirmations_enabled'] = 'Genel haritalarda onayları göster';
+$lang['options_public_map_show_confirmations_hint'] = 'Genel ziyaretçi haritalarında hangi QSO\'ların onaylandığını (LoTW, eQSL, kâğıt QSL veya QRZ.com) göstermeyi etkinleştirin veya devre dışı bırakın.';
+$lang['options_public_map_show_confirmations_settings_saved'] = 'Genel harita onay ayarları başarıyla kaydedildi.';
 $lang['options_enabled'] = 'Etkinleştirildi';
 $lang['options_disabled'] = 'Devre dışı';
 

--- a/application/migrations/278_add_public_map_show_confirmations_option.php
+++ b/application/migrations/278_add_public_map_show_confirmations_option.php
@@ -1,0 +1,28 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Add_public_map_show_confirmations_option extends CI_Migration {
+
+    public function up()
+    {
+        $this->db->where('option_name', 'public_map_show_confirmations');
+        $query = $this->db->get('options');
+
+        if ($query->num_rows() == 0) {
+            $data = array(
+                'option_name' => 'public_map_show_confirmations',
+                'option_value' => '0',
+                'autoload' => 'yes'
+            );
+            $this->db->insert('options', $data);
+        }
+    }
+
+    public function down()
+    {
+        $this->db->where('option_name', 'public_map_show_confirmations');
+        $this->db->delete('options');
+    }
+
+}

--- a/application/views/options/public_map_show_confirmations.php
+++ b/application/views/options/public_map_show_confirmations.php
@@ -1,0 +1,38 @@
+<div class="container settings">
+
+	<div class="row">
+		<!-- Nav Start -->
+		<?php $this->load->view('options/sidebar') ?>
+		<!-- Nav End -->
+
+		<!-- Content -->
+		<div class="col-md-9">
+            <div class="card">
+                <div class="card-header"><h2><i class="fas fa-map"></i> <?php echo $page_title; ?> - <?php echo $sub_heading; ?></h2></div>
+
+                <div class="card-body">
+                    <?php if($this->session->flashdata('success')) { ?>
+                        <div class="alert alert-success">
+                            <?php echo $this->session->flashdata('success'); ?>
+                        </div>
+                    <?php } ?>
+
+                    <?php echo form_open('options/public_map_show_confirmations_save'); ?>
+
+                    <div class="mb-3">
+                        <label for="publicMapShowConfirmations"><?php echo lang('options_public_map_show_confirmations_enabled'); ?></label>
+                        <select class="form-select" id="publicMapShowConfirmations" name="public_map_show_confirmations" aria-describedby="publicMapShowConfirmationsHelp" required>
+                            <option value='1' <?php if($this->optionslib->get_option('public_map_show_confirmations') == "1" || $this->optionslib->get_option('public_map_show_confirmations') == "true") { echo "selected=\"selected\""; } ?>><?php echo lang('options_enabled'); ?></option>
+                            <option value='0' <?php if($this->optionslib->get_option('public_map_show_confirmations') != "1" && $this->optionslib->get_option('public_map_show_confirmations') != "true") { echo "selected=\"selected\""; } ?>><?php echo lang('options_disabled'); ?></option>
+                        </select>
+                        <small id="publicMapShowConfirmationsHelp" class="form-text text-muted"><?php echo lang('options_public_map_show_confirmations_hint'); ?></small>
+                    </div>
+
+                    <input class="btn btn-primary" type="submit" value="<?php echo lang('options_save'); ?>" />
+                    </form>
+                </div>
+            </div>
+		</div>
+	</div>
+
+</div>

--- a/application/views/options/sidebar.php
+++ b/application/views/options/sidebar.php
@@ -45,6 +45,11 @@ $current_page = $this->uri->segment(2) ?: 'index';
 					<i class="fas fa-book"></i> <?php echo lang('options_public_station_diary'); ?>
 				</a>
 			</li>
+			<li class="list-group-item <?php echo ($current_page == 'public_map_show_confirmations') ? 'active' : ''; ?>">
+				<a class="nav-link" href="<?php echo site_url('options/public_map_show_confirmations'); ?>">
+					<i class="fas fa-map"></i> <?php echo lang('options_public_map_show_confirmations'); ?>
+				</a>
+			</li>
 		</ul>
 	</div>
 </div>


### PR DESCRIPTION
## Summary
- Completes https://github.com/magicbug/Cloudlog/pull/3428 on `dev` (the original PR conflicted and still needed follow-up).
- Stores `public_map_show_confirmations` in Global Options via OptionsLib and a migration, instead of `config.php`.
- Adds language strings for all locales, and passes logbook locations as the 9th gridmap argument so visitor maps keep working after the satellite-orbit filter change.

## Test plan
- [ ] Run migrations and confirm `public_map_show_confirmations` exists in Options (default disabled).
- [ ] Enable the option under Global Options and confirm visitor gridmap/QSO map show confirmed grids.
- [ ] Disable the option and confirm public maps hide confirmation colouring.

EOF

Made with [Cursor](https://cursor.com)